### PR TITLE
Fix NCNN export for ES-MOE tracing

### DIFF
--- a/ultralytics/nn/modules/moe/experts.py
+++ b/ultralytics/nn/modules/moe/experts.py
@@ -237,10 +237,10 @@ class SharedInvertedExpertGroup(nn.Module):
 
         output = x.new_zeros(B, self.out_channels, H, W)
 
-        if torch.onnx.is_in_onnx_export():
-            # ONNX tracing cannot capture data-dependent ``torch.unique`` /
-            # dynamic-length loops. Dense path: compute every expert's
-            # projection for the full batch, gather Top-K, weighted-sum.
+        if torch.onnx.is_in_onnx_export() or torch.jit.is_tracing():
+            # Export tracing cannot capture data-dependent ``torch.unique`` /
+            # dynamic-length loops used by the sparse path. Dense path:
+            # compute every expert projection, gather Top-K, weighted-sum.
             all_projs = torch.stack(
                 [proj(features) for proj in self.expert_projections], dim=1
             )  # [B, E, out_C, H, W]

--- a/ultralytics/nn/modules/moe/modules.py
+++ b/ultralytics/nn/modules/moe/modules.py
@@ -598,9 +598,14 @@ class ES_MOE(nn.Module):
             )
 
         # Dense forward only during training (gradients to all experts) or when
-        # exporting to ONNX (sparse control-flow breaks tracing). For normal
+        # exporting/tracing (sparse control-flow breaks exporters). For normal
         # eval/inference use the Top-K sparse path to reclaim the MoE speedup.
-        use_dense = self.training or torch.onnx.is_in_onnx_export() or not getattr(self, "use_sparse_inference", True)
+        use_dense = (
+            self.training
+            or torch.onnx.is_in_onnx_export()
+            or torch.jit.is_tracing()
+            or not getattr(self, "use_sparse_inference", True)
+        )
         if use_dense:
             final_output = self._dense_forward(x, routing_weights)
         else:


### PR DESCRIPTION
Related to #51 
## Summary

Fix NCNN export for ES-MOE models by routing MoE blocks through the dense export-safe path during JIT/PNX tracing.

NCNN export uses PNNX, which traces the PyTorch model. Before this change, `ES_MOE` used the sparse inference path during NCNN export. That path contains dynamic `torch.where` and `index_add_` dispatch logic, which PNNX could not lower correctly and generated invalid Python such as:

```python
v_29 = aten::where(v_28)
```

This caused NCNN export to fail with:

```text
SyntaxError: invalid syntax (model_pnnx.py, line 640)
```

## Changes

- Treat `torch.jit.is_tracing()` like ONNX export in `ES_MOE.forward`.
- Use the dense MoE path during export/tracing to avoid sparse dynamic control flow.
- Apply the same tracing guard to `SharedInvertedExpertGroup` export logic.
- Preserve normal runtime behavior: eval/inference still uses sparse MoE when not exporting.

## Validation

Validated with the standard export API:

```python
from ultralytics import YOLO

model = YOLO("YOLO-Master-EsMoE-N.pt")
model.export(format="ncnn", imgsz=960)
```

Before this change, NCNN export failed during PNNX conversion with:

```text
SyntaxError: invalid syntax (model_pnnx.py, line 640)
```

After this change, export succeeds and generates:

```text
YOLO-Master-EsMoE-N_ncnn_model/model.ncnn.param
YOLO-Master-EsMoE-N_ncnn_model/model.ncnn.bin
YOLO-Master-EsMoE-N_ncnn_model/metadata.yaml
```