### PR TITLE
feat(mixture): MoA window attention, MoT GShard balance loss, MoE cor…

### DIFF
--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -245,6 +245,14 @@ moe_expert_warmup_epochs: 3 # (int) Epochs to freeze experts while router learns
 moe_router_lr_scale: 0.5 # (float) Router LR as fraction of base LR (was 0.1, too small to correct collapse)
 moe_collapse_threshold: 0.8 # (float) If max expert usage > threshold, trigger collapse recovery
 
+# MoT / MoA router settings
+mot_balance_loss: 0.01 # (float) GShard balance loss coefficient for MoT blocks
+mot_router_z_loss: 0.01 # (float) Router z-loss coefficient for MoT blocks
+mot_sparse_train: False # (bool) Sparse expert dispatch during MoT training (faster; default dense for exploration)
+moa_local_window_size: 7 # (int) Window size for MoA local attention head
+moa_mot_temperature_factor: 0.97 # (float) Per-epoch router temperature multiplier for MoA/MoT
+moa_mot_min_temperature: 0.3 # (float) Minimum router temperature after annealing
+
 # MoLoRA (Mixture-of-LoRA) settings -----------------------------------------------------------------------------------------
 molora_num_experts: 0 # (int) Number of experts in MoLoRA layers (0 to disable)
 molora_top_k: 2 # (int) Number of experts to activate per forward

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -385,7 +385,9 @@ class BaseTrainer:
         self._detect_moa_mot_modules()
 
         # MoE Routing Collapse Detector (initialize if model has MoE layers)
-        has_moe = any(hasattr(m, 'num_experts') for m in self.model.modules())
+        from ultralytics.nn.modules.moe.utils import is_core_moe_block, model_has_core_moe, iter_core_moe_expert_params
+
+        has_moe = model_has_core_moe(self.model)
         # Persist the detection result so the train loop can gate MoE-only
         # logic (warmup schedule, gain schedule, collapse detector) and avoid
         # printing MoE messages on plain (non-MoE) models.
@@ -426,6 +428,8 @@ class BaseTrainer:
 
             injected = 0
             for m in self.model.modules():
+                if not is_core_moe_block(m):
+                    continue
                 if hasattr(m, 'balance_loss_coeff'):
                     m.balance_loss_coeff = balance_loss_coeff
                     injected += 1
@@ -453,6 +457,39 @@ class BaseTrainer:
                 f"balance_loss={balance_loss_coeff}, z_loss={router_z_loss_coeff}, "
                 f"noise_std={noise_std}, temperature={temperature}"
             )
