### PR TITLE
docs(lora): add YOLO-Master domain adaptation configs

### DIFF
--- a/examples/lora_examples/README.md
+++ b/examples/lora_examples/README.md
@@ -18,6 +18,8 @@ We provide optimized LoRA configurations for the following model families:
 | **YOLO12** | `yolo12_lora.yaml` | Hybrid (CNN+Attn) | `include_attention=True` |
 | **RT-DETR** | `rtdetr_lora.yaml` | Transformer | `include_attention=True` |
 | **YOLO-World** | `yoloworld_lora.yaml` | Multi-modal | `include_attention=True` |
+| **YOLO-Master-EsMoE-N / VisDrone** | `yolo_master_visdrone_lora.yaml` | MoE dense aerial detection | `r=16`, `include_moe=True`, `include_attention=True` |
+| **YOLO-Master-EsMoE-N / brain-tumor** | `yolo_master_brain_tumor_lora.yaml` | MoE sparse medical detection | `r=8`, `include_moe=True`, `include_attention=False` |
 
 ## 🚀 Usage Guide
 
@@ -67,6 +69,27 @@ Notes:
 - On Apple Silicon, `PYTORCH_ENABLE_MPS_FALLBACK=1` avoids MPS backward kernel gaps during RT-DETR training.
 - If all requested targets are non-linear layers, AdaLoRA target selection will be filtered to an empty set and adapter creation will stop.
 
+### 5. YOLO-Master-EsMoE-N Domain LoRA Sweeps
+
+Two domain-specific configs are provided for quick 20-50 epoch LoRA iteration on visually different scenarios:
+
+```bash
+# Dense aerial small-object detection
+yolo train cfg=examples/lora_examples/yolo_master_visdrone_lora.yaml
+
+# Sparse medical detection
+yolo train cfg=examples/lora_examples/yolo_master_brain_tumor_lora.yaml
+```
+
+Run the standard rank comparison (`r=4,8,16`) and collect a CSV summary:
+
+```bash
+python examples/lora_examples/domain_lora_rank_sweep.py --scenario visdrone --device 0
+python examples/lora_examples/domain_lora_rank_sweep.py --scenario brain_tumor --device 0
+```
+
+Use `--dry-run` to inspect the exact `yolo train` commands without launching training.
+
 ---
 
 ## 🛠️ Configuration Guide
@@ -91,6 +114,44 @@ Each `.yaml` file follows the standard Ultralytics configuration structure, divi
 | `lora_target_modules` | Regex for modules to target. | `["conv"]` | `["linear", "conv"]` |
 | `lora_only_3x3` | Skip `1x1` convs during auto target detection. | **True** | False |
 | `lora_total_step` | AdaLoRA total steps. `0` lets the trainer auto-resolve it. | N/A | `0` |
