### PR TITLE
feat(moe/scheduler): add MapSaturationScheduler for mAP-driven balance annealing

### DIFF
--- a/tests/test_moe_dynamic_scheduler.py
+++ b/tests/test_moe_dynamic_scheduler.py
@@ -1,16 +1,21 @@
+# ruff: noqa: E402
 import sys
 import types
 
 import pytest
 import torch
 
-sys.modules.setdefault("seaborn", types.SimpleNamespace(heatmap=lambda *args, **kwargs: None))
+_seaborn_stub = types.ModuleType("seaborn")
+_seaborn_stub.heatmap = lambda *_args, **_kw: None  # type: ignore[attr-defined]
+sys.modules.setdefault("seaborn", _seaborn_stub)
 
 from ultralytics.nn.modules.moe.loss import MoELoss
 from ultralytics.nn.modules.moe.modules import AdaptiveBalanceController
 from ultralytics.nn.modules.moe.scheduler import (
     MoEDynamicScheduler,
     MoEDynamicSchedulerConfig,
+    MapSaturationScheduler,
+    MapSaturationSchedulerConfig,
     compute_gini,
 )
 
@@ -63,3 +68,95 @@ def test_adaptive_balance_controller_accepts_dynamic_scheduler():
     assert torch.isfinite(loss)
     assert ctrl.last_dynamic_schedule is not None
     assert ctrl.last_dynamic_schedule["balance_loss_coeff"] > 1.0
+
+
+
+def test_compute_gini_edge_cases():
+    assert compute_gini(torch.tensor([])) == 0.0
+    assert compute_gini(torch.zeros(4)) == 0.0
+    assert compute_gini(torch.tensor([1.0])) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_dynamic_scheduler_disabled_passthrough():
+    scheduler = MoEDynamicScheduler(MoEDynamicSchedulerConfig(enabled=False))
+    state = scheduler.step(torch.tensor([1.0, 0.0, 0.0, 0.0]), base_balance_coeff=1.23)
+    assert state.balance_loss_coeff == pytest.approx(1.23)
+
+
+def test_dynamic_scheduler_state_dict_round_trip():
+    scheduler = MoEDynamicScheduler(MoEDynamicSchedulerConfig(target_gini=0.3, gain=1.0))
+    scheduler.step(torch.tensor([1.0, 0.0, 0.0, 0.0]), base_balance_coeff=1.0)
+    sd = scheduler.state_dict()
+
+    restored = MoEDynamicScheduler()
+    restored.load_state_dict(sd)
+
+    assert restored.ema_gini == pytest.approx(scheduler.ema_gini)
+    assert restored.config.target_gini == pytest.approx(0.3)
+    assert restored.last_state is not None
+
+
+
+
+def test_map_saturation_no_plateau_keeps_scale_at_one():
+    scheduler = MapSaturationScheduler(
+        MapSaturationSchedulerConfig(window_size=3, saturation_threshold=0.005, decay_factor=0.8)
+    )
+    # Feed strictly increasing mAP — no plateau should be detected.
+    maps = [0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17]
+    state = None
+    for m in maps:
+        state = scheduler.update(m)
+    assert state is not None
+    assert state.saturation_scale == pytest.approx(1.0)
+    assert not state.plateau_detected
+
+
+def test_map_saturation_plateau_decays_scale():
+    scheduler = MapSaturationScheduler(
+        MapSaturationSchedulerConfig(window_size=3, saturation_threshold=0.01, decay_factor=0.7)
+    )
+    # Feed flat mAP — plateau should trigger after 2*window_size epochs.
+    state = None
+    for _ in range(6):
+        state = scheduler.update(0.20)
+    assert state is not None
+    assert state.plateau_detected
+    assert state.saturation_scale < 1.0
+
+
+def test_map_saturation_scale_floored_at_min():
+    scheduler = MapSaturationScheduler(
+        MapSaturationSchedulerConfig(window_size=2, saturation_threshold=1.0, decay_factor=0.1, min_scale=0.05)
+    )
+    # Force repeated plateaus to hit the floor.
+    for _ in range(20):
+        scheduler.update(0.20)
+    assert scheduler.saturation_scale == pytest.approx(0.05)
+
+
+def test_map_saturation_apply_scales_coefficient():
+    scheduler = MapSaturationScheduler(MapSaturationSchedulerConfig(enabled=True))
+    scheduler.saturation_scale = 0.5
+    assert scheduler.apply(2.0) == pytest.approx(1.0)
+
+
+def test_map_saturation_disabled_passthrough():
+    scheduler = MapSaturationScheduler(MapSaturationSchedulerConfig(enabled=False))
+    for _ in range(10):
+        scheduler.update(0.20)
+    assert scheduler.apply(1.5) == pytest.approx(1.5)
+
+
+def test_map_saturation_state_dict_round_trip():
+    scheduler = MapSaturationScheduler(MapSaturationSchedulerConfig(window_size=3, decay_factor=0.9))
+    for m in [0.10, 0.11, 0.12, 0.13, 0.14, 0.15]:
+        scheduler.update(m)
+    sd = scheduler.state_dict()
+
+    restored = MapSaturationScheduler()
+    restored.load_state_dict(sd)
+
+    assert restored.saturation_scale == pytest.approx(scheduler.saturation_scale)
+    assert restored.map_history == scheduler.map_history
+    assert restored.config.window_size == 3