+
+        # MoT router aux-loss coefficients (separate from core MoE injection)
+        try:
+            from ultralytics.nn.modules.mot import MoTBlock
+            from ultralytics.nn.modules.moa import MoABlock, C2fMoA
+
+            mot_balance = getattr(self.args, "mot_balance_loss", 0.01)
+            mot_z = getattr(self.args, "mot_router_z_loss", 0.01)
+            mot_sparse = bool(getattr(self.args, "mot_sparse_train", False))
+            moa_win = int(getattr(self.args, "moa_local_window_size", 7))
+            mot_injected = 0
+            moa_injected = 0
+            for m in self.model.modules():
+                if isinstance(m, MoTBlock):
+                    m.balance_loss_coeff = mot_balance
+                    m.router_z_loss_coeff = mot_z
+                    m.sparse_train = mot_sparse
+                    mot_injected += 1
+                elif isinstance(m, MoABlock):
+                    m.local_head.window_size = max(1, moa_win)
+                    moa_injected += 1
+            if mot_injected and RANK in {-1, 0}:
+                LOGGER.info(
+                    f"[MoT] Config injected into {mot_injected} MoTBlock layers: "
+                    f"balance_loss={mot_balance}, z_loss={mot_z}, sparse_train={mot_sparse}"
+                )
+            if moa_injected and RANK in {-1, 0}:
+                LOGGER.info(
+                    f"[MoA] Config injected into {moa_injected} MoABlock layers: "
+                    f"local_window_size={moa_win}"
+                )
+        except Exception:
+            pass
 
         # MoLoRA injection (even if no MoE layers present)
         has_molora = any(
@@ -701,9 +738,10 @@ class BaseTrainer:
             # unconditionally print '[MoE] Unfreezing expert weights ...' at
             # epoch == warmup, even though there were no expert weights at all.
             if getattr(self, "_has_moe", False):
+                from ultralytics.nn.modules.moe.utils import iter_core_moe_expert_params
+
                 moe_warmup_epochs = getattr(self.args, 'moe_expert_warmup_epochs', 3)
-                expert_params = [p for n, p in self.model.named_parameters()
-                                 if "experts" in n and "routing" not in n and "router" not in n and "shared" not in n]
+                expert_params = list(iter_core_moe_expert_params(self.model))
                 if expert_params:
                     if epoch < moe_warmup_epochs:
                         for p in expert_params:

--- a/ultralytics/nn/modules/moa/moa.py
+++ b/ultralytics/nn/modules/moa/moa.py
@@ -54,21 +54,62 @@ def _flash_attn(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
     return attn @ v
 
 
+def _window_flash_attn(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    scale: float,
+    window_size: int,
+    height: int,
+    width: int,
+) -> torch.Tensor:
+    """Window-partitioned SDPA on [B, nh, N, hd] tokens (O(N·win²) complexity)."""
+    B, nh, n_tokens, hd = q.shape
+    assert n_tokens == height * width
+    win = max(1, min(int(window_size), height, width))
+
+    def to_spatial(t: torch.Tensor) -> torch.Tensor:
+        return t.transpose(2, 3).reshape(B, nh, height, width, hd)
+
+    qs, ks, vs = to_spatial(q), to_spatial(k), to_spatial(v)
+    pad_h = (win - height % win) % win
+    pad_w = (win - width % win) % win
+    if pad_h or pad_w:
+        pad = (0, 0, 0, pad_w, 0, pad_h)
+        qs, ks, vs = F.pad(qs, pad), F.pad(ks, pad), F.pad(vs, pad)
+    hp, wp = qs.shape[2], qs.shape[3]
+
+    def partition(t: torch.Tensor) -> torch.Tensor:
+        t = t.view(B, nh, hp // win, win, wp // win, win, hd)
+        return t.permute(0, 1, 2, 4, 3, 5, 6).reshape(-1, win * win, hd)
+
+    def reverse(windows: torch.Tensor) -> torch.Tensor:
+        n_h, n_w = hp // win, wp // win
+        t = windows.view(B, nh, n_h, n_w, win, win, hd)
+        t = t.permute(0, 1, 2, 4, 3, 5, 6).reshape(B, nh, hp, wp, hd)
+        return t[:, :, :height, :width, :].reshape(B, nh, height * width, hd)
+
+    out_w = _flash_attn(partition(qs), partition(ks), partition(vs), scale)
+    return reverse(out_w)
+
+
 # ---------------------------------------------------------------------------
 # Sub-modules: three attention head variants
 # ---------------------------------------------------------------------------
 
 class _LocalAttnHead(nn.Module):
-    """Local attention head: DW-3×3 biased QKV projection.
+    """Local attention head: DW-biased QKV + window-partitioned self-attention.
 
-    Each token attends only within a local neighbourhood defined by the
-    positional encoding, keeping computation well-localised.
+    Each token attends only within a fixed ``window_size × window_size`` neighbourhood
+    (Swin-style), giving true O(N·win²) local context instead of global O(N²) SDPA.
     """
 
-    def __init__(self, dim: int, num_heads: int, head_dim: Optional[int] = None):
+    def __init__(self, dim: int, num_heads: int, head_dim: Optional[int] = None,
+                 window_size: int = 7):
         super().__init__()
         self.num_heads = num_heads
         self.head_dim = head_dim or max(dim // num_heads, 16)
+        self.window_size = max(1, int(window_size))
         inner = self.head_dim * num_heads
         # QKV with DW-3×3 for local bias
         self.qkv_dw = nn.Conv2d(dim, dim, 3, padding=1, groups=dim, bias=False)
@@ -95,7 +136,9 @@ class _LocalAttnHead(nn.Module):
         def to_heads(t):
             return t.flatten(2).view(B, nh, hd, N).transpose(2, 3)   # [B,nh,N,hd]
 
-        out = _flash_attn(to_heads(q), to_heads(k), to_heads(v), self.scale)
+        out = _window_flash_attn(
+            to_heads(q), to_heads(k), to_heads(v), self.scale, self.window_size, H, W
+        )
         # [B, nh, N, hd] → [B, inner, H, W]
         out = out.transpose(2, 3).reshape(B, inner, H, W)
         return self.norm(self.proj(out))
@@ -336,6 +379,7 @@ class MoABlock(nn.Module):
         shortcut: bool = True,
         aux_loss_coeff: float = 0.01,
         block_index: int = 0,
+        local_window_size: int = 7,
     ):
         super().__init__()
         assert num_heads % self.NUM_GROUPS == 0, (
@@ -348,7 +392,7 @@ class MoABlock(nn.Module):
 
         # Three attention head-groups (global head uses a per-block RF seed).
         global_rf_seed = block_index * 7919 + 2 * 65537
-        self.local_head   = _LocalAttnHead(dim, heads_per_group, head_dim)
+        self.local_head   = _LocalAttnHead(dim, heads_per_group, head_dim, window_size=local_window_size)
         self.region_head  = _RegionalAttnHead(dim, heads_per_group, head_dim)
         self.global_head  = _GlobalAttnHead(dim, heads_per_group, head_dim, rf_seed=global_rf_seed)
 
@@ -457,6 +501,7 @@ class C2fMoA(nn.Module):
         shortcut: bool = True,
         e: float = 0.5,
         aux_loss_coeff: float = 0.01,
+        local_window_size: int = 7,
     ):
         super().__init__()
         self.c = int(c2 * e)
@@ -478,7 +523,8 @@ class C2fMoA(nn.Module):
                      temperature=temperature,
                      shortcut=shortcut,
                      aux_loss_coeff=aux_loss_coeff,
-                     block_index=i)
+                     block_index=i,
+                     local_window_size=local_window_size)
             for i in range(n)
         )
         self.last_aux_loss: torch.Tensor = torch.zeros((), requires_grad=False)

--- a/ultralytics/nn/modules/moe/__init__.py
+++ b/ultralytics/nn/modules/moe/__init__.py
@@ -58,7 +58,10 @@ from .routers import (
 from .utils import (
     FlopsUtils,
     get_safe_groups,
-    BatchedExpertComputation
+    BatchedExpertComputation,
+    is_core_moe_block,
+    model_has_core_moe,
+    iter_core_moe_expert_params,
 )
 
 from .analysis import ExpertUsageTracker, diagnose_model, RoutingCollapseDetector
@@ -110,6 +113,9 @@ __all__ = [
     "FlopsUtils",
     "get_safe_groups",
     "BatchedExpertComputation",
+    "is_core_moe_block",
+    "model_has_core_moe",
+    "iter_core_moe_expert_params",
     "ExpertUsageTracker",
     "RoutingCollapseDetector",
     "diagnose_model",

--- a/ultralytics/nn/modules/moe/experts.py
+++ b/ultralytics/nn/modules/moe/experts.py
@@ -204,18 +204,21 @@ class SharedInvertedExpertGroup(nn.Module):
         hidden_dim = max(1, int(in_channels * expand_ratio))
         padding = kernel_size // 2
 
+        def _gn(channels: int) -> nn.GroupNorm:
+            return nn.GroupNorm(get_safe_groups(channels, 8), channels)
+
         self.shared_feature = nn.Sequential(
             nn.Conv2d(in_channels, hidden_dim, 1, bias=False),
-            nn.BatchNorm2d(hidden_dim),
+            _gn(hidden_dim),
             nn.SiLU(inplace=True),
             nn.Conv2d(hidden_dim, hidden_dim, kernel_size, padding=padding, groups=hidden_dim, bias=False),
-            nn.BatchNorm2d(hidden_dim),
+            _gn(hidden_dim),
             nn.SiLU(inplace=True),
         )
         self.expert_projections = nn.ModuleList(
             nn.Sequential(
                 nn.Conv2d(hidden_dim, out_channels, 1, bias=False),
-                nn.BatchNorm2d(out_channels),
+                _gn(out_channels),
             )
             for _ in range(num_experts)
         )

--- a/ultralytics/nn/modules/moe/utils.py
+++ b/ultralytics/nn/modules/moe/utils.py
@@ -2,11 +2,46 @@
 """Utility functions for Mixture-of-Experts models"""
 import torch
 import torch.nn as nn
-from typing import Tuple, Union, List
+from typing import Iterator, Tuple, Union, List
+
+# Namespace for full MoE *block* classes (excludes routers/experts/loss helpers).
+_CORE_MOE_MODULE = "ultralytics.nn.modules.moe.modules"
+
+
+def is_core_moe_block(module: nn.Module) -> bool:
+    """Return True for top-level MoE blocks in ``moe.modules`` (not routers/sub-experts)."""
+    mod = getattr(module.__class__, "__module__", "") or ""
+    return mod == _CORE_MOE_MODULE or mod.endswith(".moe.modules")
+
+
+def model_has_core_moe(model: nn.Module) -> bool:
+    """Return True when the model contains at least one core MoE block."""
+    return any(is_core_moe_block(m) for m in model.modules())
+
+
+def iter_core_moe_expert_params(model: nn.Module) -> Iterator[torch.nn.Parameter]:
+    """Yield expert-weight parameters that belong to core MoE blocks only.
+
+    Excludes MoT ``experts.*``, MoLoRA ``experts.*``, routers, and shared paths so
+    expert-warmup does not freeze unrelated mixture modules.
+    """
+    for prefix, m in model.named_modules():
+        if not is_core_moe_block(m):
+            continue
+        for name, param in m.named_parameters():
+            full = f"{prefix}.{name}" if prefix else name
+            if "routing" in full or "router" in full:
+                continue
+            if "shared" in full:
+                continue
+            if "expert" in full:
+                yield param
 
 
 def get_safe_groups(channels: int, desired_groups: int = 8) -> int:
     """Ensure num_groups divides channels"""
+    if channels <= 0:
+        return 1
     groups = min(desired_groups, channels)
     while channels % groups != 0:
         groups -= 1

--- a/ultralytics/nn/modules/mot/mot.py
+++ b/ultralytics/nn/modules/mot/mot.py
@@ -42,6 +42,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from ultralytics.nn.modules.conv import Conv
+from ultralytics.nn.modules.moe.loss import differentiable_balance_loss
 from ultralytics.nn.modules.moe.utils import get_safe_groups as _safe_groups
 from ultralytics.utils import LOGGER
 
@@ -558,9 +559,45 @@ class _MoTRouter(nn.Module):
             return weights, indices, logits
         return weights, indices
 
+    @staticmethod
+    def expert_usage_from_indices(indices: torch.Tensor, num_experts: int) -> torch.Tensor:
+        """Discrete expert usage share from Top-K index tensor (any rank ≥ 2)."""
+        flat = indices.reshape(-1).to(torch.long)
+        counts = torch.bincount(flat, minlength=num_experts).float()
+        return counts / max(flat.numel(), 1)
+
     def router_z_loss(self, x: torch.Tensor) -> torch.Tensor:
         """Z-loss for load balance: encourages router logits to be small."""
         return self.z_loss_from_logits(self._compute_logits(x))
+
+
+def _mot_router_aux_loss(
+    weights: torch.Tensor,
+    logits: torch.Tensor,
+    indices: torch.Tensor,
+    num_experts: int,
+    balance_coeff: float,
+    z_coeff: float,
+) -> torch.Tensor:
+    """GShard balance + router z-loss for MoT (matches MoE/MoLoRA formulation)."""
+    if balance_coeff <= 0 and z_coeff <= 0:
+        return weights.new_zeros(())
+
+    probs = weights
+    if probs.dim() == 4:
+        probs = probs.reshape(probs.shape[0], num_experts, -1).mean(-1)
+    probs = probs.reshape(-1, num_experts)
+
+    usage = _MoTRouter.expert_usage_from_indices(indices, num_experts)
+    balance = differentiable_balance_loss(probs, usage, num_experts)
+    z_loss = _MoTRouter.z_loss_from_logits(logits)
+
+    total = weights.new_zeros(())
+    if balance_coeff > 0:
+        total = total + balance_coeff * balance
+    if z_coeff > 0:
+        total = total + z_coeff * z_loss
+    return total
 
 
 # ---------------------------------------------------------------------------
@@ -609,15 +646,21 @@ class MoTBlock(nn.Module):
         temperature: float = 1.0,
         use_spatial_router: bool = True,
         balance_loss_coeff: float = 0.01,
+        router_z_loss_coeff: float | None = None,
         dropout: float = 0.0,
         exploration_eps: float = 0.02,
         window_shift: bool = False,
         grid_align_corners: bool = True,
+        sparse_train: bool = False,
     ):
         super().__init__()
         assert 1 <= top_k <= self.NUM_EXPERTS
         self.top_k = top_k
         self.balance_loss_coeff = balance_loss_coeff
+        self.sparse_train = sparse_train
+        # Legacy YAML/checkpoints used balance_loss_coeff for z-loss only; when
+        # router_z_loss_coeff is omitted, keep that behaviour for the z term.
+        self.router_z_loss_coeff = balance_loss_coeff if router_z_loss_coeff is None else router_z_loss_coeff
 
         # Each expert uses the *full* dim with its own num_heads.
         # Find largest num_heads ≤ requested that divides dim.
@@ -660,41 +703,63 @@ class MoTBlock(nn.Module):
     def _init_weights(self):
         nn.init.trunc_normal_(self.out_proj.weight, std=0.02)
 
-    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        """
-        Returns:
-            out           : [B, C, H, W]
-            aux_loss      : scalar (router z-loss, 0 if balance_loss_coeff==0)
-        """
-        # ── Routing weights ──────────────────────────────────────────────
-        weights, indices, router_logits = self.router(x, return_logits=True)   # [B, E, H, W]
+    def _blend_experts(
+        self,
+        x: torch.Tensor,
+        weights: torch.Tensor,
+        indices: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Blend expert outputs; sparse when eval or ``sparse_train`` (not during ONNX export).
 
-        # ── Expert computation ───────────────────────────────────────────
-        if not self.training:
-            # Inference: sparse batch dispatch — only active experts per sample.
-            out = x.new_zeros(x.shape)
-            B = x.shape[0]
+        Sparse dispatch keys off discrete Top-K ``indices`` so training-time
+        ``exploration_eps`` blending does not force every expert to run.
+        """
+        out = x.new_zeros(x.shape)
+        use_sparse = (not self.training or self.sparse_train) and not torch.onnx.is_in_onnx_export()
+        B = x.shape[0]
+        if use_sparse:
             for e_idx, expert in enumerate(self.experts):
-                active = weights[:, e_idx].reshape(B, -1).sum(dim=1) > 0
+                if indices is not None:
+                    active = (indices == e_idx).reshape(B, -1).any(dim=1)
+                else:
+                    active = weights[:, e_idx].reshape(B, -1).sum(dim=1) > 0
                 batch_idx = torch.nonzero(active, as_tuple=True)[0]
                 if batch_idx.numel() == 0:
                     continue
                 w = weights[batch_idx, e_idx:e_idx + 1]
                 out[batch_idx] = out[batch_idx] + expert(x[batch_idx]) * w
         else:
-            # Training: dense compute keeps all experts in the graph for exploration.
-            out = x.new_zeros(x.shape)
             for e_idx, expert in enumerate(self.experts):
-                w = weights[:, e_idx:e_idx + 1]   # [B, 1, H, W]
+                w = weights[:, e_idx:e_idx + 1]
                 out = out + expert(x) * w
+        return out
+
+    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Returns:
+            out           : [B, C, H, W]
+            aux_loss      : scalar (GShard balance + router z-loss, 0 if both coeffs==0)
+        """
+        # ── Routing weights ──────────────────────────────────────────────
+        weights, indices, router_logits = self.router(x, return_logits=True)   # [B, E, H, W]
+
+        # ── Expert computation ───────────────────────────────────────────
+        out = self._blend_experts(x, weights, indices)
         out = self.out_norm(self.out_proj(out))
 
         # Residual (block-level shortcut)
         out = out + x
 
         # ── Auxiliary loss ───────────────────────────────────────────────
-        if self.balance_loss_coeff > 0 and self.training:
-            aux = self.router.z_loss_from_logits(router_logits) * self.balance_loss_coeff
+        if self.training and (self.balance_loss_coeff > 0 or self.router_z_loss_coeff > 0):
+            aux = _mot_router_aux_loss(
+                weights,
+                router_logits,
+                indices,
+                self.NUM_EXPERTS,
+                self.balance_loss_coeff,
+                self.router_z_loss_coeff,
+            )
         else:
             aux = x.new_zeros(())
 
@@ -746,6 +811,7 @@ class C2fMoT(nn.Module):
         temperature: float = 1.0,
         balance_loss_coeff: float = 0.01,
         e: float = 0.5,
+        sparse_train: bool = False,
     ):
         super().__init__()
         self.c = int(c2 * e)
@@ -779,6 +845,7 @@ class C2fMoT(nn.Module):
                 temperature=temperature,
                 balance_loss_coeff=balance_loss_coeff,
                 window_shift=bool(i % 2),
+                sparse_train=sparse_train,
             )
             for i in range(n)
         )

--- a/ultralytics/nn/peft/molora/config.py
+++ b/ultralytics/nn/peft/molora/config.py
@@ -114,6 +114,7 @@ class MoLoRAConfig(LoRAConfig):
             "freeze_experts": "molora_freeze_experts",
             "share_moe_registry": "molora_share_moe_registry",
             "expert_init": "molora_expert_init",
+            "use_rslora": "molora_use_rslora",
         }
 
         molora_kwargs = {}

--- a/ultralytics/nn/peft/molora/layer.py
+++ b/ultralytics/nn/peft/molora/layer.py
@@ -4,6 +4,7 @@ Contains:
   - MoLoRAExpert: a single LoRA expert (Conv2d or Linear low-rank pair)
   - MoLoRALayer: a wrapper that replaces a base layer with top-k sparse experts
 """
+import math
 from typing import Dict, List, Optional, Tuple, Any
 
 import torch
@@ -244,29 +245,26 @@ class MoLoRALayer(nn.Module):
 
     def _apply_capacity_limit(
         self,
-        router_probs: torch.Tensor,
-        expert_indices: torch.Tensor,
+        top_k_weights: torch.Tensor,
+        top_k_indices: torch.Tensor,
     ) -> torch.Tensor:
-        """Apply per-sample soft capacity penalty.
+        """Apply a global soft capacity penalty on Top-K expert selections.
 
-        Note: This is a simplified per-sample soft penalty, not a global
-        hard capacity limit like standard MoE. When an expert is selected
-        by too many samples in a batch, its weights are scaled down.
+        When an expert is selected by more than ``capacity_factor * B * K / E`` slots
+        in the batch, its Top-K weights are scaled down and renormalized.
         """
-        if self.capacity_factor <= 0 or self.capacity_factor >= 1e6:
-            return router_probs
-        B = router_probs.shape[0]
-        capacity = max(1, int(self.capacity_factor * B / self.num_experts))
-        # Count selections per expert, zero out excess
-        weights = router_probs.gather(1, expert_indices)  # [B, K]
+        if self.capacity_factor <= 0 or self.capacity_factor >= 1.0:
+            return top_k_weights
+        B, K = top_k_weights.shape
+        max_slots = max(1, int(math.ceil(self.capacity_factor * B * K / self.num_experts)))
+        weights = top_k_weights.clone()
         for e in range(self.num_experts):
-            mask = expert_indices == e
-            count = mask.sum(dim=1)  # [B]
-            # Simple per-expert capacity: if too many tokens select this expert, clip
-            # For simplicity, we apply a soft penalty by scaling down weights
-            scale = (capacity / (count + 1).clamp_min(1)).clamp_max(1.0)
-            weights = weights * scale.unsqueeze(1)
-        return weights
+            slots = top_k_indices == e
+            usage = int(slots.sum().item())
+            if usage > max_slots:
+                scale = max_slots / usage
+                weights = torch.where(slots, weights * scale, weights)
+        return weights / weights.sum(dim=-1, keepdim=True).clamp_min(1e-6)
 
     # ------------------------------------------------------------------
     # Domain pre-allocation
@@ -356,9 +354,9 @@ class MoLoRALayer(nn.Module):
         top_k_weights, top_k_indices = torch.topk(router_probs, effective_k, dim=-1)  # [B, K]
         top_k_weights = top_k_weights / top_k_weights.sum(dim=-1, keepdim=True).clamp_min(1e-6)
 
-        # Apply capacity limit
-        if self.capacity_factor > 0 and self.capacity_factor < 1e6:
-            top_k_weights = self._apply_capacity_limit(router_probs, top_k_indices)
+        # Apply capacity limit (1.0 = no limit per config convention)
+        if 0 < self.capacity_factor < 1.0:
+            top_k_weights = self._apply_capacity_limit(top_k_weights, top_k_indices)
 
         # Compute sparse expert outputs
         adapted = self._compute_sparse_experts(x, top_k_weights, top_k_indices, base_out)


### PR DESCRIPTION
- moa: Swin-style window-partitioned flash attention in _LocalAttnHead (O(N·win²))
- mot: GShard balance loss + router z-loss for MoT blocks; sparse_train toggle
- moe: is_core_moe_block, model_has_core_moe, iter_core_moe_expert_params utils to prevent false detection of MoT/MoLoRA as core MoE; GroupNorm in SharedInvertedExpertGroup
- molora: fix capacity limit threshold (1.0 = no limit); add use_rslora mapping
- molora: fix get_safe_groups zero-division guard
- moe: export new utils in __init__.py
- cfg: add MoT/MoA router settings (mot_balance_loss, mot_router_z_loss, etc.)
- trainer: use precise MoE detection; inject MoT/MoA config from args