+
+## YOLO-Master-EsMoE-N Domain Adaptation Guide
+
+### Scenario Defaults
+
+| Scenario | Config | Dataset | Epochs | Default rank | Recommended rank | Target modules | Routing policy |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| VisDrone dense aerial | `yolo_master_visdrone_lora.yaml` | `VisDrone.yaml` | 30 | 16 | 16 | `conv`, `linear` | Do not explicitly target `routing`; adapt features/experts while keeping top-k routing stable. |
+| Brain-tumor sparse medical | `yolo_master_brain_tumor_lora.yaml` | `brain-tumor.yaml` | 40 | 8 | 8 | `conv`, `linear` | Do not explicitly target `routing`; sparse data can overfit router logits quickly. |
+
+### Rank Comparison Table
+
+The sweep script writes `examples/lora_examples/domain_lora_rank_results.csv`. Record the final validation row from each run using the following format:
+
+| Scenario | Rank | mAP50-95 | Trainable params | Train time | Peak VRAM | Notes |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| VisDrone | 4 | fill from sweep output | fill from trainer log | fill from sweep output | fill from `GPU_mem`/monitor | Lowest memory, may underfit tiny dense objects. |
+| VisDrone | 8 | fill from sweep output | fill from trainer log | fill from sweep output | fill from `GPU_mem`/monitor | Balanced fallback if r=16 exceeds VRAM. |
+| VisDrone | 16 | fill from sweep output | fill from trainer log | fill from sweep output | fill from `GPU_mem`/monitor | Default recommendation for scale and density shift. |
+| brain-tumor | 4 | fill from sweep output | fill from trainer log | fill from sweep output | fill from `GPU_mem`/monitor | Strong regularization, safest for very small subsets. |
+| brain-tumor | 8 | fill from sweep output | fill from trainer log | fill from sweep output | fill from `GPU_mem`/monitor | Default recommendation for sparse medical detection. |
+| brain-tumor | 16 | fill from sweep output | fill from trainer log | fill from sweep output | fill from `GPU_mem`/monitor | Use only if validation mAP improves without overfitting. |
+
+### Target Module Selection
+
+- `lora_include_moe=True` is enabled in both configs so LoRA can adapt YOLO-Master v0.5 MoE feature transforms and expert/projection paths.
+- `lora_target_modules=["conv", "linear"]` keeps the search broad enough for Conv-heavy YOLO blocks and Linear SE/gating projections.
+- Routing layers are not explicitly named in `lora_target_modules`. The router controls expert assignment and can collapse under short few-shot training if aggressively adapted.
+- VisDrone enables `lora_include_attention=True` because dense aerial detection benefits from context and scale adaptation.
+- Brain-tumor keeps `lora_include_attention=False` to reduce overfitting risk on a small grayscale-like medical dataset.
+
+### Common Pitfalls
+
+- Medical grayscale inputs: keep the dataset loader/image conversion consistent with YOLO's expected 3-channel input. If custom DICOM/PNG preprocessing is used, convert grayscale to RGB before label alignment.
+- Medical augmentations: avoid mosaic-heavy augmentation on sparse lesions; `close_mosaic=0` is set in the brain-tumor config.
+- Aerial scale variation: keep larger `imgsz` and `multi_scale=True` for VisDrone when GPU memory allows; reduce `imgsz` before lowering rank if OOM occurs.
+- Dense scenes: increase `max_det` for VisDrone because many frames contain hundreds of small objects.
+- MoE stability: do not combine high rank, router adaptation, and very short schedules unless you also monitor expert usage and MoE balance loss.
 
 ## Backend Behavior
 

