### PR TITLE
Adds YOLO-Master-EsMoE-N LoRA adaptation examples for brain-tumor and VisDrone 

### DIFF
--- a/examples/lora_examples/README.md
+++ b/examples/lora_examples/README.md
@@ -16,6 +16,8 @@ We provide optimized LoRA configurations for the following model families:
 | **YOLOv10** | `yolov10_lora.yaml` | Conv-based | `gradient_checkpointing=True` |
 | **YOLO11** | `yolo11_lora.yaml` | Conv-based | `gradient_checkpointing=True` |
 | **YOLO12** | `yolo12_lora.yaml` | Hybrid (CNN+Attn) | `include_attention=True` |
+| **YOLO-Master-EsMoE-N VisDrone** | `yolo_master_visdrone_lora.yaml` | EsMoE dense detector | `rslora=True`, router LoRA excluded |
+| **YOLO-Master-EsMoE-N brain-tumor** | `yolo_master_brain_tumor_lora.yaml` | EsMoE sparse detector | `rslora=True`, router LoRA excluded |
 | **RT-DETR** | `rtdetr_lora.yaml` | Transformer | `include_attention=True` |
 | **YOLO-World** | `yoloworld_lora.yaml` | Multi-modal | `include_attention=True` |
 
@@ -38,6 +40,13 @@ You can override any parameter from the CLI without modifying the YAML:
 ```bash
 # Train YOLOv8n with a larger LoRA rank (r=32)
 yolo train cfg=examples/lora_examples/yolov8_lora.yaml lora_r=32
+```
+
+### YOLO-Master-EsMoE-N scenario sweeps
+The YOLO-Master examples cover two intentionally different few-shot transfer scenes: dense aerial VisDrone and sparse brain-tumor detection. See `yolo_master_lora_scenarios_README.md` for rank-sweep results, target-module guidance, and dataset-specific pitfalls.
+
+```bash
+python examples/lora_examples/run_yolo_master_lora_rank_sweep.py --scene all --device 0
 ```
 
 ### 3. Training on Custom Data

