### PR TITLE
docs(reproduce): add vertical baseline scripts

### DIFF
--- a/scripts/reproduce/README.md
+++ b/scripts/reproduce/README.md
@@ -1,0 +1,95 @@
+# Vertical Dataset Baseline Reproduction
+
+This directory provides reproducible scripts for comparing `YOLO-Master-v0.1-N` and `YOLO-Master-EsMoE-N` on dense vertical detection datasets.
+
+## Datasets
+
+The scripts use the built-in dataset definitions:
+
+| Dataset | Config | Scenario | Notes |
+| :--- | :--- | :--- | :--- |
+| VisDrone | `ultralytics/cfg/datasets/VisDrone.yaml` | Aerial dense small objects | Downloads about 2.3 GB and converts annotations to YOLO format. |
+| SKU-110K | `ultralytics/cfg/datasets/SKU-110K.yaml` | Retail dense products | Downloads about 13.6 GB and converts CSV boxes to YOLO labels. |
+
+Dataset download is handled by Ultralytics when training starts. To pre-check dataset loading, run a short smoke command:
+
+```bash
+yolo train model=YOLO-Master-v0.1-N.pt data=VisDrone.yaml imgsz=640 epochs=1 batch=4
+yolo train model=YOLO-Master-v0.1-N.pt data=SKU-110K.yaml imgsz=640 epochs=1 batch=4
+```
+
+## Training Commands
+
+Recommended reproduction settings follow the issue requirement: `imgsz=640`, `epochs=100~300`.
+
+```bash
+python scripts/reproduce/reproduce_visdrone.py --epochs 100 --imgsz 640 --device 0 --wandb-project yolo-master-reproduce
+python scripts/reproduce/reproduce_sku110k.py --epochs 100 --imgsz 640 --device 0 --wandb-project yolo-master-reproduce
+```
+
+For larger GPU budgets, increase epochs:
+
+```bash
+python scripts/reproduce/reproduce_visdrone.py --epochs 300 --imgsz 640 --device 0
+python scripts/reproduce/reproduce_sku110k.py --epochs 300 --imgsz 640 --device 0
+```
+
+Use dry-run mode to inspect the exact commands:
+
+```bash
+python scripts/reproduce/reproduce_visdrone.py --dry-run
+python scripts/reproduce/reproduce_sku110k.py --dry-run
+```
+
+## Logging
+
+Each script launches two runs:
+
+| Model key | Weights |
+| :--- | :--- |
+| `v0.1-n` | `YOLO-Master-v0.1-N.pt` from the `YOLO-Master-v26.02` release |
+| `esmmoe-n` | `YOLO-Master-EsMoE-N.pt` from the `YOLO-Master-v26.02` release |
+
+Ultralytics writes per-epoch logs to each run directory, including:
+
+- `metrics/mAP50(B)`
+- `metrics/mAP50-95(B)`
+- `train/box_loss`
+- `train/cls_loss`
+- `train/moe_loss` when the model reports MoE auxiliary loss
+- `val/box_loss`
+- `val/cls_loss`
+- `val/moe_loss` when available
+
+When W&B is installed and authenticated, pass `--wandb-project <name>` and publish the resulting W&B run URLs in the table below.
+
+## Result Tables
+
+The scripts write summary CSV files after successful training:
+
+- `runs/reproduce/visdrone/visdrone_summary.csv`
+- `runs/reproduce/sku110k/sku110k_summary.csv`
+
+Record final results here after full training:
+
+| Dataset | Model | Epochs | mAP50 | mAP50-95 | box_loss | cls_loss | moe_loss | W&B URL |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| VisDrone | YOLO-Master-v0.1-N | 100~300 | fill from summary | fill from summary | fill from summary | fill from summary | N/A or fill from summary | fill after run |
+| VisDrone | YOLO-Master-EsMoE-N | 100~300 | fill from summary | fill from summary | fill from summary | fill from summary | fill from summary | fill after run |
+| SKU-110K | YOLO-Master-v0.1-N | 100~300 | fill from summary | fill from summary | fill from summary | fill from summary | N/A or fill from summary | fill after run |
+| SKU-110K | YOLO-Master-EsMoE-N | 100~300 | fill from summary | fill from summary | fill from summary | fill from summary | fill from summary | fill after run |
+
+## Expected Trends
+
+- VisDrone stresses tiny objects and dense scenes; EsMoE should be monitored for better recall/mAP50-95 under high object density.
+- SKU-110K stresses extreme retail crowding; high `max_det` is set to avoid clipping dense predictions during validation.
+- `YOLO-Master-v0.1-N` provides the non-EsMoE nano baseline from the same release family.
+- `YOLO-Master-EsMoE-N` should additionally report MoE auxiliary loss when enabled by the model/trainer path.
+
+## Known Issues And Fixes
+
+- Dataset download timeout: manually download the archives referenced in the dataset YAML and place them under `datasets/` before rerunning.
+- SKU-110K dependency errors: install dataset conversion dependencies such as `polars` and `numpy` before first run.
+- CUDA OOM: lower `batch`, use `--batch 8`, or reduce dataloader workers before changing `imgsz`.
+- W&B not logging: run `wandb login` first, or set `--wandb-mode offline` and sync later.
+- Missing `moe_loss`: non-MoE baselines may not emit this metric; leave the table cell as `N/A`.