--- a/examples/lora_examples/domain_lora_rank_sweep.py
+++ b/examples/lora_examples/domain_lora_rank_sweep.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Run LoRA rank sweeps for YOLO-Master domain adaptation configs.
+
+The script launches one `yolo train` run per rank and writes a compact CSV
+summary with mAP50-95, trainable parameter count placeholder, wall-clock time,
+and peak CUDA memory when available from the run artifacts/logs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import subprocess
+import time
+from pathlib import Path
+
+
+SCENARIOS = {
+    "visdrone": {
+        "cfg": "examples/lora_examples/yolo_master_visdrone_lora.yaml",
+        "name_prefix": "yolo_master_visdrone_lora",
+        "epochs": 30,
+    },
+    "brain_tumor": {
+        "cfg": "examples/lora_examples/yolo_master_brain_tumor_lora.yaml",
+        "name_prefix": "yolo_master_brain_tumor_lora",
+        "epochs": 40,
+    },
+}
+
+
+def latest_metric(results_csv: Path, key: str) -> str:
+    if not results_csv.exists():
+        return ""
+    rows = list(csv.DictReader(results_csv.open(newline="")))
+    if not rows:
+        return ""
+    row = rows[-1]
+    for candidate in (key, f"metrics/{key}", f"metrics/{key}(B)"):
+        if candidate in row and row[candidate] != "":
+            return row[candidate]
+    return ""
+
+
+def write_summary_row(path: Path, row: dict[str, str]) -> None:
+    fieldnames = [
+        "scenario",
+        "rank",
+        "alpha",
+        "epochs",
+        "mAP50-95",
+        "trainable_params",
+        "train_time_min",
+        "peak_mem_gb",
+        "run_dir",
+    ]
+    exists = path.exists()
+    with path.open("a", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        if not exists:
+            writer.writeheader()
+        writer.writerow(row)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run YOLO-Master LoRA rank sweeps.")
+    parser.add_argument("--scenario", choices=SCENARIOS.keys(), required=True)
+    parser.add_argument("--ranks", default="4,8,16", help="Comma-separated LoRA ranks.")
+    parser.add_argument("--device", default="0")
+    parser.add_argument("--project", default="runs/lora_examples")
+    parser.add_argument("--summary", default="examples/lora_examples/domain_lora_rank_results.csv")
+    parser.add_argument("--dry-run", action="store_true", help="Print commands without launching training.")
+    args = parser.parse_args()
+
+    scenario = SCENARIOS[args.scenario]
+    ranks = [int(r.strip()) for r in args.ranks.split(",") if r.strip()]
+    summary_path = Path(args.summary)
+
+    for rank in ranks:
+        alpha = rank * 2
+        run_name = f"{scenario['name_prefix']}_r{rank}"
+        cmd = [
+            "yolo",
+            "train",
+            f"cfg={scenario['cfg']}",
+            f"device={args.device}",
+            f"project={args.project}",
+            f"name={run_name}",
+            f"epochs={scenario['epochs']}",
+            f"lora_r={rank}",
+            f"lora_alpha={alpha}",
+        ]
+
+        if args.dry_run:
+            print(" ".join(cmd))
+            continue
+
+        start = time.perf_counter()
+        subprocess.run(cmd, check=True)
+        elapsed_min = (time.perf_counter() - start) / 60.0
+
+        run_dir = Path(args.project) / run_name
+        results_csv = run_dir / "results.csv"
+        write_summary_row(
+            summary_path,
+            {
+                "scenario": args.scenario,
+                "rank": str(rank),
+                "alpha": str(alpha),
+                "epochs": str(scenario["epochs"]),
+                "mAP50-95": latest_metric(results_csv, "mAP50-95"),
+                "trainable_params": "see args.yaml / trainer log",
+                "train_time_min": f"{elapsed_min:.2f}",
+                "peak_mem_gb": latest_metric(results_csv, "GPU_mem"),
+                "run_dir": str(run_dir),
+            },
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/lora_examples/yolo_master_brain_tumor_lora.yaml
+++ b/examples/lora_examples/yolo_master_brain_tumor_lora.yaml
@@ -1,0 +1,92 @@
+# Ultralytics YOLO 🚀, AGPL-3.0 license
+# YOLO-Master-EsMoE-N LoRA configuration for sparse brain-tumor medical detection.
+# Usage: yolo train cfg=examples/lora_examples/yolo_master_brain_tumor_lora.yaml
+
+# Global settings ------------------------------------------------------------------------------------------------------
+task: detect
+mode: train
+device: 0
+
+# Train settings -------------------------------------------------------------------------------------------------------
+model: ultralytics/cfg/models/master/v0_5/det/yolo-master-n.yaml
+data: brain-tumor.yaml
+epochs: 40 # 20-50 epoch quick adaptation window for small medical datasets
+time:
+patience: 15
+batch: 16
+imgsz: 640
+save: True
+save_period: -1
+cache: False
+workers: 4
+project: runs/lora_examples
+name: yolo_master_brain_tumor_lora_r8
+exist_ok: False
+pretrained: True
+optimizer: AdamW
+lr0: 0.0005
+lrf: 0.01
+momentum: 0.937
+weight_decay: 0.0001
+warmup_epochs: 3.0
+verbose: True
+seed: 0
+deterministic: True
+single_cls: False
+rect: False
+cos_lr: True
+close_mosaic: 0 # avoid mosaic artifacts on sparse medical images
+resume: False
+amp: True
+fraction: 1.0
+profile: False
+freeze:
+multi_scale: False
+compile: False
+
+# Val/Test settings ----------------------------------------------------------------------------------------------------
+val: True
+split: val
+save_json: False
+conf:
+iou: 0.7
+max_det: 50
+half: False
+dnn: False
+plots: True
+
+# LoRA settings --------------------------------------------------------------------------------------------------------
+lora_r: 8 # compare with r=4 and r=16 via domain_lora_rank_sweep.py
+lora_alpha: 16
+lora_dropout: 0.02
+lora_bias: "none"
+lora_backend: "auto"
+lora_variant: "lora"
+lora_include_head: False
+lora_freeze_bn: True # small medical batches benefit from stable BN statistics
+lora_target_modules: ["conv", "linear"] # Keep both Conv feature extractors and SE/linear gates adaptable.
+lora_save_adapters: True
+lora_adapter_dir: "lora_adapter"
+lora_auto_r_ratio: 0.0
+lora_use_dora: False
+lora_use_rslora: True
+lora_init_lora_weights: "gaussian"
+lora_type: "lora"
+lora_quantization: "none"
+lora_include_moe: True # Include MoE expert/projection layers; medical texture shift is concentrated in feature blocks.
+lora_include_attention: False # Keep attention-like paths frozen to reduce overfitting on the small grayscale-like dataset.
+lora_only_backbone: False
+lora_only_3x3: False
+lora_skip_stem: True
+lora_min_channels: 32
+lora_exclude_modules:
+lora_last_n:
+lora_from_layer: 3
+lora_to_layer:
+lora_allow_depthwise: False
+lora_kernels:
+lora_gradient_checkpointing: True
+lora_lr_mult: 1.5
+
+# Routing policy: do not explicitly target `routing` modules. Brain-tumor data is sparse and low-diversity, so adapting
+# router logits can overfit expert assignment; adapt experts/features and keep routing decisions stable.

--- a/examples/lora_examples/yolo_master_visdrone_lora.yaml
+++ b/examples/lora_examples/yolo_master_visdrone_lora.yaml
@@ -1,0 +1,92 @@
+# Ultralytics YOLO 🚀, AGPL-3.0 license
+# YOLO-Master-EsMoE-N LoRA configuration for VisDrone dense aerial detection.
+# Usage: yolo train cfg=examples/lora_examples/yolo_master_visdrone_lora.yaml
+
+# Global settings ------------------------------------------------------------------------------------------------------
+task: detect
+mode: train
+device: 0
+
+# Train settings -------------------------------------------------------------------------------------------------------
+model: ultralytics/cfg/models/master/v0_5/det/yolo-master-n.yaml
+data: VisDrone.yaml
+epochs: 30 # 20-50 epoch quick adaptation window for dense aerial few-shot iteration
+time:
+patience: 20
+batch: 8
+imgsz: 960 # preserve small-object detail in aerial frames; lower to 768 on 12GB GPUs
+save: True
+save_period: -1
+cache: False
+workers: 8
+project: runs/lora_examples
+name: yolo_master_visdrone_lora_r16
+exist_ok: False
+pretrained: True
+optimizer: AdamW
+lr0: 0.001
+lrf: 0.01
+momentum: 0.937
+weight_decay: 0.0005
+warmup_epochs: 3.0
+verbose: True
+seed: 0
+deterministic: True
+single_cls: False
+rect: False
+cos_lr: True
+close_mosaic: 10
+resume: False
+amp: True
+fraction: 1.0
+profile: False
+freeze:
+multi_scale: True # helps object scale changes across drone altitudes
+compile: False
+
+# Val/Test settings ----------------------------------------------------------------------------------------------------
+val: True
+split: val
+save_json: False
+conf:
+iou: 0.7
+max_det: 500 # VisDrone scenes can contain many tiny targets
+half: False
+dnn: False
+plots: True
+
+# LoRA settings --------------------------------------------------------------------------------------------------------
+lora_r: 16 # compare with r=4 and r=8 via domain_lora_rank_sweep.py
+lora_alpha: 32
+lora_dropout: 0.05
+lora_bias: "none"
+lora_backend: "auto"
+lora_variant: "lora"
+lora_include_head: False
+lora_freeze_bn: False
+lora_target_modules: ["conv", "linear"] # Conv adapts scale/texture; Linear covers SE gates in MoE blocks.
+lora_save_adapters: True
+lora_adapter_dir: "lora_adapter"
+lora_auto_r_ratio: 0.0
+lora_use_dora: False
+lora_use_rslora: True
+lora_init_lora_weights: "gaussian"
+lora_type: "lora"
+lora_quantization: "none"
+lora_include_moe: True # Include MoE expert/projection layers for aerial density and scale shifts.
+lora_include_attention: True # YOLO-Master-N uses A2C2f attention-like blocks; keep them adaptable for dense scenes.
+lora_only_backbone: False
+lora_only_3x3: False
+lora_skip_stem: True
+lora_min_channels: 32
+lora_exclude_modules:
+lora_last_n:
+lora_from_layer: 3
+lora_to_layer:
+lora_allow_depthwise: False
+lora_kernels:
+lora_gradient_checkpointing: True
+lora_lr_mult: 2.0
+
+# Routing policy: do not explicitly target `routing` modules. Router logits/top-k decisions are highly sensitive on
+# short VisDrone runs; this config adapts Conv/Linear feature transforms and MoE experts while leaving routing stable.


### PR DESCRIPTION
## Description | 描述

Adds YOLO-Master-EsMoE-N LoRA adaptation examples for two visually different vertical scenarios requested in #50:

- VisDrone dense aerial detection
- brain-tumor sparse medical detection

The PR includes scenario-specific LoRA configs, a reproducible rank sweep launcher, and README guidance for rank selection, target module policy, MoE routing handling, and common pitfalls.

## Related Issue | 关联 Issue

Fixes #50

## Change Type | 修改类型

- [ ] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [x] Training/example configuration | 训练/示例配置

## Files Added | 新增文件

- `examples/lora_examples/yolo_master_visdrone_lora.yaml`
- `examples/lora_examples/yolo_master_brain_tumor_lora.yaml`
- `examples/lora_examples/domain_lora_rank_sweep.py`

## Implementation Details | 实现说明

### VisDrone

- Uses `VisDrone.yaml`
- Uses YOLO-Master v0.5 nano detection config: `ultralytics/cfg/models/master/v0_5/det/yolo-master-n.yaml`
- Default rank: `r=16`, `alpha=32`
- Enables `lora_include_moe=True` and `lora_include_attention=True`
- Uses larger `imgsz=960`, `multi_scale=True`, and `max_det=500` for dense small-object aerial scenes

### brain-tumor

- Uses `brain-tumor.yaml`
- Uses YOLO-Master v0.5 nano detection config: `ultralytics/cfg/models/master/v0_5/det/yolo-master-n.yaml`
- Default rank: `r=8`, `alpha=16`
- Enables `lora_include_moe=True`, keeps `lora_include_attention=False`
- Freezes BN and disables mosaic-style late scheduling for sparse medical data stability

### MoE routing policy

Both configs intentionally do not explicitly target `routing` modules. The router controls top-k expert assignment and can overfit or collapse under short few-shot schedules. The configs adapt Conv/Linear feature transforms and MoE expert/projection paths while keeping routing decisions stable.

## Rank Sweep | Rank 对比

Added `domain_lora_rank_sweep.py` to run the required `r=4,8,16` comparisons:

```bash
python examples/lora_examples/domain_lora_rank_sweep.py --scenario visdrone --device 0
python examples/lora_examples/domain_lora_rank_sweep.py --scenario brain_tumor --device 0
```

The script launches one `yolo train` command per rank and writes a CSV summary including:

- mAP50-95
- train time
- peak memory when available from logs/results
- run directory
- trainable parameter note for trainer logs

The README includes the comparison table template and scenario recommendations.

## Self-test Checklist | 自测清单

- [x] Verified Python syntax for the sweep script
- [x] Verified VisDrone dry-run commands for `r=4,8,16`
- [x] Verified brain-tumor dry-run commands for `r=4,8,16`
- [x] Verified diff has no whitespace errors

Commands run locally:

```bash
python3 -m py_compile examples/lora_examples/domain_lora_rank_sweep.py
python3 examples/lora_examples/domain_lora_rank_sweep.py --scenario visdrone --dry-run
python3 examples/lora_examples/domain_lora_rank_sweep.py --scenario brain_tumor --dry-run
git diff --check
```