### PR TITLE
【Issue 51】Add edge deployment validation example

### DIFF
--- a/examples/YOLO-Master-Edge-Deployment/CMakeLists.txt
+++ b/examples/YOLO-Master-Edge-Deployment/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.12)
+project(yolo_master_edge_deployment LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(yolo_master_edge_benchmark cpp/edge_benchmark_stub.cpp)

--- a/examples/YOLO-Master-Edge-Deployment/README.md
+++ b/examples/YOLO-Master-Edge-Deployment/README.md
@@ -1,0 +1,59 @@
+# YOLO-Master Edge Deployment Example
+
+This example supports issue #51: vertical-model edge inference acceleration and consistency validation.
+
+It provides a lightweight, reproducible scaffold for exporting YOLO-Master models to ONNX plus NCNN/MNN, running vertical-domain preprocessing, comparing backend outputs, and summarizing edge benchmark logs.
+
+## Files
+
+- `edge_utils.py` - shared preprocessing, postprocessing, consistency, and benchmark utilities.
+- `export_edge_models.py` - export helper for ONNX, NCNN, and MNN.
+- `validate_edge_outputs.py` - compare PyTorch/exported backend outputs saved as `.npy` tensors.
+- `cpp/edge_benchmark_stub.cpp` - minimal C++ benchmark entry that can be extended with ONNX Runtime, NCNN, or MNN runtime calls.
+- `CMakeLists.txt` - portable CMake target for the C++ benchmark entry.
+
+## Vertical Profiles
+
+The example includes two profiles:
+
+- `visdrone`: keeps long/short aspect ratio, uses lower confidence for small objects.
+- `sku110k`: supports high-resolution shelf images and a slightly higher NMS IoU.
+
+## Export
+
+```bash
+python export_edge_models.py --model runs/train/weights/best.pt --formats onnx ncnn --imgsz 960 --half
+python export_edge_models.py --model runs/train/weights/best.pt --formats onnx mnn --imgsz 960
+```
+
+For ONNX simplification, install export dependencies and pass `--simplify`.
+
+## Consistency Validation
+
+Save backend outputs as `.npy` tensors with compatible shapes, then run:
+
+```bash
+python validate_edge_outputs.py --reference pytorch.npy --candidate onnx.npy --tolerance 0.005
+python validate_edge_outputs.py --reference pytorch.npy --candidate ncnn.npy --tolerance 0.01
+```
+
+The tool reports max absolute error, mean absolute error, RMSE, and whether the configured tolerance is met.
+
+## CMake Smoke Build
+
+```bash
+cmake -S . -B build
+cmake --build build
+./build/yolo_master_edge_benchmark --backend onnx --model best.onnx --images val.txt
+```
+
+The C++ file is intentionally dependency-light. It establishes the CLI contract and build target, so backend-specific runtime calls can be added without changing benchmark automation.
+
+## Recommended Issue #51 Workflow
+
+1. Train or reuse a YOLO-Master-EsMoE-N checkpoint on VisDrone or SKU-110K.
+2. Export ONNX plus NCNN or MNN.
+3. Validate ONNX opset/simplification and NCNN/MNN conversion files.
+4. Run the same 500-image validation list through PyTorch and exported backends.
+5. Compare mAP50-95 deltas and tensor/output differences.
+6. Report latency P50/P95/P99 and FPS per backend/platform.

--- a/examples/YOLO-Master-Edge-Deployment/cpp/edge_benchmark_stub.cpp
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/edge_benchmark_stub.cpp
@@ -1,0 +1,32 @@
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+
+static std::unordered_map<std::string, std::string> parse_args(int argc, char** argv) {
+    std::unordered_map<std::string, std::string> args;
+    for (int i = 1; i + 1 < argc; i += 2) {
+        args[argv[i]] = argv[i + 1];
+    }
+    return args;
+}
+
+int main(int argc, char** argv) {
+    const auto args = parse_args(argc, argv);
+    const auto backend = args.count("--backend") ? args.at("--backend") : "onnx";
+    const auto model = args.count("--model") ? args.at("--model") : "";
+    const auto images = args.count("--images") ? args.at("--images") : "";
+
+    if (model.empty() || images.empty()) {
+        std::cerr << "Usage: yolo_master_edge_benchmark --backend onnx|ncnn|mnn --model MODEL --images LIST\n";
+        return 2;
+    }
+
+    const auto start = std::chrono::steady_clock::now();
+    const auto end = std::chrono::steady_clock::now();
+    const auto elapsed_ms = std::chrono::duration<double, std::milli>(end - start).count();
+
+    std::cout << "backend,model,images,latency_ms\n"
+              << backend << "," << model << "," << images << "," << elapsed_ms << "\n";
+    return 0;
+}

--- a/examples/YOLO-Master-Edge-Deployment/edge_utils.py
+++ b/examples/YOLO-Master-Edge-Deployment/edge_utils.py
@@ -1,0 +1,126 @@
+"""Utilities for YOLO-Master vertical edge deployment examples."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import mean, median
+from typing import Iterable
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class EdgeProfile:
+    name: str
+    image_size: tuple[int, int]
+    conf_threshold: float
+    iou_threshold: float
+    keep_aspect_ratio: bool = True
+
+
+PROFILES = {
+    "visdrone": EdgeProfile("visdrone", (960, 544), 0.20, 0.55),
+    "sku110k": EdgeProfile("sku110k", (1280, 768), 0.25, 0.60),
+}
+
+
+def get_profile(name: str) -> EdgeProfile:
+    try:
+        return PROFILES[name.lower()]
+    except KeyError as exc:
+        raise ValueError(f"unknown profile {name!r}; choose one of {sorted(PROFILES)}") from exc
+
+
+def letterbox_shape(
+    shape: tuple[int, int],
+    new_shape: tuple[int, int],
+    stride: int = 32,
+    auto: bool = False,
+) -> tuple[float, tuple[int, int], tuple[int, int]]:
+    """Return resize ratio, unpadded shape, and half-padding for letterbox preprocessing."""
+    height, width = shape
+    target_h, target_w = new_shape
+    ratio = min(target_h / height, target_w / width)
+    new_unpad = (int(round(width * ratio)), int(round(height * ratio)))
+    pad_w = target_w - new_unpad[0]
+    pad_h = target_h - new_unpad[1]
+    if auto:
+        pad_w %= stride
+        pad_h %= stride
+    return ratio, new_unpad, (pad_w // 2, pad_h // 2)
+
+
+def scale_xyxy_boxes(
+    boxes: np.ndarray,
+    original_shape: tuple[int, int],
+    input_shape: tuple[int, int],
+    pad: tuple[int, int],
+    ratio: float,
+) -> np.ndarray:
+    """Map xyxy boxes from letterboxed network input back to original image coordinates."""
+    if boxes.size == 0:
+        return boxes.reshape(0, 4)
+    out = boxes.astype(np.float32).copy()
+    out[:, [0, 2]] -= pad[0]
+    out[:, [1, 3]] -= pad[1]
+    out[:, :4] /= ratio
+    h, w = original_shape
+    out[:, [0, 2]] = out[:, [0, 2]].clip(0, w)
+    out[:, [1, 3]] = out[:, [1, 3]].clip(0, h)
+    return out
+
+
+def compare_arrays(reference: np.ndarray, candidate: np.ndarray, tolerance: float) -> dict[str, float | bool]:
+    """Compare two backend output tensors."""
+    if reference.shape != candidate.shape:
+        raise ValueError(f"shape mismatch: reference {reference.shape}, candidate {candidate.shape}")
+    diff = np.abs(reference.astype(np.float32) - candidate.astype(np.float32))
+    return {
+        "max_abs_error": float(diff.max(initial=0.0)),
+        "mean_abs_error": float(diff.mean() if diff.size else 0.0),
+        "rmse": float(math.sqrt(float((diff ** 2).mean())) if diff.size else 0.0),
+        "passed": bool(diff.max(initial=0.0) <= tolerance),
+    }
+
+
+def percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    idx = min(len(ordered) - 1, max(0, math.ceil(pct / 100 * len(ordered)) - 1))
+    return float(ordered[idx])
+
+
+def summarize_latency_ms(values: Iterable[float]) -> dict[str, float]:
+    data = [float(v) for v in values]
+    if not data:
+        return {"count": 0, "mean_ms": 0.0, "p50_ms": 0.0, "p95_ms": 0.0, "p99_ms": 0.0, "fps": 0.0}
+    avg = mean(data)
+    return {
+        "count": len(data),
+        "mean_ms": float(avg),
+        "p50_ms": float(median(data)),
+        "p95_ms": percentile(data, 95),
+        "p99_ms": percentile(data, 99),
+        "fps": float(1000.0 / avg) if avg > 0 else 0.0,
+    }
+
+
+def read_latency_csv(path: Path) -> list[float]:
+    with path.open(newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    return [float(row["latency_ms"]) for row in rows if row.get("latency_ms")]
+
+
+def profile_arg(value: str) -> EdgeProfile:
+    return get_profile(value)
+
+
+def add_profile_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--profile", type=profile_arg, default=get_profile("visdrone"), help="Vertical profile")
+    parser.add_argument("--conf", type=float, default=None, help="Override profile confidence threshold")
+    parser.add_argument("--iou", type=float, default=None, help="Override profile NMS IoU threshold")

--- a/examples/YOLO-Master-Edge-Deployment/export_edge_models.py
+++ b/examples/YOLO-Master-Edge-Deployment/export_edge_models.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Export YOLO-Master checkpoints for edge backend validation."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from edge_utils import add_profile_args
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True, help="YOLO-Master checkpoint path")
+    parser.add_argument("--formats", nargs="+", default=["onnx", "ncnn"], choices=("onnx", "ncnn", "mnn"))
+    parser.add_argument("--imgsz", type=int, default=960)
+    parser.add_argument("--opset", type=int, default=12)
+    parser.add_argument("--half", action="store_true")
+    parser.add_argument("--int8", action="store_true")
+    parser.add_argument("--simplify", action="store_true", help="Simplify ONNX where supported")
+    add_profile_args(parser)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    from ultralytics import YOLO
+
+    model = YOLO(str(args.model))
+    for fmt in args.formats:
+        export_args = {
+            "format": fmt,
+            "imgsz": args.imgsz,
+            "half": args.half,
+            "int8": args.int8,
+        }
+        if fmt == "onnx":
+            export_args.update({"opset": args.opset, "simplify": args.simplify})
+        print(f"[export] {args.model} -> {fmt} with {export_args}")
+        model.export(**export_args)
+    print(
+        f"[profile] {args.profile.name}: conf={args.conf if args.conf is not None else args.profile.conf_threshold}, "
+        f"iou={args.iou if args.iou is not None else args.profile.iou_threshold}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/YOLO-Master-Edge-Deployment/validate_edge_outputs.py
+++ b/examples/YOLO-Master-Edge-Deployment/validate_edge_outputs.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Compare saved backend output tensors for edge deployment validation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+from edge_utils import compare_arrays
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--reference", type=Path, required=True, help="Reference PyTorch output .npy")
+    parser.add_argument("--candidate", type=Path, required=True, help="Exported backend output .npy")
+    parser.add_argument("--tolerance", type=float, default=0.005, help="Max absolute error tolerance")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    reference = np.load(args.reference)
+    candidate = np.load(args.candidate)
+    report = compare_arrays(reference, candidate, args.tolerance)
+    print(json.dumps(report, indent=2))
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_edge_deployment_utils.py
+++ b/tests/test_edge_deployment_utils.py
@@ -1,0 +1,46 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EDGE_UTILS = ROOT / "examples" / "YOLO-Master-Edge-Deployment" / "edge_utils.py"
+
+spec = importlib.util.spec_from_file_location("edge_utils", EDGE_UTILS)
+edge_utils = importlib.util.module_from_spec(spec)
+sys.modules["edge_utils"] = edge_utils
+spec.loader.exec_module(edge_utils)
+
+
+def test_letterbox_profile_keeps_aspect_ratio():
+    ratio, new_unpad, pad = edge_utils.letterbox_shape((540, 960), edge_utils.get_profile("visdrone").image_size)
+    assert ratio > 0
+    assert new_unpad[0] <= 960
+    assert new_unpad[1] <= 544
+    assert pad[0] >= 0 and pad[1] >= 0
+
+
+def test_scale_xyxy_boxes_clips_to_original_shape():
+    boxes = np.array([[10, 20, 2000, 1200]], dtype=np.float32)
+    scaled = edge_utils.scale_xyxy_boxes(boxes, original_shape=(720, 1280), input_shape=(960, 960), pad=(0, 0), ratio=0.75)
+    assert scaled.shape == (1, 4)
+    assert scaled[0, 2] <= 1280
+    assert scaled[0, 3] <= 720
+
+
+def test_compare_arrays_reports_pass_fail():
+    ref = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    cand = np.array([1.0, 2.004, 3.0], dtype=np.float32)
+    report = edge_utils.compare_arrays(ref, cand, tolerance=0.005)
+    assert report["passed"] is True
+    assert report["max_abs_error"] > 0
+
+
+def test_latency_summary_percentiles_and_fps():
+    report = edge_utils.summarize_latency_ms([10, 20, 30, 40, 50])
+    assert report["count"] == 5
+    assert report["p50_ms"] == 30
+    assert report["p95_ms"] == 50
+    assert report["fps"] > 0


### PR DESCRIPTION
关联 issue: https://github.com/Tencent/YOLO-Master/issues/51

## 完成内容

- [x] 新增 `examples/YOLO-Master-Edge-Deployment` 边缘端部署示例目录
- [x] 提供 VisDrone / SKU-110K 垂类 profile、letterbox 形状计算和坐标恢复工具
- [x] 提供 ONNX + NCNN/MNN 导出脚本骨架
- [x] 提供 `.npy` 输出一致性验证工具，报告 max error / mean error / RMSE / pass-fail
- [x] 提供延迟 P50/P95/P99/FPS 汇总工具
- [x] 提供 CMake + C++ benchmark CLI 入口，便于接入 ONNX Runtime / NCNN / MNN
- [x] 增加工具级单元测试

## 验证

- [x] `python -m pytest tests/test_edge_deployment_utils.py -q`
- [x] `python examples/YOLO-Master-Edge-Deployment/validate_edge_outputs.py --reference ref.npy --candidate cand.npy --tolerance 0.005`
- [ ] CMake build 未运行：当前 Windows 环境未安装 `cmake` 命令