### PR TITLE
fix(validator): remove undefined convert_ndjson_to_yolo_if_needed call

### DIFF
--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -161,8 +161,6 @@ class BaseValidator:
                     model.end2end = self.args.end2end
                 if model.end2end:
                     model.set_head_attr(max_det=self.args.max_det, agnostic_nms=self.args.agnostic_nms)
-            with torch_distributed_zero_first(LOCAL_RANK):
-                self.args.data = convert_ndjson_to_yolo_if_needed(self.args.data)
             model = AutoBackend(
                 model=model or self.args.model,
                 device=select_device(self.args.device) if RANK == -1 else torch.device("cuda", RANK),


### PR DESCRIPTION
I oberved an issue when working on #49 

And here is the fix and detailed explanation:

`BaseValidator.__call__`'s standalone branch called `convert_ndjson_to_yolo_if_needed(...)` — a function not defined anywhere in the repo — wrapped in `torch_distributed_zero_first(LOCAL_RANK)` (also not imported). Any standalone validation therefore crashes with `NameError`: `model.val()`, `yolo val`, and the post-training `final_eval()` on best.pt, for every model and task. Per-epoch validation during training takes the trainer branch and is unaffected, so the crash only surfaces at end-of-training or on an explicit valication call. 

Fix: **removed the two lines**. The ndjson conversion never functioned since it's undefined and there is no other ndjson reference in the codebase; standard YAML/COCO datasets need no conversion. This does not affect any DDP/training path — the removed `torch_distributed_zero_first` guard only gated the (nonexistent) conversion, not a collective op; real DDP coordination lives in trainer.py.