--- a/ultralytics/nn/modules/moe/__init__.py
+++ b/ultralytics/nn/modules/moe/__init__.py
@@ -74,7 +74,15 @@ from .analysis import ExpertUsageTracker, diagnose_model, RoutingCollapseDetecto
 from .diagnostics import MoELayerDiagnostic, collect_moe_diagnostics, diagnostics_to_dict, format_moe_diagnostics
 from .history import MoEDiagnosticsRecorder, export_moe_history_plots
 from .pruning import prune_moe_model
-from .scheduler import MoEDynamicScheduler, MoEDynamicSchedulerConfig, MoEDynamicScheduleState, compute_gini
+from .scheduler import (
+    MoEDynamicScheduler,
+    MoEDynamicSchedulerConfig,
+    MoEDynamicScheduleState,
+    MapSaturationScheduler,
+    MapSaturationSchedulerConfig,
+    MapSaturationScheduleState,
+    compute_gini,
+)
 
 __all__ = [
     "UltraOptimizedMoE",
@@ -142,5 +150,8 @@ __all__ = [
     "MoEDynamicScheduler",
     "MoEDynamicSchedulerConfig",
     "MoEDynamicScheduleState",
+    "MapSaturationScheduler",
+    "MapSaturationSchedulerConfig",
+    "MapSaturationScheduleState",
     "compute_gini",
 ]

--- a/ultralytics/nn/modules/moe/scheduler.py
+++ b/ultralytics/nn/modules/moe/scheduler.py
@@ -106,3 +106,100 @@ class MoEDynamicScheduler:
         self.ema_gini = float(ema) if ema is not None else None
         last = state.get("last_state")
         self.last_state = MoEDynamicScheduleState(**last) if isinstance(last, dict) else None
+
+
+@dataclass
+class MapSaturationSchedulerConfig:
+    """Configuration for validation-mAP saturation driven coefficient annealing.
+
+    When validation mAP improvement stalls over a rolling window, the balance
+    coefficient is decayed by `decay_factor`. This relaxes routing pressure
+    at late training stages so experts can specialize without interference.
+
+    Formula (applied once per epoch):
+        If max(mAP[-window:]) - max(mAP[-2*window:-window]) < saturation_threshold:
+            saturation_scale *= decay_factor   (floored at min_scale)
+
+    The effective balance coefficient is then:
+        effective_coeff = base_coeff * saturation_scale
+    """
+
+    enabled: bool = True
+    window_size: int = 5
+    saturation_threshold: float = 0.001
+    decay_factor: float = 0.8
+    min_scale: float = 0.1
+
+
+@dataclass
+class MapSaturationScheduleState:
+    """Serializable state emitted after each epoch update."""
+
+    val_map: float
+    saturation_scale: float
+    plateau_detected: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class MapSaturationScheduler:
+    """Validation-mAP saturation driven annealing of MoE balance-loss coefficients.
+
+    Unlike `MoEDynamicScheduler` which reacts to routing imbalance per training
+    step, this scheduler operates at epoch granularity: it monitors whether
+    validation mAP is still improving, and relaxes the balance pressure when
+    learning plateaus. Call `update(val_map)` once per epoch, then `apply(base_coeff)`
+    at each training step to obtain the effective coefficient.
+    """
+
+    def __init__(self, config: MapSaturationSchedulerConfig | None = None):
+        self.config = config or MapSaturationSchedulerConfig()
+        self.map_history: list[float] = []
+        self.saturation_scale: float = 1.0
+        self.last_state: MapSaturationScheduleState | None = None
+
+    def update(self, val_map: float) -> MapSaturationScheduleState:
+        """Record a new validation mAP and update the saturation scale."""
+        self.map_history.append(float(val_map))
+        plateau = (
+            self.config.enabled
+            and len(self.map_history) >= 2 * (w := self.config.window_size)
+            and max(self.map_history[-w:]) - max(self.map_history[-2 * w : -w])
+            < self.config.saturation_threshold
+        )
+        if plateau:
+            self.saturation_scale = max(
+                self.saturation_scale * self.config.decay_factor,
+                self.config.min_scale,
+            )
+        self.last_state = MapSaturationScheduleState(
+            val_map=float(val_map),
+            saturation_scale=self.saturation_scale,
+            plateau_detected=plateau,
+        )
+        return self.last_state
+
+    def apply(self, base_coeff: float) -> float:
+        """Return the balance coefficient scaled by the current saturation decay."""
+        return float(base_coeff) * (self.saturation_scale if self.config.enabled else 1.0)
+
+    def state_dict(self) -> dict[str, Any]:
+        return {
+            "config": asdict(self.config),
+            "map_history": list(self.map_history),
+            "saturation_scale": self.saturation_scale,
+            "last_state": self.last_state.to_dict() if self.last_state else None,
+        }
+
+    def load_state_dict(self, state: dict[str, Any]) -> None:
+        match state.get("config"):
+            case dict() as cfg:
+                self.config = MapSaturationSchedulerConfig(**cfg)
+        self.map_history = list(state.get("map_history", []))
+        self.saturation_scale = float(s) if (s := state.get("saturation_scale")) is not None else 1.0
+        match state.get("last_state"):
+            case dict() as last:
+                self.last_state = MapSaturationScheduleState(**last)
+            case _:
+                self.last_state = None


### PR DESCRIPTION
## 关联 Issue

implements dynamic hyperparameter scheduling part of #52

## 背景

MoE 训练中 `balance_loss_coeff` 固定不变，在验证 mAP 饱和后仍持续施加同等负荷，既无法加速收敛，又可能引入不必要的正则化压力。

## 方案

新增 `MapSaturationScheduler`（`ultralytics/nn/modules/moe/scheduler.py`）：

- 滑动窗口检测 mAP 停滞：`recent_window_max - prev_window_max < saturation_threshold` 时判定为饱和
- 检测到饱和时按 `decay_factor` 衰减 `saturation_scale`，下限为 `min_scale`
- `apply(base_coeff)` 返回经衰减的系数，可直接传入 `MoELossCalculator`
- `state_dict()` / `load_state_dict()` 支持训练断点续传
- 全参数可配置（`MapSaturationSchedulerConfig` dataclass）

### 配置示例

```python
scheduler = MapSaturationScheduler(MapSaturationSchedulerConfig(
    enabled=True,
    window_size=5,
    saturation_threshold=0.001,
    decay_factor=0.8,
    min_scale=0.1,
))

# 每个 val epoch
state = scheduler.update(val_map)
current_coeff = scheduler.apply(base_balance_loss_coeff)
```

## 测试

在 `tests/test_moe_dynamic_scheduler.py` 追加 5 个测试用例：

- `test_map_saturation_no_plateau_keeps_scale_at_one` - 持续提升时不衰减
- `test_map_saturation_plateau_decays_scale` - 停滞时触发衰减
- `test_map_saturation_scale_floored_at_min` - 衰减不低于下限
- `test_map_saturation_apply_scales_coefficient` - apply() 输出正确
- `test_map_saturation_disabled_passthrough` - enabled=False 时透传原始系数
- `test_map_saturation_state_dict_round_trip` - 状态序列化/反序列化

全部 13 项测试通过。