### PR TITLE
feat(reproduce): add reproducible VisDrone & SKU-110K training scripts and guide for v0.1-N and EsMoE-N with ES-MoE dense-eval fix

### DIFF
--- a/scripts/reproduce/README.md
+++ b/scripts/reproduce/README.md
@@ -3,6 +3,8 @@
 
 Reproducible training strategy for the two YOLO-Master nano variants on two dense-scene vertical scenes, with per-epoch logging of the required metrics (mAP50, mAP50-95, box_loss, cls_loss, moe_loss)
 
+📊 **Live training curves for all six runs (Weights & Biases):** https://wandb.ai/yolo-master-reproduce/yolo-master-reproduce
+
 | Model | Config | # Params | MoE characteristics |
 | --- | --- | --- | --- |
 | `YOLO-Master-v0.1-N` | `ultralytics/cfg/models/master/v0_1/det/yolo-master-n.yaml` | 7.55 M | `ModularRouterExpertMoE` |
@@ -110,14 +112,14 @@ correctly** (its train losses track `v0.1-N`), ***but with the default sparse
 evaluation its validation mAP collapses***; `--no-sparse-eval` restores it to the
 `v0.1-N` level **(see Known issue 1 for the mechanism)**
 
-| Model | Dataset | Eval Method | mAP50 | mAP50-95 | Raw Results (I'm blocked by W&B) |
-| --- | --- | --- | --- | --- | --- |
-| v0.1-N | VisDrone | default | 0.344 | 0.201 | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/result-v0.1n-visdrone.zip) |
-| EsMoE-N | VisDrone | default (sparse) | 0.010 | 0.003 | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/result-esmoen-sparse-visdrone.zip) |
-| EsMoE-N | VisDrone | `--no-sparse-eval` | 0.350 | 0.203 | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/result-esmoen-visdrone.zip) |
-| v0.1-N | SKU-110K | default | 0.906 | 0.582 | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/result-v0.1n-sku110k.zip) |
-| EsMoE-N | SKU-110K | default (sparse) | 0.305 | 0.136 | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/result-esmoen-sparse-sku110k.zip) |
-| EsMoE-N | SKU-110K | `--no-sparse-eval` | 0.904 | 0.583 | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/result-esmoen-sku110k.zip) |
+| Model | Dataset | Eval Method | mAP50 | mAP50-95 | W&B Run | Raw Results |
+| --- | --- | --- | --- | --- | --- | --- |
+| v0.1-N | VisDrone | default | 0.344 | 0.201 | [View](https://wandb.ai/yolo-master-reproduce/yolo-master-reproduce/runs/rbmyjy6b) | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/result-v0.1n-visdrone.zip) |
+| EsMoE-N | VisDrone | default (sparse) | 0.010 | 0.003 | [View](https://wandb.ai/yolo-master-reproduce/yolo-master-reproduce/runs/49bmlyp2) | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/result-esmoen-sparse-visdrone.zip) |
+| EsMoE-N | VisDrone | `--no-sparse-eval` | 0.350 | 0.203 | [View](https://wandb.ai/yolo-master-reproduce/yolo-master-reproduce/runs/6rsdhsn9) | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/result-esmoen-visdrone.zip) |
+| v0.1-N | SKU-110K | default | 0.906 | 0.582 | [View](https://wandb.ai/yolo-master-reproduce/yolo-master-reproduce/runs/rogiamt4) | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/result-v0.1n-sku110k.zip) |
+| EsMoE-N | SKU-110K | default (sparse) | 0.305 | 0.136 | [View](https://wandb.ai/yolo-master-reproduce/yolo-master-reproduce/runs/7nofdfnb) | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/result-esmoen-sparse-sku110k.zip) |
+| EsMoE-N | SKU-110K | `--no-sparse-eval` | 0.904 | 0.583 | [View](https://wandb.ai/yolo-master-reproduce/yolo-master-reproduce/runs/yiz22jp3) | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/result-esmoen-sku110k.zip) |
 
 ### Visualization
 
@@ -179,36 +181,7 @@ tar -xzf SKU110K_fixed.tar.gz --no-same-owner --no-same-permissions -C <datasets
 
 Then let Ultralytics re-run `check_det_dataset('SKU-110K.yaml')` to build the labels and the `train.txt`, `val.txt`, and `test.txt` split files.
 
-### 3. Unable to make public W&B URL on organization accounts.
-
-This is a W&B problem I encountered when I try to log my trainings to wandb and make it public, **not affiliated with the repo.**
-
-**Mechanism.** W&B accounts bound to an organization — for example, through an institutional email — restrict project visibility to **Team / Restricted**. The **Public / Open** option is disabled by organization policy.
-
-The personal-profile entity is not a loggable target in the organization model. Attempts to log there via CLI can fail with:
-
-```bash
-CommError: entity <user> not found during upsertBucket
-```
-
-As a result, a publicly viewable project cannot be created from such an account.
-
-**Solution.** Log to W&B **privately** under the team entity:
-
-```bash
---wandb-entity <team>
-```
-
-Alternatively, publish the run logs directly by committing each run's `results.csv` and `results.png`.
-
-A public W&B project requires a non-organization personal account. **However, due to the bad frontend design of their website, I somehow cannot create any project without linking to a W&B team. And after trying to fix the issue, I'm accidentally blocked by W&B for no reason. 
-Screenshot:
-
-<img width="512" alt="Screenshot 2026-07-01 at 12 56 46 PM" src="https://github.com/user-attachments/assets/a9b46591-d203-4147-870b-61469d1f6d05" />
-
-I've already contacted their support and will update the W&B public URL as soon as they unblock me.**
-
-### 4. `model.val()` hangs/crashes with dataloader workers on Python 3.14 (minor)
+### 3. `model.val()` hangs/crashes with dataloader workers on Python 3.14 (minor)
 
 **Mechanism.** A standalone `model.val()` call with `workers >0` can hit a multiprocessing forkserver `ConnectionResetError` on Python 3.14.
 

--- a/scripts/reproduce/README.md
+++ b/scripts/reproduce/README.md
@@ -1,0 +1,246 @@
+# Reproduction Methodology for Training the Baseline YOLO-Master-v0.1-N & YOLO-Master-EsMoE-N on VisDrone & SKU-110K
+ 
+
+Reproducible training strategy for the two YOLO-Master nano variants on two dense-scene vertical scenes, with per-epoch logging of the required metrics (mAP50, mAP50-95, box_loss, cls_loss, moe_loss)
+
+| Model | Config | # Params | MoE characteristics |
+| --- | --- | --- | --- |
+| `YOLO-Master-v0.1-N` | `ultralytics/cfg/models/master/v0_1/det/yolo-master-n.yaml` | 7.55 M | `ModularRouterExpertMoE` |
+| `YOLO-Master-EsMoE-N` | `ultralytics/cfg/models/master/v0/det/yolo-master-n.yaml` | 2.69 M | `ES_MOE` |
+
+Weights:
+
+| Dataset | Model | mAP50 | mAP50-95 | Weights |
+| --- | --- | --- | --- | --- |
+| VisDrone | `YOLO-Master-v0.1-N` | 0.3443  | 0.2009 | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/yolo-master-v01-n-visdrone.pt) |
+| VisDrone | `YOLO-Master-EsMoE-N` | 0.3499 | 0.2029 | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/yolo-master-esmoe-n-visdrone.pt) |
+| SKU-110K | `YOLO-Master-v0.1-N` | 0.9059 | 0.5821 | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/yolo-master-v01-n-sku110k.pt) |
+| SKU-110K | `YOLO-Master-EsMoE-N` | 0.9041 | 0.5829  | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/yolo-master-esmoe-n-sku110k.pt) |
+
+Below is a comprehensive guide on how to reproduce the full training pipeline
+
+## 1. Setup
+
+Below is the physical server setup I used to train the two models:
+
+| Category | My setup | Recommended |
+| --- | --- | --- |
+| OS | Ubuntu Server 22.04 LTS | Linux |
+| CPU | Intel Xeon 8568Y 96C192T | 8C16T |
+| Memory | 2,048GB | >32GB |
+| GPU | Nvidia H200 SXM (only enabled 1) | Nvidia Ampere architecture (`sm_80`) or newer |
+| GPU VRAM | 144GB / GPU | ≥16GB |
+| Driver | `570.211.01` |  |
+| Python | `3.14.6` | `3.13` or newer |
+| CUDA | `12.8` | `12.8` |
+| PyTorch | `2.11.0+cu128` | `2.11.0+cu128` |
+
+Follow the official setup guides for environmental setup. Or directly install the exact conda environment I used: [download here](https://drive.google.com/file/d/1gskbzdVQ56pZBgungk9HcKtb2ft5WaVf/view?usp=share_link)
+
+Download it (don't extract yet!), then run:
+
+```bash
+# 1) download the pack from Google Drive, then extract into your conda's envs dir
+pip install gdown
+gdown 1gskbzdVQ56pZBgungk9HcKtb2ft5WaVf -O yolo_master.tar.gz
+ENV_DIR="$(conda info --base)/envs/yolo_master"
+mkdir -p "$ENV_DIR"
+tar -xzf yolo_master.tar.gz -C "$ENV_DIR"
+
+# 2) activate, then rewrite the packed paths for THIS machine (conda-unpack ships inside the pack; run once)
+conda activate yolo_master
+conda-unpack
+
+# 3) install this repo's ultralytics into the env (editable pkg was NOT bundled in the pack)
+pip install -e .
+```
+
+## 2. Dataset Download
+
+Datasets shall download automatically the first time training initializes. To fetch them manually, execute:
+
+```bash
+python -c "from ultralytics.data.utils import check_det_dataset; check_det_dataset('VisDrone.yaml', autodownload=True)"
+python -c "from ultralytics.data.utils import check_det_dataset; check_det_dataset('SKU-110K.yaml', autodownload=True)"
+```
+
+The dataset will be stored under the default Ultralytics `datasets_dir` , usually under `../datasets` . VisDrone is approximately 2.3GB and SKU-110K is 13.6GB
+
+## 3. Training
+
+Recommended hyperparam settings: `--imgsz 640` ,`--epochs 300` , and adjust batch size `--batch` based on your GPU memory. 
+
+### Full commands
+
+```bash
+# Adjust the batch size and # of epochs based on your computer's capability.
+
+# ------ VisDrone ------
+# YOLO-Master-v0.1-N
+python scripts/reproduce/reproduce_visdrone.py --model v0.1-N  --epochs <epoch> --batch <batch-size> 
+# YOLO-Master-EsMoE-N
+python scripts/reproduce/reproduce_visdrone.py --model EsMoE-N --epochs <epoch> --batch <batch-size>  --no-sparse-eval
+
+# ------ SKU-110K ------
+# YOLO-Master-v0.1-N
+python scripts/reproduce/reproduce_sku110k.py  --model v0.1-N  --epochs <epoch> --batch <batch-size> 
+# YOLO-Master-EsMoE-N
+python scripts/reproduce/reproduce_sku110k.py  --model EsMoE-N --epochs <epoch> --batch <batch-size>  --no-sparse-eval
+```
+
+### Key flags
+
+| Flag | Default | Explanation |
+| --- | --- | --- |
+| `--model {v0.1-N,EsMoE-N,both}` | `both` | which model to train |
+| `--no-sparse-eval` | **off** | **opt-in** correct evaluation for `EsMoE-N` **(see Known issue 1 below)**. Off = reproduce the model exactly as shipped. No-op for `v0.1-N`. |
+| `--epochs / --imgsz / --batch` | `300 / 640 / 64` | training hyps |
+| `--wandb / --no-wandb` | on | stream per-epoch metrics to Weights & Biases |
+| `--wandb-entity <e>` | **default** | W&B entity/team to log under |
+| `--wandb-mode {online,offline,disabled}` | `online` | W&B mode. To use `online` , you must login first. |
+
+Tune batch size smaller if you encountered OOM (CUDA out of memory) errors.
+
+A training of 100 epochs can already achieve a high mAP. **Only train for 300 or more epochs if you have enough GPU memory or want to challenge the SOTA.** 
+
+### Expected results
+
+`v0.1-N` trains and validates cleanly on both datasets. `EsMoE-N` **also trains
+correctly** (its train losses track `v0.1-N`), ***but with the default sparse
+evaluation its validation mAP collapses***; `--no-sparse-eval` restores it to the
+`v0.1-N` level **(see Known issue 1 for the mechanism)**
+
+| Model | Dataset | Eval Method | mAP50 | mAP50-95 | Raw Results (I'm blocked by W&B) |
+| --- | --- | --- | --- | --- | --- |
+| v0.1-N | VisDrone | default | 0.344 | 0.201 | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/result-v0.1n-visdrone.zip) |
+| EsMoE-N | VisDrone | default (sparse) | 0.010 | 0.003 | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/result-esmoen-sparse-visdrone.zip) |
+| EsMoE-N | VisDrone | `--no-sparse-eval` | 0.350 | 0.203 | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/result-esmoen-visdrone.zip) |
+| v0.1-N | SKU-110K | default | 0.906 | 0.582 | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/result-v0.1n-sku110k.zip) |
+| EsMoE-N | SKU-110K | default (sparse) | 0.305 | 0.136 | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/result-esmoen-sparse-sku110k.zip) |
+| EsMoE-N | SKU-110K | `--no-sparse-eval` | 0.904 | 0.583 | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/result-esmoen-sku110k.zip) |
+
+### Visualization
+
+| Model | VisDrone | SKU-110K |
+| --- | --- | --- |
+| **v0.1-N** | <img width="2234" height="882" alt="v0.1-visdrone" src="https://github.com/user-attachments/assets/7d076b6f-48aa-48a2-8d0c-31f55164d76b" /> | <img width="2234" height="882" alt="v0.1-sku110k" src="https://github.com/user-attachments/assets/15f98b56-0c47-4665-878f-0fc13e657381" /> |
+| **EsMoE-N (sparse eval)** | <img width="2234" height="882" alt="esmoe-sparse-visdrone" src="https://github.com/user-attachments/assets/e9a0dd9d-e760-4b41-8b06-c076f9793ad9" /> | <img width="2234" height="882" alt="esmoe-sparse-sku110k" src="https://github.com/user-attachments/assets/9fbf7230-fa11-4f55-9609-644a7b973762" /> |
+| **EsMoE-N (`--no-sparse-eval`)** | <img width="2234" height="882" alt="esmoe-visdrone" src="https://github.com/user-attachments/assets/1258edb0-bc03-4f50-84d3-b86507d663f6" /> | <img width="2234" height="882" alt="esmoe-sku110k" src="https://github.com/user-attachments/assets/cc50bd4c-1079-4abd-8b4d-9408d10d01a9" /> |
+
+***Expected qualitative trend: `--no-sparse-eval` lifts `EsMoE-N` from collapsed (VisDrone) / far-below-baseline (SKU-110K) up to outperform the `v0.1-N` mAP, only with ~1/3 of its parameters.***
+
+## 4. Known issues + solutions ‼️Very important‼️
+
+### 1. **`EsMoE-N` validation mAP collapses (ES_MOE sparse inference)**
+
+**Symptom.** `EsMoE-N` train losses (`box/cls/dfl`) descend normally — identical to `v0.1-N` — yet its **validation** mAP is near zero (VisDrone only ~0.01) or far below the `v0.1-N` (SKU-110K 0.31 vs 0.91). On VisDrone the mAP peaks mid-training then decays toward zero. 
+
+**Why it happens? The machemism:**
+
+the function `ES_MOE.forward` in `ultralytics/nn/modules/moe/modules.py`) uses two different code paths: 
+
+- **Training** → `_dense_forward`: it computes **all** experts and sums them weighted by the softmax routing weights, which sum to 1 → output at the correct magnitude.
+- **Inference** → `_sparse_forward` (taken because `use_sparse_inference=True` by default). For these configs (`top_k=None`, i.e. dense softmax over all experts), it:
+    1. **Prunes** every expert whose routing weight `< dynamic_threshold` (`0.4`), keeping only the top-ranked one. With ~4 experts whose softmax weights average ~0.25, this reduces the block to ≈ top-1.
+    2. **Does not renormalize**: the surviving expert's output is scaled by its raw softmax weight (~0.3) and never rescaled to sum-1.
+
+So at inference the block emits roughly **one** expert at **~1/N** the activation magnitude that the trained `BatchNorm` (`self.norm`) was fitted to during dense training. The downstream head then sees mis-scaled, wrong-expert features → degenerate detections. It gets worse as training sharpens the router.
+
+**Proof.** Re-validating the **same** trained checkpoint with the two paths:
+
+- sparse (default) → mAP50 0.06
+- forced dense → mAP50 0.35 (≈ the `v0.1-N` result)
+
+The weights are fine; but the inference path is wrongly is configured.
+
+**Solution.** `--no-sparse-eval` registers a callback that sets `ES_MOE.use_sparse_inference=False` on both the live model and its EMA at `on_pretrain_routine_end` / `on_train_start`, before any validation and before the EMA-derived checkpoints are written. Per-epoch validation, the saved `.pt`, and the final evaluation then all use the dense forward that matches training.
+
+**Why `v0.1-N` is unaffected.** Its MoE block (`OptimizedMOEImproved`) runs the **same** top-k routing in train and eval (no dense→sparse switch), and adds an always-on shared expert plus a residual — a mode-invariant dense path that keeps the output scale stable.
+
+**Be careful:** 
+
+This is fixed at run time (a script flag), not in the library — `ES_MOE`'s default `use_sparse_inference=True` and `_sparse_forward` are unchanged. A plain `yolo val` or an exported `EsMoE-N` model will still exhibit the same collapse.
+
+### 2. SKU-110K extraction error (`tar ... Operation not permitted`)
+
+**Mechanism.** The dataset downloader extracts the SKU-110K archive with `tar xfz`, which tries to restore the files' archived ownership (`uid` / `gid`). On filesystems that disallow `chown` — for example, many networked, rootless, or container mounts — `tar` prints:
+
+```bash
+Cannot change ownership ... Operation not permitted
+```
+
+and exits non-zero, leaving the dataset unprepared.
+
+**Solution.** Extract the archive while ignoring ownership and permissions:
+
+```bash
+tar -xzf SKU110K_fixed.tar.gz --no-same-owner --no-same-permissions -C <datasets_dir>
+```
+
+Then let Ultralytics re-run `check_det_dataset('SKU-110K.yaml')` to build the labels and the `train.txt`, `val.txt`, and `test.txt` split files.
+
+### 3. Unable to make public W&B URL on organization accounts.
+
+This is a W&B problem I encountered when I try to log my trainings to wandb and make it public, **not affiliated with the repo.**
+
+**Mechanism.** W&B accounts bound to an organization — for example, through an institutional email — restrict project visibility to **Team / Restricted**. The **Public / Open** option is disabled by organization policy.
+
+The personal-profile entity is not a loggable target in the organization model. Attempts to log there via CLI can fail with:
+
+```bash
+CommError: entity <user> not found during upsertBucket
+```
+
+As a result, a publicly viewable project cannot be created from such an account.
+
+**Solution.** Log to W&B **privately** under the team entity:
+
+```bash
+--wandb-entity <team>
+```
+
+Alternatively, publish the run logs directly by committing each run's `results.csv` and `results.png`.
+
+A public W&B project requires a non-organization personal account. **However, due to the bad frontend design of their website, I somehow cannot create any project without linking to a W&B team. And after trying to fix the issue, I'm accidentally blocked by W&B for no reason. 
+Screenshot:
+
+<img width="512" alt="Screenshot 2026-07-01 at 12 56 46 PM" src="https://github.com/user-attachments/assets/a9b46591-d203-4147-870b-61469d1f6d05" />
+
+I've already contacted their support and will update the W&B public URL as soon as they unblock me.**
+
+### 4. `model.val()` hangs/crashes with dataloader workers on Python 3.14 (minor)
+
+**Mechanism.** A standalone `model.val()` call with `workers >0` can hit a multiprocessing forkserver `ConnectionResetError` on Python 3.14.
+
+Full training is unaffected because it validates each epoch through the training path.
+
+**Solution.** Pass `workers=0` for standalone validation invocations:
+
+```python
+model.val(workers=0)
+```
+
+## 5. Directory for Run logs
+
+Per run, Ultralytics writes to:
+
+```
+runs/reproduce/<dataset>/<Dataset>_<model>/
+```
+
+Each run directory contains:
+
+- `results.csv` — per-epoch `mAP50`, `mAP50-95`, and `box/cls/dfl/moe_loss` metrics for both training and validation.
+- `results.png` — the corresponding metric curves.
+- `weights/best.pt` and `weights/last.pt` — the best and latest model checkpoints.
+- `args.yaml` — the exact resolved training configuration.
+
+The dataset-level summary file:
+
+```
+runs/reproduce/<dataset>/summary.csv
+```
+
+aggregates the final metrics for both models, including a `dense_eval` column that records whether `--no-sparse-eval` was applied.
+
+**Should you have any questions or doubts, feel free to make a comment or contact: rlici@connect.ust.hk**