--- a/scripts/reproduce/_domain_baseline_common.py
+++ b/scripts/reproduce/_domain_baseline_common.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Shared helpers for YOLO-Master vertical-domain baseline reproduction."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+MODEL_SPECS = {
+    "v0.1-n": "https://github.com/Tencent/YOLO-Master/releases/download/YOLO-Master-v26.02/YOLO-Master-v0.1-N.pt",
+    "esmoe-n": "https://github.com/Tencent/YOLO-Master/releases/download/YOLO-Master-v26.02/YOLO-Master-EsMoE-N.pt",
+}
+
+METRIC_KEYS = [
+    "metrics/mAP50(B)",
+    "metrics/mAP50-95(B)",
+    "train/box_loss",
+    "train/cls_loss",
+    "train/moe_loss",
+    "val/box_loss",
+    "val/cls_loss",
+    "val/moe_loss",
+]
+
+
+@dataclass(frozen=True)
+class DatasetSpec:
+    name: str
+    data: str
+    project: str
+    max_det: int
+    batch: int
+
+
+def read_last_metrics(results_csv: Path) -> dict[str, str]:
+    if not results_csv.exists():
+        return {}
+    with results_csv.open(newline="") as f:
+        rows = list(csv.DictReader(f))
+    if not rows:
+        return {}
+    return {key.strip(): value for key, value in rows[-1].items()}
+
+
+def metric_value(metrics: dict[str, str], key: str) -> str:
+    value = metrics.get(key, "")
+    if value == "":
+        return ""
+    try:
+        return f"{float(value):.6g}"
+    except ValueError:
+        return value
+
+
+def train_command(args: argparse.Namespace, dataset: DatasetSpec, model_name: str, model: str) -> list[str]:
+    run_name = f"{dataset.name}_{model_name}"
+    cmd = [
+        "yolo",
+        "train",
+        f"model={model}",
+        f"data={dataset.data}",
+        f"imgsz={args.imgsz}",
+        f"epochs={args.epochs}",
+        f"batch={args.batch}",
+        f"device={args.device}",
+        f"workers={args.workers}",
+        f"project={args.project}",
+        f"name={run_name}",
+        f"max_det={dataset.max_det}",
+        f"seed={args.seed}",
+        "deterministic=True",
+        "val=True",
+        "plots=True",
+        f"cache={args.cache}",
+        f"amp={args.amp}",
+        f"exist_ok={args.exist_ok}",
+    ]
+    if args.resume:
+        cmd.append("resume=True")
+    return cmd
+
+
+def write_summary(args: argparse.Namespace, dataset: DatasetSpec, rows: list[dict[str, str]]) -> Path:
+    out_dir = ROOT / args.project
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out = out_dir / f"{dataset.name}_summary.csv"
+    fieldnames = [
+        "dataset",
+        "model",
+        "run_dir",
+        "epochs",
+        "imgsz",
+        "duration_min",
+        *METRIC_KEYS,
+        "wandb_url",
+    ]
+    with out.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    return out
+
+
+def run_reproduction(dataset: DatasetSpec) -> None:
+    parser = argparse.ArgumentParser(description=f"Reproduce {dataset.name} YOLO-Master baselines.")
+    parser.add_argument("--epochs", type=int, default=100, help="Recommended range: 100-300.")
+    parser.add_argument("--imgsz", type=int, default=640)
+    parser.add_argument("--batch", type=int, default=dataset.batch)
+    parser.add_argument("--device", default="0")
+    parser.add_argument("--workers", type=int, default=8)
+    parser.add_argument("--project", default=dataset.project)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--cache", default="False")
+    parser.add_argument("--amp", default="True")
+    parser.add_argument("--exist-ok", default="False")
+    parser.add_argument("--resume", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--wandb-project", default="", help="Optional W&B project name.")
+    parser.add_argument("--wandb-mode", default="online", choices=["online", "offline", "disabled"])
+    args = parser.parse_args()
+
+    if args.wandb_project:
+        os.environ.setdefault("WANDB_PROJECT", args.wandb_project)
+    os.environ.setdefault("WANDB_MODE", args.wandb_mode)
+
+    rows: list[dict[str, str]] = []
+    for model_name, model in MODEL_SPECS.items():
+        cmd = train_command(args, dataset, model_name, model)
+        run_dir = ROOT / args.project / f"{dataset.name}_{model_name}"
+        print(" ".join(cmd))
+        if args.dry_run:
+            continue
+
+        start = time.perf_counter()
+        subprocess.run(cmd, check=True, cwd=ROOT)
+        duration_min = (time.perf_counter() - start) / 60.0
+        metrics = read_last_metrics(run_dir / "results.csv")
+        rows.append(
+            {
+                "dataset": dataset.name,
+                "model": model_name,
+                "run_dir": str(run_dir.relative_to(ROOT)),
+                "epochs": str(args.epochs),
+                "imgsz": str(args.imgsz),
+                "duration_min": f"{duration_min:.2f}",
+                **{key: metric_value(metrics, key) for key in METRIC_KEYS},
+                "wandb_url": "fill from W&B run page if enabled",
+            }
+        )
+
+    if rows:
+        out = write_summary(args, dataset, rows)
+        print(f"[summary] wrote {out.relative_to(ROOT)}")

--- a/scripts/reproduce/reproduce_sku110k.py
+++ b/scripts/reproduce/reproduce_sku110k.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Reproduce YOLO-Master-v0.1-N vs YOLO-Master-EsMoE-N on SKU-110K."""
+
+from _domain_baseline_common import DatasetSpec, run_reproduction
+
+
+if __name__ == "__main__":
+    run_reproduction(
+        DatasetSpec(
+            name="sku110k",
+            data="SKU-110K.yaml",
+            project="runs/reproduce/sku110k",
+            max_det=1000,
+            batch=16,
+        )
+    )

--- a/scripts/reproduce/reproduce_visdrone.py
+++ b/scripts/reproduce/reproduce_visdrone.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Reproduce YOLO-Master-v0.1-N vs YOLO-Master-EsMoE-N on VisDrone."""
+
+from _domain_baseline_common import DatasetSpec, run_reproduction
+
+
+if __name__ == "__main__":
+    run_reproduction(
+        DatasetSpec(
+            name="visdrone",
+            data="VisDrone.yaml",
+            project="runs/reproduce/visdrone",
+            max_det=500,
+            batch=16,
+        )
+    )


### PR DESCRIPTION
## Description | 描述

Adds reproducible baseline scripts for issue #49 to compare `YOLO-Master-v0.1-N` and `YOLO-Master-EsMoE-N` on dense vertical datasets:

- VisDrone aerial dense small-object detection
- SKU-110K retail dense product detection

The scripts use the built-in dataset YAML files and release weights from `YOLO-Master-v26.02`, then collect final metrics from Ultralytics `results.csv` into per-dataset summary CSV files.

## Related Issue | 关联 Issue

Fixes #49

## Change Type | 修改类型

- [ ] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [x] Reproduction scripts | 复现脚本

## Files Added | 新增文件

- `scripts/reproduce/reproduce_visdrone.py`
- `scripts/reproduce/reproduce_sku110k.py`
- `scripts/reproduce/_domain_baseline_common.py`
- `scripts/reproduce/README.md`

## Usage | 使用方式

```bash
python scripts/reproduce/reproduce_visdrone.py --epochs 100 --imgsz 640 --device 0 --wandb-project yolo-master-reproduce
python scripts/reproduce/reproduce_sku110k.py --epochs 100 --imgsz 640 --device 0 --wandb-project yolo-master-reproduce
```

Dry-run command inspection:

```bash
python scripts/reproduce/reproduce_visdrone.py --dry-run --epochs 100 --imgsz 640
python scripts/reproduce/reproduce_sku110k.py --dry-run --epochs 100 --imgsz 640
```

## Logged Metrics | 日志指标

The scripts preserve full Ultralytics per-epoch logs in each run directory and summarize final values for:

- `metrics/mAP50(B)`
- `metrics/mAP50-95(B)`
- `train/box_loss`
- `train/cls_loss`
- `train/moe_loss` when emitted by the model
- `val/box_loss`
- `val/cls_loss`
- `val/moe_loss` when emitted by the model

W&B can be enabled with `--wandb-project`; the README includes a result table for adding public W&B URLs after full training.

## Notes | 说明

This PR provides reproducible scripts, command templates, logging paths, and result table templates. It does not fabricate full 100-300 epoch training metrics in the repository.

## Self-test Checklist | 自测清单

- [x] Python syntax check passed
- [x] VisDrone dry-run emits the expected two-model training commands
- [x] SKU-110K dry-run emits the expected two-model training commands
- [x] `git diff --check` passed

Commands run locally:

```bash
python3 -m py_compile scripts/reproduce/_domain_baseline_common.py scripts/reproduce/reproduce_visdrone.py scripts/reproduce/reproduce_sku110k.py
python3 scripts/reproduce/reproduce_visdrone.py --dry-run --epochs 100 --imgsz 640
python3 scripts/reproduce/reproduce_sku110k.py --dry-run --epochs 100 --imgsz 640
git diff --check
```