--- a/examples/lora_examples/run_yolo_master_lora_rank_sweep.py
+++ b/examples/lora_examples/run_yolo_master_lora_rank_sweep.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Run YOLO-Master LoRA rank sweeps for VisDrone and brain-tumor examples."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Iterable
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover - user-facing dependency check
+    raise SystemExit("PyYAML is required to parse Ultralytics args.yaml files.") from exc
+
+
+SCENES = {
+    "visdrone": {
+        "cfg": "examples/lora_examples/yolo_master_visdrone_lora.yaml",
+        "base_name": "yolo_master_visdrone_lora",
+        "epochs": 30,
+        "fraction": 0.25,
+    },
+    "brain_tumor": {
+        "cfg": "examples/lora_examples/yolo_master_brain_tumor_lora.yaml",
+        "base_name": "yolo_master_brain_tumor_lora",
+        "epochs": 40,
+        "fraction": 1.0,
+    },
+}
+
+
+def run_command(cmd: list[str], dry_run: bool) -> float:
+    if dry_run:
+        print(" ".join(cmd))
+        return 0.0
+    start = time.perf_counter()
+    subprocess.run(cmd, check=True)
+    return (time.perf_counter() - start) / 60.0
+
+
+def run_command_with_log(cmd: list[str], log_path: Path, dry_run: bool) -> tuple[float, int]:
+    if dry_run:
+        print(" ".join(cmd))
+        return 0.0, 0
+
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    start = time.perf_counter()
+    env = os.environ.copy()
+    env["PYTHONUNBUFFERED"] = "1"
+    with log_path.open("w", encoding="utf-8") as log:
+        log.write("$ " + " ".join(cmd) + "\n")
+        log.flush()
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            env=env,
+            bufsize=1,
+        )
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            print(line, end="")
+            log.write(line)
+        return_code = proc.wait()
+    return (time.perf_counter() - start) / 60.0, return_code
+
+
+def read_yaml(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    with path.open(encoding="utf-8") as handle:
+        return yaml.safe_load(handle) or {}
+
+
+def read_results(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    if not rows:
+        return {}
+    best = max(rows, key=lambda row: float(row.get("metrics/mAP50-95(B)", 0.0) or 0.0))
+    return {
+        "best_epoch": best.get("epoch", ""),
+        "map50_95": best.get("metrics/mAP50-95(B)", ""),
+        "completed_epochs": len(rows),
+    }
+
+
+def _parse_gpu_mem(value: str) -> float:
+    match = re.search(r"([0-9]*\.?[0-9]+)\s*G", str(value))
+    return float(match.group(1)) if match else 0.0
+
+
+def _peak_gpu_mem(rows: list[dict]) -> str:
+    peak = max((_parse_gpu_mem(row.get("GPU_mem", "")) for row in rows), default=0.0)
+    return f"{peak:.3f}" if peak else ""
+
+
+def parse_log(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    trainable = ""
+    adapter_params = ""
+    match = re.search(r"Trainable:\s*([0-9,]+).*?Adapter Params:\s*([0-9,]+)", text, re.S)
+    if match:
+        trainable = match.group(1).replace(",", "")
+        adapter_params = match.group(2).replace(",", "")
+    peak_vram = _peak_gpu_mem_from_log(text)
+    completed = bool(re.search(r"\b\d+\s+epochs completed\b", text))
+    return {
+        "trainable_params": trainable,
+        "adapter_params": adapter_params,
+        "peak_vram_gb": peak_vram,
+        "completed": completed,
+    }
+
+
+def _peak_gpu_mem_from_log(text: str) -> str:
+    values = [float(match.group(1)) for match in re.finditer(r"\s([0-9]+(?:\.[0-9]+)?)G\s+", text)]
+    return f"{max(values):.3f}" if values else ""
+
+
+def summarize_run(scene: str, rank: int, run_dir: Path, minutes: float, return_code: int, log_path: Path) -> dict:
+    args = read_yaml(run_dir / "args.yaml")
+    metrics = read_results(run_dir / "results.csv")
+    log_info = parse_log(log_path)
+    return {
+        "scene": scene,
+        "rank": rank,
+        "alpha": rank * 2,
+        "epochs": args.get("epochs", ""),
+        "fraction": args.get("fraction", ""),
+        "map50_95": metrics.get("map50_95", ""),
+        "best_epoch": metrics.get("best_epoch", ""),
+        "trainable_params": log_info.get("trainable_params", ""),
+        "adapter_params": log_info.get("adapter_params", ""),
+        "train_time_min": f"{minutes:.2f}" if minutes else "",
+        "peak_vram_gb": log_info.get("peak_vram_gb", ""),
+        "status": "completed" if log_info.get("completed") else "incomplete",
+        "return_code": return_code,
+        "log": str(log_path),
+        "run_dir": str(run_dir),
+    }
+
+
+def write_summary(rows: Iterable[dict], output: Path) -> None:
+    rows = list(rows)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = [
+        "scene",
+        "rank",
+        "alpha",
+        "epochs",
+        "fraction",
+        "map50_95",
+        "best_epoch",
+        "trainable_params",
+        "adapter_params",
+        "train_time_min",
+        "peak_vram_gb",
+        "status",
+        "return_code",
+        "log",
+        "run_dir",
+    ]
+    with output.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scene", choices=[*SCENES.keys(), "all"], default="all")
+    parser.add_argument("--ranks", nargs="+", type=int, default=[4, 8, 16])
+    parser.add_argument("--device", default="0")
+    parser.add_argument("--project", default="runs/lora_rank_sweeps")
+    parser.add_argument("--output", default="examples/lora_examples/yolo_master_lora_rank_sweep_results.csv")
+    parser.add_argument("--log-dir", default="runs/lora_rank_sweeps/logs")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    selected = SCENES if args.scene == "all" else {args.scene: SCENES[args.scene]}
+    rows = []
+    for scene, spec in selected.items():
+        for rank in args.ranks:
+            name = f"{spec['base_name']}_r{rank}"
+            run_dir = Path(args.project) / name
+            cmd = [
+                "yolo",
+                "train",
+                f"cfg={spec['cfg']}",
+                f"lora_r={rank}",
+                f"lora_alpha={rank * 2}",
+                f"device={args.device}",
+                f"epochs={spec['epochs']}",
+                f"fraction={spec['fraction']}",
+                f"project={args.project}",
+                f"name={name}",
+                "exist_ok=True",
+            ]
+            log_path = Path(args.log_dir) / f"{name}.log"
+            minutes, return_code = run_command_with_log(cmd, log_path, args.dry_run)
+            rows.append(summarize_run(scene, rank, run_dir, minutes, return_code, log_path))
+            write_summary(rows, Path(args.output))
+            if return_code != 0:
+                raise SystemExit(return_code)
+
+    write_summary(rows, Path(args.output))
+    print(f"Wrote summary to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/lora_examples/yolo_master_brain_tumor_lora.yaml
+++ b/examples/lora_examples/yolo_master_brain_tumor_lora.yaml
@@ -1,0 +1,90 @@
+# Ultralytics YOLO 🚀, AGPL-3.0 license
+# YOLO-Master-EsMoE-N LoRA configuration for sparse brain-tumor detection.
+# Usage: yolo train cfg=examples/lora_examples/yolo_master_brain_tumor_lora.yaml
+
+# Global settings ------------------------------------------------------------------------------------------------------
+task: detect
+mode: train
+device: 0
+
+# Train settings -------------------------------------------------------------------------------------------------------
+model: ultralytics/cfg/models/master/v0_9/det/yolo-master-n.yaml
+data: brain-tumor.yaml
+epochs: 40
+time:
+patience: 15
+batch: 16
+imgsz: 640
+save: True
+save_period: -1
+cache: False
+workers: 8
+project: runs/lora_examples
+name: yolo_master_brain_tumor_lora
+exist_ok: False
+pretrained: True
+optimizer: auto
+verbose: True
+seed: 0
+deterministic: True
+single_cls: False
+rect: False
+cos_lr: True
+close_mosaic: 0
+resume: False
+amp: True
+fraction: 1.0
+profile: False
+freeze:
+multi_scale: False
+compile: False
+
+# Val/Test settings ----------------------------------------------------------------------------------------------------
+val: True
+split: val
+save_json: False
+conf:
+iou: 0.7
+max_det: 100
+half: False
+dnn: False
+plots: True
+
+# LoRA settings --------------------------------------------------------------------------------------------------------
+lora_r: 4
+lora_alpha: 8
+lora_dropout: 0.1
+lora_bias: "none"
+lora_backend: "auto"
+lora_variant: "lora"
+lora_include_head: False
+lora_freeze_bn: True
+lora_target_modules: [
+  "conv", "fused_conv", "bottleneck.0", "shared_feature.0", "static_net.3", "proj",
+  "expert_projections.0.0", "expert_projections.1.0", "expert_projections.2.0", "expert_projections.3.0",
+  "expert_projections.4.0", "expert_projections.5.0", "expert_projections.6.0", "expert_projections.7.0",
+  "expert_projections.8.0", "expert_projections.9.0", "expert_projections.10.0", "expert_projections.11.0",
+  "expert_projections.12.0", "expert_projections.13.0", "expert_projections.14.0", "expert_projections.15.0"
+]
+lora_save_adapters: True
+lora_adapter_dir: "lora_adapter"
+lora_auto_r_ratio: 0.0
+lora_use_dora: False
+lora_use_rslora: True
+lora_init_lora_weights: "gaussian"
+lora_type: "lora"
+lora_quantization: "none"
+lora_include_moe: True
+lora_include_attention: False
+lora_only_backbone: False
+lora_only_3x3: False
+# Routing/gating layers are intentionally excluded from LoRA in the default sparse-medical recipe.
+# Brain-tumor images have low object count and limited appearance diversity; changing routers in a short run can
+# overfit expert assignment, so this recipe adapts expert/backbone convs and keeps routing stable.
+lora_exclude_modules: ["router", "routing", "gate", "gating"]
+lora_last_n:
+lora_from_layer:
+lora_to_layer:
+lora_allow_depthwise: False
+lora_kernels:
+lora_gradient_checkpointing: True

--- a/examples/lora_examples/yolo_master_lora_rank_sweep_results.csv
+++ b/examples/lora_examples/yolo_master_lora_rank_sweep_results.csv
@@ -3,4 +3,5 @@ brain_tumor,4,8,40,1.0,0.27129,36,468290,123116,13.31,3.200,0,runs/lora_rank_swe
 brain_tumor,8,16,40,1.0,0.31259,40,596782,251608,13.74,3.210,0,runs/lora_rank_sweeps/logs/yolo_master_brain_tumor_lora_r8.log,runs/lora_rank_sweeps/yolo_master_brain_tumor_lora_r8
 brain_tumor,16,32,40,1.0,0.33535,37,848390,503216,14.82,3.300,0,runs/lora_rank_sweeps/logs/yolo_master_brain_tumor_lora_r16.log,runs/lora_rank_sweeps/yolo_master_brain_tumor_lora_r16
 visdrone,4,8,30,0.25,0.01239,20,472410,123116,34.82,12.500,0,runs/lora_rank_sweeps/logs/yolo_master_visdrone_lora_r4.log,runs/lora_rank_sweeps/yolo_master_visdrone_lora_r4
+visdrone,8,16,30,0.25,0.0149,23,600902,251608,34.71,12.500,0,runs/lora_rank_sweeps/logs/yolo_master_visdrone_lora_r8.log,runs/lora_rank_sweeps/yolo_master_visdrone_lora_r8
 visdrone,16,32,30,0.25,0.02615,26,852510,503216,36.04,12.600,0,runs/lora_rank_sweeps/logs/yolo_master_visdrone_lora_r16.log,runs/lora_rank_sweeps/yolo_master_visdrone_lora_r16

--- a/examples/lora_examples/yolo_master_lora_rank_sweep_results.csv
+++ b/examples/lora_examples/yolo_master_lora_rank_sweep_results.csv
@@ -1,0 +1,6 @@
+scene,rank,alpha,epochs,fraction,map50_95,best_epoch,trainable_params,adapter_params,train_time_min,peak_vram_gb,return_code,log,run_dir
+brain_tumor,4,8,40,1.0,0.27129,36,468290,123116,13.31,3.200,0,runs/lora_rank_sweeps/logs/yolo_master_brain_tumor_lora_r4.log,runs/lora_rank_sweeps/yolo_master_brain_tumor_lora_r4
+brain_tumor,8,16,40,1.0,0.31259,40,596782,251608,13.74,3.210,0,runs/lora_rank_sweeps/logs/yolo_master_brain_tumor_lora_r8.log,runs/lora_rank_sweeps/yolo_master_brain_tumor_lora_r8
+brain_tumor,16,32,40,1.0,0.33535,37,848390,503216,14.82,3.300,0,runs/lora_rank_sweeps/logs/yolo_master_brain_tumor_lora_r16.log,runs/lora_rank_sweeps/yolo_master_brain_tumor_lora_r16
+visdrone,4,8,30,0.25,0.01239,20,472410,123116,34.82,12.500,0,runs/lora_rank_sweeps/logs/yolo_master_visdrone_lora_r4.log,runs/lora_rank_sweeps/yolo_master_visdrone_lora_r4
+visdrone,16,32,30,0.25,0.02615,26,852510,503216,36.04,12.600,0,runs/lora_rank_sweeps/logs/yolo_master_visdrone_lora_r16.log,runs/lora_rank_sweeps/yolo_master_visdrone_lora_r16

--- a/examples/lora_examples/yolo_master_lora_scenarios_README.md
+++ b/examples/lora_examples/yolo_master_lora_scenarios_README.md
@@ -66,7 +66,7 @@ All runs use YOLO-Master-EsMoE-N with the scene configs above, `lora_use_rslora=
 | brain-tumor | 8 | 40 | 1.0 | 0.31259 | 40 | 596,782 | 251,608 | 13.74 min | 3.21 GB |
 | brain-tumor | 16 | 40 | 1.0 | 0.33535 | 37 | 848,390 | 503,216 | 14.82 min | 3.30 GB |
 | VisDrone | 4 | 30 | 0.25 | 0.01239 | 20 | 472,410 | 123,116 | 34.82 min | 12.50 GB |
-| VisDrone | 8 | 30 | 0.25 | pending | pending | 600,902 | 251,608 | running | 11.10 GB so far |
+| VisDrone | 8 | 30 | 0.25 | 0.0149 | 23 | 600,902 | 251,608 | 35.12 min | 12.50 GB |
 | VisDrone | 16 | 30 | 0.25 | 0.02615 | 26 | 852,510 | 503,216 | 36.04 min | 12.60 GB |
 
 ## Rank Recommendations

--- a/examples/lora_examples/yolo_master_lora_scenarios_README.md
+++ b/examples/lora_examples/yolo_master_lora_scenarios_README.md
@@ -1,0 +1,96 @@
+# YOLO-Master-EsMoE-N LoRA Scenario Guide
+
+This guide documents two deliberately different LoRA adaptation scenes for YOLO-Master-EsMoE-N:
+
+| Scene | Dataset | Transfer setting | Config |
+| :--- | :--- | :--- | :--- |
+| Dense aerial detection | `VisDrone.yaml` | many tiny objects, heavy scale variation, crowded images | `yolo_master_visdrone_lora.yaml` |
+| Sparse medical detection | `brain-tumor.yaml` | few boxes per image, grayscale-like MRI signal, small dataset | `yolo_master_brain_tumor_lora.yaml` |
+
+Both configs expose the requested LoRA controls: `lora_r`, `lora_alpha`, `lora_use_rslora`, `lora_target_modules`, `lora_include_attention`, and `lora_gradient_checkpointing`.
+
+## Config Choices
+
+| Setting | VisDrone | brain-tumor |
+| :--- | :--- | :--- |
+| Default rank | `8` | `4` |
+| Epochs | `30` | `40` |
+| Data fraction | `0.25` | `1.0` |
+| Image size | `768` | `640` |
+| Batch size | `8` | `16` |
+| `lora_use_rslora` | `True` | `True` |
+| `lora_include_attention` | `False` | `False` |
+| `lora_gradient_checkpointing` | `True` | `True` |
+| Router/gating LoRA | excluded | excluded |
+
+The target modules include backbone convolutions and EsMoE expert paths:
+
+```yaml
+lora_target_modules:
+  - conv
+  - fused_conv
+  - bottleneck.0
+  - shared_feature.0
+  - static_net.3
+  - proj
+  - expert_projections.0.0
+  ...
+  - expert_projections.15.0
+```
+
+Routing and gating layers are intentionally excluded via:
+
+```yaml
+lora_exclude_modules: ["router", "routing", "gate", "gating"]
+```
+
+For short few-shot runs, router LoRA can change expert assignment before the target dataset has enough examples to stabilize the routing distribution. The default recipes adapt the expert/backbone feature transforms while keeping the router priors fixed. Router adaptation should be treated as a separate ablation.
+
+## Rank Sweep
+
+Run the same `r=4,8,16` comparison for both scenes:
+
+```bash
+python examples/lora_examples/run_yolo_master_lora_rank_sweep.py --scene all --device 0
+```
+
+The helper writes `examples/lora_examples/yolo_master_lora_rank_sweep_results.csv` and logs to `runs/lora_rank_sweeps/logs/`. Rank overrides use `lora_alpha=2*r`.
+
+## Current Results
+
+All runs use YOLO-Master-EsMoE-N with the scene configs above, `lora_use_rslora=True`, `lora_include_attention=False`, and router/gating LoRA excluded.
+
+| Scene | Rank | Epochs | Fraction | mAP50-95 | Best epoch | Trainable params | Adapter params | Train time | Peak VRAM |
+| :--- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | :--- | :--- |
+| brain-tumor | 4 | 40 | 1.0 | 0.27129 | 36 | 468,290 | 123,116 | 13.31 min | 3.20 GB |
+| brain-tumor | 8 | 40 | 1.0 | 0.31259 | 40 | 596,782 | 251,608 | 13.74 min | 3.21 GB |
+| brain-tumor | 16 | 40 | 1.0 | 0.33535 | 37 | 848,390 | 503,216 | 14.82 min | 3.30 GB |
+| VisDrone | 4 | 30 | 0.25 | 0.01239 | 20 | 472,410 | 123,116 | 34.82 min | 12.50 GB |
+| VisDrone | 8 | 30 | 0.25 | pending | pending | 600,902 | 251,608 | running | 11.10 GB so far |
+| VisDrone | 16 | 30 | 0.25 | 0.02615 | 26 | 852,510 | 503,216 | 36.04 min | 12.60 GB |
+
+## Rank Recommendations
+
+For brain-tumor, `r=16` is currently the best completed rank by mAP50-95. The gain from `r=8` to `r=16` is modest but measurable, while VRAM remains nearly flat on this small dataset. Use `r=8` if faster iteration is preferred, and use `r=16` for the current best accuracy.
+
+For VisDrone, compare `r=8` after it finishes before locking the recommendation. Among completed runs, `r=16` is better than `r=4` on dense aerial detection. This matches the expectation that crowded small-object scenes need more adapter capacity.
+
+## Target Module Guidance
+
+Use convolution and MoE expert modules first. These cover the domain-specific feature transforms while preserving the routing policy. Keep `lora_include_attention=False` for the default YOLO-Master-EsMoE-N configs because the current stable recipes focus on conv and expert-projection adaptation; attention LoRA can be revisited as a separate ablation.
+
+Keep `lora_use_rslora=True` when sweeping rank. RS-LoRA improves scaling stability as rank increases, especially for `r=16`.
+
+Keep `lora_gradient_checkpointing=True` for both scenes. VisDrone is memory-heavy because of larger images and many instances, and checkpointing keeps the sweep practical on a single 24 GB GPU.
+
+## Common Pitfalls
+
+Medical grayscale handling: many MRI exports are single-channel or grayscale RGB. Confirm that dataset preprocessing feeds the expected channel format, disable unnecessary color-heavy augmentation when debugging, and inspect `train_batch*.jpg` before trusting metrics.
+
+Sparse medical overfitting: brain-tumor has few boxes and limited visual diversity. Freezing BN, using dropout, and keeping router LoRA excluded help avoid memorizing scanner or annotation artifacts.
+
+Aerial scale variation: VisDrone objects can be extremely small and densely packed. Use larger validation `max_det`, keep `imgsz` consistent across rank sweeps, and avoid comparing ranks trained with different data fractions.
+
+Router ablations: if you remove `router`, `routing`, `gate`, or `gating` from `lora_exclude_modules`, run it as a separate experiment and watch validation mAP, MoE balance losses, and expert usage. Training loss can improve while routing drift hurts validation.
+
+Metric comparability: keep epochs, fraction, image size, batch size, seed, and hardware fixed across ranks before comparing train time or peak VRAM.

--- a/examples/lora_examples/yolo_master_visdrone_lora.yaml
+++ b/examples/lora_examples/yolo_master_visdrone_lora.yaml
@@ -1,0 +1,95 @@
+# Ultralytics YOLO 🚀, AGPL-3.0 license
+# YOLO-Master-EsMoE-N LoRA configuration for VisDrone dense aerial detection.
+# Usage: yolo train cfg=examples/lora_examples/yolo_master_visdrone_lora.yaml
+
+# Global settings ------------------------------------------------------------------------------------------------------
+task: detect
+mode: train
+device: 0
+
+# Train settings -------------------------------------------------------------------------------------------------------
+model: ultralytics/cfg/models/master/v0_9/det/yolo-master-n.yaml
+data: VisDrone.yaml
+epochs: 30
+time:
+patience: 20
+batch: 8
+imgsz: 768
+save: True
+save_period: -1
+cache: False
+workers: 8
+project: runs/lora_examples
+name: yolo_master_visdrone_lora
+exist_ok: False
+pretrained: True
+optimizer: auto
+verbose: True
+seed: 0
+deterministic: True
+single_cls: False
+rect: False
+cos_lr: True
+close_mosaic: 10
+resume: False
+amp: False
+fraction: 0.25
+profile: False
+freeze:
+multi_scale: False
+compile: False
+
+# Val/Test settings ----------------------------------------------------------------------------------------------------
+val: True
+split: val
+save_json: False
+conf:
+iou: 0.7
+max_det: 500
+half: False
+dnn: False
+plots: True
+
+# LoRA settings --------------------------------------------------------------------------------------------------------
+lora_r: 8
+lora_alpha: 16
+lora_dropout: 0.05
+lora_bias: "none"
+lora_backend: "auto"
+lora_variant: "lora"
+lora_include_head: False
+lora_freeze_bn: False
+lora_target_modules: [
+  "conv", "fused_conv", "bottleneck.0", "shared_feature.0", "static_net.3", "proj",
+  "expert_projections.0.0", "expert_projections.1.0", "expert_projections.2.0", "expert_projections.3.0",
+  "expert_projections.4.0", "expert_projections.5.0", "expert_projections.6.0", "expert_projections.7.0",
+  "expert_projections.8.0", "expert_projections.9.0", "expert_projections.10.0", "expert_projections.11.0",
+  "expert_projections.12.0", "expert_projections.13.0", "expert_projections.14.0", "expert_projections.15.0"
+]
+lora_save_adapters: True
+lora_adapter_dir: "lora_adapter"
+lora_auto_r_ratio: 0.0
+lora_use_dora: False
+lora_use_rslora: True
+lora_init_lora_weights: "gaussian"
+lora_type: "lora"
+lora_quantization: "none"
+lora_include_moe: True
+lora_include_attention: False
+lora_only_backbone: False
+lora_only_3x3: False
+# the initial dense-aerial recipe used imgsz=960,
+# multi_scale=True, AMP, attention LoRA, and the default LoRA LR multiplier. That
+# combination produced NaN/Inf checkpoints.
+lora_lr_mult: 0.5
+lora_alpha_warmup: 8
+# Routing/gating layers are intentionally excluded from LoRA in the default dense-aerial recipe.
+# VisDrone has strong scale and crowd-density shifts; adapting expert convs while keeping router priors fixed
+# reduces expert-selection drift during short few-shot runs. Opt in by removing these names only for router ablations.
+lora_exclude_modules: ["router", "routing", "gate", "gating"]
+lora_last_n:
+lora_from_layer:
+lora_to_layer:
+lora_allow_depthwise: False
+lora_kernels:
+lora_gradient_checkpointing: True

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -48,6 +48,20 @@ def img2label_paths(img_paths: list[str]) -> list[str]:
     return [sb.join(x.rsplit(sa, 1)).rsplit(".", 1)[0] + ".txt" for x in img_paths]
 
 
+def convert_ndjson_to_yolo_if_needed(data: str | Path) -> str:
+    """Convert an NDJSON dataset path/URL to YOLO YAML when needed, otherwise return the original value."""
+    data_str = str(data)
+    suffix_source = clean_url(data_str).split("?", 1)[0].lower()
+    if not suffix_source.endswith(".ndjson"):
+        return data_str
+
+    import asyncio
+
+    from ultralytics.data.converter import convert_ndjson_to_yolo
+
+    return str(asyncio.run(convert_ndjson_to_yolo(data_str)))
+
+
 def check_file_speeds(
     files: list[str], threshold_ms: float = 10, threshold_mb: float = 50, max_files: int = 5, prefix: str = ""
 ):

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -37,14 +37,7 @@ from ultralytics.nn.autobackend import AutoBackend
 from ultralytics.utils import LOCAL_RANK, LOGGER, RANK, TQDM, callbacks, colorstr, emojis
 from ultralytics.utils.checks import check_imgsz
 from ultralytics.utils.ops import Profile
-from ultralytics.utils.torch_utils import (
-    attempt_compile,
-    select_device,
-    smart_inference_mode,
-    torch_distributed_zero_first,
-    unwrap_model,
-)
-
+from ultralytics.utils.torch_utils import attempt_compile, select_device, smart_inference_mode, torch_distributed_zero_first, unwrap_model
 
 class BaseValidator:
     """A base class for creating validators.

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -32,12 +32,18 @@ import torch
 import torch.distributed as dist
 
 from ultralytics.cfg import get_cfg, get_save_dir
-from ultralytics.data.utils import check_cls_dataset, check_det_dataset
+from ultralytics.data.utils import check_cls_dataset, check_det_dataset, convert_ndjson_to_yolo_if_needed
 from ultralytics.nn.autobackend import AutoBackend
-from ultralytics.utils import LOGGER, RANK, TQDM, callbacks, colorstr, emojis
+from ultralytics.utils import LOCAL_RANK, LOGGER, RANK, TQDM, callbacks, colorstr, emojis
 from ultralytics.utils.checks import check_imgsz
 from ultralytics.utils.ops import Profile
-from ultralytics.utils.torch_utils import attempt_compile, select_device, smart_inference_mode, unwrap_model
+from ultralytics.utils.torch_utils import (
+    attempt_compile,
+    select_device,
+    smart_inference_mode,
+    torch_distributed_zero_first,
+    unwrap_model,
+)
 
 
 class BaseValidator:


### PR DESCRIPTION
## Summary

Fixes #50.

This PR adds YOLO-Master-EsMoE-N LoRA adaptation examples for two vertical scenarios: dense aerial detection on VisDrone and sparse medical detection on brain-tumor. It includes scenario-specific LoRA configs, a reusable rank-sweep script, recorded sweep results, and a guide covering rank selection, target-module choices, and common dataset pitfalls.

env: Ultralytics 8.3.240 🚀 Python-3.11.15 torch-2.12.1+cu130 CUDA:0 (NVIDIA GeForce RTX 3090, 24126MiB)

## Edits to main code 

`ultralytics/validator.py` is currently missing import for `torch_distributed_zero_first` and `LOCAL_RANK`. Missing inplement for convert_ndjson_to_yolo_if_needed

I add them

## Changes

- Added `yolo_master_visdrone_lora.yaml` for dense aerial VisDrone LoRA fine-tuning.
- Added `yolo_master_brain_tumor_lora.yaml` for sparse brain-tumor LoRA fine-tuning.
- Added `run_yolo_master_lora_rank_sweep.py` to run rank sweeps with `r=4,8,16`.
- Added `yolo_master_lora_rank_sweep_results.csv` with recorded metrics, trainable params, training time, and peak VRAM.
- Added `yolo_master_lora_scenarios_README.md` with:
  - scenario comparison
  - rank recommendations
  - LoRA target-module guidance
  - routing/gating exclusion rationale for MoE
  - common pitfalls for medical and aerial datasets
- Updated the LoRA examples README to reference the new YOLO-Master scenarios.
- Added NDJSON-to-YOLO conversion helper wiring used by validation utilities.

## LoRA Design Notes

Both scenario configs expose the requested LoRA controls:

- `lora_r`
- `lora_alpha`
- `lora_use_rslora`
- `lora_target_modules`
- `lora_include_attention`
- `lora_gradient_checkpointing`

For YOLO-Master-EsMoE-N, the default recipes adapt convolution and expert-projection modules while excluding router/gating layers:

```yaml
lora_exclude_modules: ["router", "routing", "gate", "gating"]
```
This keeps expert routing stable during short few-shot fine-tuning runs. Router LoRA can still be evaluated separately as an ablation.

## Experiments

Rank sweeps were run within the 20-50 epoch constraint.</p><div><div>
Scene | Rank | Epochs | Fraction | mAP50-95 | Best epoch | Trainable params | Adapter params | Train time | Peak VRAM
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
brain-tumor | 4 | 40 | 1.0 | 0.27129 | 36 | 468,290 | 123,116 | 13.31 min | 3.20 GB
brain-tumor | 8 | 40 | 1.0 | 0.31259 | 40 | 596,782 | 251,608 | 13.74 min | 3.21 GB
brain-tumor | 16 | 40 | 1.0 | 0.33535 | 37 | 848,390 | 503,216 | 14.82 min | 3.30 GB
VisDrone | 4 | 30 | 0.25 | 0.01239 | 20 | 472,410 | 123,116 | 34.82 min | 12.50 GB
VisDrone | 8 | 30 | 0.25 | 0.0149 | 23 | 600,902 | 251,608 | 35.12 min | 12.50 GB 
VisDrone | 16 | 30 | 0.25 | 0.02615 | 26 | 852,510 | 503,216 | 36.04 min | 12.60 GB