--- a/scripts/reproduce/_reproduce_common.py
+++ b/scripts/reproduce/_reproduce_common.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Shared logic for the per-dataset YOLO-Master baseline reproduction scripts.
+
+Both reproduce_visdrone.py and reproduce_sku110k.py train the two nano release
+variants from their YAML configs (from scratch) and log per-epoch metrics
+(mAP50, mAP50-95, box/cls/dfl/moe_loss) to each run's results.csv, plus an
+aggregated summary.csv.
+
+Models
+------
+  - YOLO-Master-v0.1-N  -> ultralytics/cfg/models/master/v0_1/det/yolo-master-n.yaml
+      (MoE block: OptimizedMOEImproved -- train/eval-consistent, always-on shared
+       expert; no sparse-inference issue.)
+  - YOLO-Master-EsMoE-N -> ultralytics/cfg/models/master/v0/det/yolo-master-n.yaml
+      (MoE block: ES_MOE. Its default eval path (`use_sparse_inference=True`)
+       prunes to ~1 unnormalized expert while training blends all experts, which
+       collapses validation mAP.)
+
+Sparse vs dense evaluation (EsMoE-N only)
+-----------------------------------------
+By DEFAULT the scripts reproduce the model exactly as shipped -- ES_MOE keeps
+`use_sparse_inference=True`, so EsMoE-N's validation mAP collapses. This is
+intentional: the default is a faithful, unmodified reproduction.
+
+Pass ``--no-sparse-eval`` to opt into the CORRECTED evaluation. It is an explicit
+flag (not a silent default) so the change is visible in the command you ran. It
+registers a training callback that flips `ES_MOE.use_sparse_inference=False` on
+both the live model and its EMA at `on_pretrain_routine_end` (before any
+validation and before checkpoints are written from the EMA), so per-epoch val,
+the saved .pt, and final eval all use the same dense forward as training.
+v0.1-N has no ES_MOE modules, so the flag is a no-op there.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import time
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+METRIC_KEYS = (
+    "metrics/precision(B)",
+    "metrics/recall(B)",
+    "metrics/mAP50(B)",
+    "metrics/mAP50-95(B)",
+    "train/box_loss",
+    "train/cls_loss",
+    "train/dfl_loss",
+    "train/moe_loss",
+    "val/box_loss",
+    "val/cls_loss",
+    "val/dfl_loss",
+    "val/moe_loss",
+)
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    name: str
+    cfg: str
+    uses_esmoe: bool = False  # True if the model contains ES_MOE blocks (sparse-eval sensitive)
+
+
+@dataclass(frozen=True)
+class DatasetSpec:
+    name: str          # short tag, e.g. "VisDrone"
+    data: str          # dataset yaml, e.g. "VisDrone.yaml"
+    project: str       # e.g. "runs/reproduce/visdrone"
+
+
+# Both datasets train the same two models. EsMoE-N gets dense validation.
+MODELS = (
+    ModelSpec("v0.1-N", "ultralytics/cfg/models/master/v0_1/det/yolo-master-n.yaml", uses_esmoe=False),
+    ModelSpec("EsMoE-N", "ultralytics/cfg/models/master/v0/det/yolo-master-n.yaml", uses_esmoe=True),
+)
+
+
+# --------------------------------------------------------------------------- #
+# Dense-validation callback for ES_MOE                                         #
+# --------------------------------------------------------------------------- #
+def _make_dense_inference_callback():
+    """Return a trainer callback that sets ES_MOE.use_sparse_inference=False.
+
+    Applied to both trainer.model and trainer.ema.ema so per-epoch validation
+    (which runs on the EMA), the EMA-derived checkpoints, and the final eval all
+    take the dense forward path that matches training.
+    """
+    from ultralytics.nn.modules.moe.modules import ES_MOE
+    from ultralytics.utils import LOGGER
+
+    state = {"logged": False}
+
+    def _apply(trainer):
+        targets = []
+        model = getattr(trainer, "model", None)
+        if model is not None:
+            targets.append(model)
+        ema = getattr(trainer, "ema", None)
+        if ema is not None and getattr(ema, "ema", None) is not None:
+            targets.append(ema.ema)
+
+        count = 0
+        for target in targets:
+            for module in target.modules():
+                if isinstance(module, ES_MOE):
+                    module.use_sparse_inference = False
+                    count += 1
+        if count and not state["logged"]:
+            LOGGER.info(f"[reproduce] EsMoE dense validation enabled: "
+                        f"use_sparse_inference=False on {count} ES_MOE module(s)")
+            state["logged"] = True
+
+    return _apply
+
+
+# --------------------------------------------------------------------------- #
+# Real-time W&B per-epoch logging                                              #
+# --------------------------------------------------------------------------- #
+# Metrics logged every epoch: mAP50, mAP50-95, box_loss, cls_loss, moe_loss
+# (train + val variants where available). One W&B run per (dataset, model).
+_WANDB_METRICS = {
+    "mAP50": "metrics/mAP50(B)",
+    "mAP50-95": "metrics/mAP50-95(B)",
+    "train/box_loss": "train/box_loss",
+    "train/cls_loss": "train/cls_loss",
+    "train/moe_loss": "train/moe_loss",
+    "val/box_loss": "val/box_loss",
+    "val/cls_loss": "val/cls_loss",
+    "val/moe_loss": "val/moe_loss",
+}
+
+
+def _make_wandb_callbacks(run_name: str, dataset: "DatasetSpec", spec: "ModelSpec",
+                          args: argparse.Namespace, dense_val: bool) -> dict:
+    """Return trainer callbacks that stream per-epoch metrics to Weights & Biases.
+
+    Robust by design: if wandb is missing or init fails (e.g. not logged in for
+    online mode), a warning is emitted and training continues without wandb.
+    """
+    from ultralytics.utils import LOGGER
+
+    state = {"run": None}
+
+    def on_train_start(trainer):
+        try:
+            import wandb
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning(f"[reproduce] wandb unavailable ({exc}); continuing without it.")
+            return
+        try:
+            state["run"] = wandb.init(
+                project=args.wandb_project,
+                entity=(args.wandb_entity or None),
+                name=run_name,
+                mode=args.wandb_mode,
+                reinit=True,
+                config={
+                    "model": spec.name, "cfg": spec.cfg,
+                    "dataset": dataset.name, "data": dataset.data,
+                    "epochs": args.epochs, "imgsz": args.imgsz, "batch": args.batch,
+                    "seed": args.seed, "dense_val": dense_val,
+                },
+            )
+            url = getattr(state["run"], "url", None)
+            LOGGER.info(f"[reproduce] wandb run '{run_name}' [{args.wandb_mode}] -> {url}")
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning(
+                f"[reproduce] wandb init failed ({exc}); continuing without wandb. "
+                f"For a live URL run `wandb login` first, or use --wandb-mode offline."
+            )
+            state["run"] = None
+
+    def on_fit_epoch_end(trainer):
+        run = state["run"]
+        if run is None:
+            return
+        data = {}
+        try:
+            data.update(trainer.label_loss_items(trainer.tloss, prefix="train"))
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            data.update(trainer.metrics or {})
+        except Exception:  # noqa: BLE001
+            pass
+        epoch = int(getattr(trainer, "epoch", 0)) + 1
+        log = {"epoch": epoch}
+        for out_key, src_key in _WANDB_METRICS.items():
+            v = data.get(src_key)
+            if v is not None:
+                try:
+                    log[out_key] = float(v)
+                except (TypeError, ValueError):
+                    pass
+        try:
+            run.log(log, step=epoch)
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning(f"[reproduce] wandb log failed at epoch {epoch}: {exc}")
+
+    def on_train_end(trainer):
+        run = state["run"]
+        if run is not None:
+            try:
+                run.finish()
+            except Exception:  # noqa: BLE001
+                pass
+            state["run"] = None
+
+    return {"on_train_start": on_train_start,
+            "on_fit_epoch_end": on_fit_epoch_end,
+            "on_train_end": on_train_end}
+
+
+# --------------------------------------------------------------------------- #
+# Summary CSV                                                                  #
+# --------------------------------------------------------------------------- #
+def _read_last_metrics(results_csv: Path) -> dict[str, str]:
+    if not results_csv.exists():
+        return {}
+    with results_csv.open(newline="") as f:
+        rows = list(csv.DictReader(f))
+    return {k.strip(): v for k, v in rows[-1].items()} if rows else {}
+
+
+def _float_or_blank(value: str | None) -> str:
+    if value in (None, ""):
+        return ""
+    try:
+        return f"{float(value):.6g}"
+    except ValueError:
+        return value
+
+
+def write_summary(project: Path, dataset: DatasetSpec, models=MODELS, sparse_eval: bool = True) -> Path:
+    project.mkdir(parents=True, exist_ok=True)
+    out = project / "summary.csv"
+    fieldnames = ["dataset", "model", "cfg", "run_dir", "dense_eval", "epoch", *METRIC_KEYS]
+    with out.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        w.writeheader()
+        for spec in models:
+            run_dir = project / f"{dataset.name}_{spec.name}"
+            res = _read_last_metrics(run_dir / "results.csv")
+            row = {
+                "dataset": dataset.name,
+                "model": spec.name,
+                "cfg": spec.cfg,
+                "run_dir": str(run_dir.relative_to(ROOT)) if run_dir.is_relative_to(ROOT) else str(run_dir),
+                "dense_eval": (spec.uses_esmoe and not sparse_eval) if spec.uses_esmoe else "n/a",
+                "epoch": res.get("epoch", ""),
+            }
+            for k in METRIC_KEYS:
+                row[k] = _float_or_blank(res.get(k))
+            w.writerow(row)
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Training                                                                     #
+# --------------------------------------------------------------------------- #
+def _completed_epoch(run_dir: Path) -> int | None:
+    val = _read_last_metrics(run_dir / "results.csv").get("epoch")
+    try:
+        return int(float(val)) if val not in (None, "") else None
+    except ValueError:
+        return None
+
+
+def train_one(args: argparse.Namespace, dataset: DatasetSpec, spec: ModelSpec, project: Path) -> dict:
+    from ultralytics import YOLO
+
+    run_name = f"{dataset.name}_{spec.name}"
+    run_dir = project / run_name
+    last_pt = run_dir / "weights" / "last.pt"
+    best_pt = run_dir / "weights" / "best.pt"
+    done = _completed_epoch(run_dir)
+
+    if best_pt.exists() and done is not None and done + 1 >= args.epochs:
+        print(f"[skip] {run_name}: complete at epoch {done}", flush=True)
+        return {"model": spec.name, "status": "skipped"}
+
+    # Corrected dense evaluation is opt-in via --no-sparse-eval, and only affects
+    # ES_MOE models (v0.1-N has none, so it is a no-op there).
+    dense_eval = spec.uses_esmoe and not args.sparse_eval
+    if last_pt.exists() and done is not None:
+        print(f"[resume] {run_name}: {last_pt} epoch={done} -> {args.epochs}", flush=True)
+        model = YOLO(str(last_pt))
+        resume = True
+    else:
+        print(f"[train] {run_name}: cfg={spec.cfg} data={dataset.data} "
+              f"sparse_eval={args.sparse_eval} dense_eval={dense_eval}", flush=True)
+        model = YOLO(str(ROOT / spec.cfg))
+        resume = False
+
+    if dense_eval:
+        cb = _make_dense_inference_callback()
+        model.add_callback("on_pretrain_routine_end", cb)
+        model.add_callback("on_train_start", cb)
+
+    if args.wandb and args.wandb_mode != "disabled":
+        for event, fn in _make_wandb_callbacks(run_name, dataset, spec, args, dense_eval).items():
+            model.add_callback(event, fn)
+
+    start = time.time()
+    model.train(
+        data=dataset.data,
+        epochs=args.epochs,
+        imgsz=args.imgsz,
+        batch=args.batch,
+        device=args.device,
+        workers=args.workers,
+        seed=args.seed,
+        deterministic=True,
+        project=str(project),
+        name=run_name,
+        exist_ok=True,
+        pretrained=False,
+        val=True,
+        plots=True,
+        cache=args.cache,
+        patience=args.patience,
+        amp=args.amp,
+        resume=resume,
+        verbose=args.verbose,
+    )
+    return {"model": spec.name, "status": "resumed" if resume else "ok",
+            "duration_s": f"{time.time() - start:.1f}"}
+
+
+def build_parser(dataset: DatasetSpec) -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=f"Reproduce YOLO-Master v0.1-N and EsMoE-N baselines on {dataset.name}.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--epochs", type=int, default=300, help="Recommended ~300 (adjust to GPU budget).")
+    p.add_argument("--imgsz", type=int, default=640)
+    p.add_argument("--batch", type=int, default=64)
+    p.add_argument("--device", default="0")
+    p.add_argument("--workers", type=int, default=16)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--patience", type=int, default=0, help="0 disables early stopping.")
+    p.add_argument("--amp", action=argparse.BooleanOptionalAction, default=True)
+    p.add_argument("--cache", action="store_true")
+    p.add_argument("--project", default=dataset.project)
+    p.add_argument("--model", choices=[m.name for m in MODELS] + ["both"], default="both",
+                   help="Which model to train: v0.1-N, EsMoE-N, or both (default).")
+    p.add_argument("--sparse-eval", action=argparse.BooleanOptionalAction, default=True,
+                   help="ES_MOE sparse inference at validation/inference. Default True reproduces "
+                        "EsMoE-N as-is (its sparse-eval path collapses mAP). Pass --no-sparse-eval "
+                        "to opt into the CORRECTED dense evaluation (train==eval). No-op for v0.1-N.")
+    # --- Weights & Biases real-time per-epoch logging ---
+    p.add_argument("--wandb", action=argparse.BooleanOptionalAction, default=True,
+                   help="Stream mAP50/mAP50-95/box/cls/moe loss to W&B each epoch (default on). Use --no-wandb to disable.")
+    p.add_argument("--wandb-project", default="yolo-master-reproduce", help="W&B project name.")
+    p.add_argument("--wandb-entity", default="", help="W&B entity/team (optional).")
+    p.add_argument("--wandb-mode", choices=["online", "offline", "disabled"], default="online",
+                   help="online needs `wandb login`; offline logs locally (sync later); disabled turns it off.")
+    p.add_argument("--check-build", action="store_true", help="Instantiate both models and exit.")
+    p.add_argument("--dry-run", action="store_true", help="Print the plan and exit.")
+    p.add_argument("--summary-only", action="store_true", help="Only (re)write summary.csv from existing runs.")
+    p.add_argument("--stop-on-failure", action="store_true")
+    p.add_argument("--verbose", action="store_true")
+    return p
+
+
+def run_dataset(dataset: DatasetSpec) -> int:
+    """Entry point used by the per-dataset scripts."""
+    args = build_parser(dataset).parse_args()
+    project = Path(args.project) if Path(args.project).is_absolute() else ROOT / args.project
+    specs = list(MODELS) if args.model == "both" else [m for m in MODELS if m.name == args.model]
+
+    wandb_desc = "off" if (not args.wandb or args.wandb_mode == "disabled") else args.wandb_mode
+    print(f"[reproduce:{dataset.name}] data={dataset.data}  project={project}  "
+          f"sparse_eval={args.sparse_eval}  wandb={wandb_desc}")
+    for s in specs:
+        dense = s.uses_esmoe and not args.sparse_eval
+        note = f"dense_eval={dense}" if s.uses_esmoe else "no ES_MOE (sparse-eval n/a)"
+        print(f"  - {s.name:<8} cfg={s.cfg}  {note}")
+
+    if args.dry_run:
+        return 0
+    if args.check_build:
+        from ultralytics.nn.tasks import DetectionModel
+        for s in specs:
+            m = DetectionModel(str(ROOT / s.cfg), ch=3, nc=80, verbose=False)
+            print(f"[build-ok] {s.name}: {sum(p.numel() for p in m.parameters()) / 1e6:.3f}M  ({s.cfg})")
+        return 0
+    if args.summary_only:
+        print("[summary]", write_summary(project, dataset, specs, sparse_eval=args.sparse_eval))
+        return 0
+
+    project.mkdir(parents=True, exist_ok=True)
+    statuses = []
+    for s in specs:
+        try:
+            statuses.append(train_one(args, dataset, s, project))
+        except Exception as exc:  # noqa: BLE001
+            print(f"[fail] {s.name}: {type(exc).__name__}: {exc}", flush=True)
+            traceback.print_exc()
+            statuses.append({"model": s.name, "status": "failed", "error": str(exc)})
+            if args.stop_on_failure:
+                break
+        finally:
+            try:
+                write_summary(project, dataset, specs, sparse_eval=args.sparse_eval)
+            except OSError as e:
+                print(f"[summary-warn] {e}", flush=True)
+
+    print(f"\n[reproduce:{dataset.name}] DONE")
+    for st in statuses:
+        print("  ", st)
+    ok = {"ok", "resumed", "skipped"}
+    return 0 if all(st.get("status") in ok for st in statuses) else 1

