### PR TITLE
fix: MoLoRA _step_count buffer assignment in verify_molora.py

### DIFF
--- a/verify_molora.py
+++ b/verify_molora.py
@@ -329,9 +329,9 @@ try:
     conv = nn.Conv2d(16, 32, 3, padding=1)
     layer = MoLoRALayer(conv, r=4, alpha=8, num_experts=4, top_k=2, top_k_warmup=10, warmup_steps=10)
     check("warmup step 0: top_k=1", layer._current_top_k() == 1)
-    layer._step_count = 5
+    layer._step_count.fill_(5)
     check("warmup step 5: top_k=1 (渐进)", layer._current_top_k() == 1)
-    layer._step_count = 10
+    layer._step_count.fill_(10)
     check("warmup step 10: top_k=2", layer._current_top_k() == 2)
 
     # expert dropout


### PR DESCRIPTION
### Summary
Fixed a test failure in the MoLoRA dynamic routing warmup validation (\`verify_molora.py\`) where assigning a Python \`int\` directly to a registered PyTorch buffer caused a \`TypeError\`.
### Rationale
Assigning a raw integer to a registered PyTorch buffer (e.g., \`layer._step_count = 5\`) is disallowed by PyTorch's `nn.Module.__setattr__`, which requires buffers to remain a \`Tensor\` or \`None\`. Replacing this with `.fill_(5)` and `.fill_(10)` modifies the underlying tensor in-place, satisfying PyTorch and fixing the validation check.
### Verification Results
All MoLoRA validations pass successfully (150/150 validation checks).