--- a/scripts/reproduce/reproduce_sku110k.py
+++ b/scripts/reproduce/reproduce_sku110k.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Reproduce YOLO-Master-v0.1-N and YOLO-Master-EsMoE-N baselines on SKU-110K.
+
+SKU-110K (retail, dense products, single class), built-in config SKU-110K.yaml.
+By default the models are reproduced as-is (EsMoE-N keeps its sparse eval, which
+collapses mAP). Add --no-sparse-eval to opt into the corrected dense evaluation
+for EsMoE-N (train==eval); v0.1-N is unaffected.
+
+Examples:
+    python scripts/reproduce/reproduce_sku110k.py --check-build
+    python scripts/reproduce/reproduce_sku110k.py --epochs 300 --batch 64                  # as-is
+    python scripts/reproduce/reproduce_sku110k.py --model EsMoE-N --no-sparse-eval         # corrected
+    python scripts/reproduce/reproduce_sku110k.py --model v0.1-N --no-wandb
+    python scripts/reproduce/reproduce_sku110k.py --wandb-project my-proj --wandb-mode offline
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _reproduce_common import DatasetSpec, run_dataset  # noqa: E402
+
+DATASET = DatasetSpec(
+    name="SKU-110K",
+    data="SKU-110K.yaml",
+    project="runs/reproduce/sku110k",
+)
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_dataset(DATASET))

--- a/scripts/reproduce/reproduce_visdrone.py
+++ b/scripts/reproduce/reproduce_visdrone.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Reproduce YOLO-Master-v0.1-N and YOLO-Master-EsMoE-N baselines on VisDrone.
+
+VisDrone (aerial, dense small objects), built-in config VisDrone.yaml.
+By default the models are reproduced as-is (EsMoE-N keeps its sparse eval, which
+collapses mAP). Add --no-sparse-eval to opt into the corrected dense evaluation
+for EsMoE-N (train==eval); v0.1-N is unaffected.
+
+Examples:
+    python scripts/reproduce/reproduce_visdrone.py --check-build
+    python scripts/reproduce/reproduce_visdrone.py --epochs 300 --batch 64                 # as-is
+    python scripts/reproduce/reproduce_visdrone.py --model EsMoE-N --no-sparse-eval        # corrected
+    python scripts/reproduce/reproduce_visdrone.py --model v0.1-N --no-wandb
+    python scripts/reproduce/reproduce_visdrone.py --wandb-project my-proj --wandb-mode offline
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _reproduce_common import DatasetSpec, run_dataset  # noqa: E402
+
+DATASET = DatasetSpec(
+    name="VisDrone",
+    data="VisDrone.yaml",
+    project="runs/reproduce/visdrone",
+)
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_dataset(DATASET))


### PR DESCRIPTION
Resolves #49.

Adds reproducible training scripts for the YOLO-Master-v0.1-N & EsMoE-N on two dense-scene vertical datasets, under `scripts/reproduce/`: 

- `reproduce_visdrone.py`, `reproduce_sku110k.py` — per-dataset entry points
- `_reproduce_common.py` — shared training/logging logic

## Usage

```bash
python scripts/reproduce/reproduce_visdrone.py --model v0.1-N  --epochs 300 --batch 64
python scripts/reproduce/reproduce_visdrone.py --model EsMoE-N --epochs 300 --batch 64 --no-sparse-eval
python scripts/reproduce/reproduce_sku110k.py  --model v0.1-N  --epochs 300 --batch 64
python scripts/reproduce/reproduce_sku110k.py  --model EsMoE-N --epochs 300 --batch 64 --no-sparse-eval
```

`--model {v0.1-N,EsMoE-N,both}`, standard `--imgsz/--epochs/--batch`, resumable. Per-epoch metrics (`mAP50, mAP50-95, box_loss, cls_loss, moe_loss`) go to each run's `results.csv`; optional live Weights & Biases logging via `--wandb*`.

## `--no-sparse-eval` (why this exists)

`EsMoE-N` trains correctly however, with `ES_MOE`'s default sparse inference, its **validation** mAP would collapse (e.g. VisDrone 0.35 → 0.01): eval takes `_sparse_forward`, which prunes to ≈1 expert (`dynamic_threshold=0.4`) and doesn't actually renormalize, so features are ~1/N the magnitude the trained BatchNorm expects — whereas training always blends all experts densely. `--no-sparse-eval` is an **opt-in** flag that registers a callback setting `ES_MOE.use_sparse_inference=False` on the model **and its EMA**, so per-epoch validation, checkpoints, and final eval all use the dense path that matches training. Default (no flag) reproduces the model exactly as shipped.

| Model | Dataset | Eval | mAP50 | mAP50-95 |
|---|---|---|---|---|
| v0.1-N | VisDrone | default | 0.344 | 0.201 |
| EsMoE-N | VisDrone | default (sparse) | 0.010 | 0.003 |
| EsMoE-N | VisDrone | `--no-sparse-eval` | 0.350 | 0.203 |
| v0.1-N | SKU-110K | default | 0.906 | 0.582 |
| EsMoE-N | SKU-110K | default (sparse) | 0.305 | 0.136 |
| EsMoE-N | SKU-110K | `--no-sparse-eval` | 0.904 | 0.583 |

The comprehensive analysis of the behavior is in `scripts/reproduce/README.md`.
📊 For full training logs, visit my [W&B Project](https://wandb.ai/yolo-master-reproduce/yolo-master-reproduce).

**No core library changes** — the fix is a runtime callback in the scripts. (The separate standalone-validation `NameError` was fixed in #80.)
