### PR TITLE
Add edge benchmark backends for ONNX, NCNN, and MNN

### DIFF
--- a/examples/YOLO-Master-Edge-Deployment/CMakeLists.txt
+++ b/examples/YOLO-Master-Edge-Deployment/CMakeLists.txt
@@ -95,6 +95,57 @@ if(WITH_ONNXRUNTIME)
     target_link_libraries(yolo_master_edge_benchmark PRIVATE ${ONNXRUNTIME_LIB_RESOLVED})
 endif()
 
+if(WITH_NCNN)
+    if(NOT NCNN_ROOT AND (NOT NCNN_INCLUDE_DIR OR NOT NCNN_LIB))
+        message(FATAL_ERROR "WITH_NCNN=ON requires either -DNCNN_ROOT=/path/to/ncnn or both -DNCNN_INCLUDE_DIR=... and -DNCNN_LIB=...")
+    endif()
+    target_compile_definitions(yolo_master_edge_benchmark PRIVATE WITH_NCNN=1)
+    if(NCNN_INCLUDE_DIR)
+        set(NCNN_INCLUDE_DIR_RESOLVED ${NCNN_INCLUDE_DIR})
+    else()
+        find_path(
+            NCNN_INCLUDE_DIR_RESOLVED
+            net.h
+            HINTS
+                ${NCNN_ROOT}/include
+                ${NCNN_ROOT}/include/ncnn
+                /opt/homebrew/include
+                /opt/homebrew/include/ncnn
+                /usr/local/include
+                /usr/local/include/ncnn
+            REQUIRED
+        )
+    endif()
+    if(NCNN_LIB)
+        set(NCNN_LIB_RESOLVED ${NCNN_LIB})
+    else()
+        find_library(
+            NCNN_LIB_RESOLVED
+            NAMES ncnn libncnn
+            HINTS
+                ${NCNN_ROOT}/lib
+                ${NCNN_ROOT}/lib64
+                /opt/homebrew/lib
+                /usr/local/lib
+            REQUIRED
+        )
+    endif()
+    message(STATUS "NCNN include: ${NCNN_INCLUDE_DIR_RESOLVED}")
+    message(STATUS "NCNN library: ${NCNN_LIB_RESOLVED}")
+    target_include_directories(
+        yolo_master_edge_benchmark
+        PRIVATE
+        ${NCNN_INCLUDE_DIR_RESOLVED}
+        ${NCNN_ROOT}/include
+        ${NCNN_ROOT}/include/ncnn
+    )
+    target_link_libraries(yolo_master_edge_benchmark PRIVATE ${NCNN_LIB_RESOLVED})
+    find_package(OpenMP)
+    if(OpenMP_CXX_FOUND)
+        target_link_libraries(yolo_master_edge_benchmark PRIVATE OpenMP::OpenMP_CXX)
+    endif()
+endif()
+
 if(WITH_MNN)
     target_compile_definitions(yolo_master_edge_benchmark PRIVATE WITH_MNN=1)
     if(MNN_INCLUDE_DIR)

--- a/examples/YOLO-Master-Edge-Deployment/CMakeLists.txt
+++ b/examples/YOLO-Master-Edge-Deployment/CMakeLists.txt
@@ -1,7 +1,88 @@
 cmake_minimum_required(VERSION 3.12)
 project(yolo_master_edge_deployment LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-add_executable(yolo_master_edge_benchmark cpp/edge_benchmark_stub.cpp)
+find_package(OpenCV REQUIRED)
+
+option(WITH_ONNXRUNTIME "Build ONNX Runtime backend" OFF)
+set(ONNXRUNTIME_ROOT "" CACHE PATH "Path to ONNX Runtime package root")
+set(ONNXRUNTIME_INCLUDE_DIR "" CACHE PATH "Path to ONNX Runtime include directory")
+set(ONNXRUNTIME_LIB "" CACHE FILEPATH "Path to ONNX Runtime library")
+
+add_executable(
+    yolo_master_edge_benchmark
+    cpp/edge_benchmark.cpp
+    cpp/preprocess.cpp
+    cpp/postprocess.cpp
+    cpp/backends/backend_factory.cpp
+    cpp/backends/onnx_backend.cpp
+    cpp/backends/ncnn_backend.cpp
+    cpp/backends/mnn_backend.cpp
+)
+
+target_include_directories(
+    yolo_master_edge_benchmark
+    PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/backends
+    ${OpenCV_INCLUDE_DIRS}
+)
+
+target_link_libraries(
+    yolo_master_edge_benchmark
+    PRIVATE
+    ${OpenCV_LIBS}
+)
+
+if(WITH_ONNXRUNTIME)
+    if(NOT ONNXRUNTIME_ROOT AND (NOT ONNXRUNTIME_INCLUDE_DIR OR NOT ONNXRUNTIME_LIB))
+        message(FATAL_ERROR "WITH_ONNXRUNTIME=ON requires either -DONNXRUNTIME_ROOT=/path/to/onnxruntime or both -DONNXRUNTIME_INCLUDE_DIR=... and -DONNXRUNTIME_LIB=...")
+    endif()
+    target_compile_definitions(yolo_master_edge_benchmark PRIVATE WITH_ONNXRUNTIME=1)
+    if(ONNXRUNTIME_INCLUDE_DIR)
+        set(ONNXRUNTIME_INCLUDE_DIR_RESOLVED ${ONNXRUNTIME_INCLUDE_DIR})
+    else()
+        find_path(
+            ONNXRUNTIME_INCLUDE_DIR_RESOLVED
+            onnxruntime_cxx_api.h
+            HINTS
+                ${ONNXRUNTIME_ROOT}/include
+                ${ONNXRUNTIME_ROOT}/include/onnxruntime
+                ${ONNXRUNTIME_ROOT}/include/onnxruntime/core/session
+                /opt/homebrew/include
+                /opt/homebrew/include/onnxruntime
+                /opt/homebrew/include/onnxruntime/core/session
+                /usr/local/include
+                /usr/local/include/onnxruntime
+                /usr/local/include/onnxruntime/core/session
+            REQUIRED
+        )
+    endif()
+    if(ONNXRUNTIME_LIB)
+        set(ONNXRUNTIME_LIB_RESOLVED ${ONNXRUNTIME_LIB})
+    else()
+        find_library(
+            ONNXRUNTIME_LIB_RESOLVED
+            NAMES onnxruntime libonnxruntime
+            HINTS
+                ${ONNXRUNTIME_ROOT}/lib
+                ${ONNXRUNTIME_ROOT}/lib64
+                /opt/homebrew/lib
+                /usr/local/lib
+            REQUIRED
+        )
+    endif()
+    message(STATUS "ONNX Runtime include: ${ONNXRUNTIME_INCLUDE_DIR_RESOLVED}")
+    message(STATUS "ONNX Runtime library: ${ONNXRUNTIME_LIB_RESOLVED}")
+    target_include_directories(
+        yolo_master_edge_benchmark
+        PRIVATE
+        ${ONNXRUNTIME_INCLUDE_DIR_RESOLVED}
+        ${ONNXRUNTIME_ROOT}/include
+        ${ONNXRUNTIME_ROOT}/include/onnxruntime
+        ${ONNXRUNTIME_ROOT}/include/onnxruntime/core/session
+    )
+    target_link_libraries(yolo_master_edge_benchmark PRIVATE ${ONNXRUNTIME_LIB_RESOLVED})
+endif()

--- a/examples/YOLO-Master-Edge-Deployment/CMakeLists.txt
+++ b/examples/YOLO-Master-Edge-Deployment/CMakeLists.txt
@@ -10,6 +10,14 @@ option(WITH_ONNXRUNTIME "Build ONNX Runtime backend" OFF)
 set(ONNXRUNTIME_ROOT "" CACHE PATH "Path to ONNX Runtime package root")
 set(ONNXRUNTIME_INCLUDE_DIR "" CACHE PATH "Path to ONNX Runtime include directory")
 set(ONNXRUNTIME_LIB "" CACHE FILEPATH "Path to ONNX Runtime library")
+option(WITH_NCNN "Build NCNN backend" OFF)
+set(NCNN_ROOT "" CACHE PATH "Path to NCNN package root")
+set(NCNN_INCLUDE_DIR "" CACHE PATH "Path to NCNN include directory")
+set(NCNN_LIB "" CACHE FILEPATH "Path to NCNN library")
+option(WITH_MNN "Build MNN backend" OFF)
+set(MNN_ROOT "" CACHE PATH "Path to MNN package root")
+set(MNN_INCLUDE_DIR "" CACHE PATH "Path to MNN include directory")
+set(MNN_LIB "" CACHE FILEPATH "Path to MNN library")
 
 add_executable(
     yolo_master_edge_benchmark
@@ -85,4 +93,39 @@ if(WITH_ONNXRUNTIME)
         ${ONNXRUNTIME_ROOT}/include/onnxruntime/core/session
     )
     target_link_libraries(yolo_master_edge_benchmark PRIVATE ${ONNXRUNTIME_LIB_RESOLVED})
+endif()
+
+if(WITH_MNN)
+    target_compile_definitions(yolo_master_edge_benchmark PRIVATE WITH_MNN=1)
+    if(MNN_INCLUDE_DIR)
+        set(MNN_INCLUDE_DIR_RESOLVED ${MNN_INCLUDE_DIR})
+    else()
+        find_path(
+            MNN_INCLUDE_DIR_RESOLVED
+            Interpreter.hpp
+            HINTS
+                ${MNN_ROOT}/include
+                /opt/homebrew/include
+                /usr/local/include
+            REQUIRED
+        )
+    endif()
+    if(MNN_LIB)
+        set(MNN_LIB_RESOLVED ${MNN_LIB})
+    else()
+        find_library(
+            MNN_LIB_RESOLVED
+            NAMES MNN libMNN
+            HINTS
+                ${MNN_ROOT}/lib
+                ${MNN_ROOT}/lib64
+                /opt/homebrew/lib
+                /usr/local/lib
+            REQUIRED
+        )
+    endif()
+    message(STATUS "MNN include: ${MNN_INCLUDE_DIR_RESOLVED}")
+    message(STATUS "MNN library: ${MNN_LIB_RESOLVED}")
+    target_include_directories(yolo_master_edge_benchmark PRIVATE ${MNN_INCLUDE_DIR_RESOLVED})
+    target_link_libraries(yolo_master_edge_benchmark PRIVATE ${MNN_LIB_RESOLVED})
 endif()

--- a/examples/YOLO-Master-Edge-Deployment/README.md
+++ b/examples/YOLO-Master-Edge-Deployment/README.md
@@ -42,35 +42,16 @@ The tool reports max absolute error, mean absolute error, RMSE, and whether the 
 
 ## CMake Benchmark Build
 
-The C++ runner requires OpenCV for image loading and letterbox preprocessing. Backend SDK calls are currently isolated behind `cpp/backends/` so ONNX Runtime, NCNN, and MNN can be wired independently.
+The C++ runner requires OpenCV for image loading and letterbox preprocessing. Build with the backend SDKs you want to benchmark:
 
 ```bash
 cmake -S . -B build
 cmake --build build
-./build/yolo_master_edge_benchmark \
-  --backend onnx \
-  --model best.onnx \
-  --images /path/to/VisDrone/images/val \
-  --profile visdrone \
-  --imgsz 960 \
-  --limit 500 \
-  --output benchmark_onnx.csv
 ```
 
-`--images` accepts either a directory of images or a text file with one image path per line. Use `--limit 500` for the issue validation subset.
+Without a backend flag, ONNX/NCNN/MNN compile in stub mode so the benchmark CLI and CSV plumbing remain buildable without SDKs installed.
 
-To enable real ONNX Runtime inference, provide an ONNX Runtime package root:
-
-```bash
-cmake -S . -B build-ort \
-  -DWITH_ONNXRUNTIME=ON \
-  -DONNXRUNTIME_ROOT=/path/to/onnxruntime
-cmake --build build-ort
-```
-
-Without `WITH_ONNXRUNTIME=ON`, the ONNX backend remains a buildable stub so the benchmark CLI, preprocessing, and CSV/report plumbing can be developed without backend SDKs installed.
-
-For a local ONNX Runtime C/C++ package, point `ONNXRUNTIME_ROOT` at the directory containing `include/` and `lib/`:
+### ONNX Runtime
 
 ```bash
 cmake -S examples/YOLO-Master-Edge-Deployment \
@@ -80,34 +61,87 @@ cmake -S examples/YOLO-Master-Edge-Deployment \
 cmake --build examples/YOLO-Master-Edge-Deployment/build-ort
 ```
 
-For example, Homebrew users can use `-DONNXRUNTIME_ROOT="$(brew --prefix onnxruntime)"`.
+If needed, pass explicit paths instead of `ONNXRUNTIME_ROOT`:
 
-Smoke test the ONNX backend with bundled sample images:
+```bash
+-DONNXRUNTIME_INCLUDE_DIR=/path/to/onnxruntime/include
+-DONNXRUNTIME_LIB=/path/to/onnxruntime/lib/libonnxruntime.so
+```
+
+Run:
 
 ```bash
 examples/YOLO-Master-Edge-Deployment/build-ort/yolo_master_edge_benchmark \
   --backend onnx \
-  --model YOLO-Master-EsMoE-N.onnx \
-  --images ultralytics/assets \
+  --model /path/to/model.onnx \
+  --images /path/to/VisDrone/images/val \
   --profile visdrone \
   --imgsz 960 \
-  --limit 2 \
-  --output benchmark_onnx_assets.csv
+  --limit 500 \
+  --output benchmark_onnx.csv
 ```
 
-Example local CPU result with `imgsz=960`:
+### NCNN
 
-```text
-backend=onnx model=YOLO-Master-EsMoE-N.onnx profile=visdrone imgsz=960 conf=0.2 iou=0.55 output=benchmark_onnx_assets.csv
-count,mean_ms,p50_ms,p95_ms,p99_ms,fps
-2,402.451,400.866,400.866,400.866,2.48478
+```bash
+cmake -S examples/YOLO-Master-Edge-Deployment \
+  -B examples/YOLO-Master-Edge-Deployment/build-ncnn \
+  -DWITH_NCNN=ON \
+  -DNCNN_ROOT=/path/to/ncnn/install
+cmake --build examples/YOLO-Master-Edge-Deployment/build-ncnn
 ```
 
-The CSV contains one row per image:
+If NCNN was built but not installed, pass explicit paths. Include both source and build include dirs so generated headers such as `platform.h` are visible:
 
-```text
-image,preprocess_ms,inference_ms,postprocess_ms,total_ms,detections
+```bash
+-DNCNN_INCLUDE_DIR="/path/to/ncnn/src;/path/to/ncnn/build/src"
+-DNCNN_LIB=/path/to/ncnn/build/src/libncnn.a
 ```
+
+Run:
+
+```bash
+examples/YOLO-Master-Edge-Deployment/build-ncnn/yolo_master_edge_benchmark \
+  --backend ncnn \
+  --model /path/to/exported_ncnn_model_dir \
+  --images /path/to/VisDrone/images/val \
+  --profile visdrone \
+  --imgsz 960 \
+  --limit 500 \
+  --output benchmark_ncnn.csv
+```
+
+### MNN
+
+```bash
+cmake -S examples/YOLO-Master-Edge-Deployment \
+  -B examples/YOLO-Master-Edge-Deployment/build-mnn \
+  -DWITH_MNN=ON \
+  -DMNN_ROOT=/path/to/MNN
+cmake --build examples/YOLO-Master-Edge-Deployment/build-mnn
+```
+
+If needed, pass explicit paths instead of `MNN_ROOT`:
+
+```bash
+-DMNN_INCLUDE_DIR=/path/to/MNN/include
+-DMNN_LIB=/path/to/MNN/lib/libMNN.so
+```
+
+Run:
+
+```bash
+examples/YOLO-Master-Edge-Deployment/build-mnn/yolo_master_edge_benchmark \
+  --backend mnn \
+  --model /path/to/model.mnn \
+  --images /path/to/VisDrone/images/val \
+  --profile visdrone \
+  --imgsz 960 \
+  --limit 500 \
+  --output benchmark_mnn.csv
+```
+
+`--images` accepts either a directory of images or a text file with one image path per line. The CSV contains `image,preprocess_ms,inference_ms,postprocess_ms,total_ms,detections`, and the runner prints summary latency/FPS.
 
 ## Recommended Issue #51 Workflow
 

--- a/examples/YOLO-Master-Edge-Deployment/README.md
+++ b/examples/YOLO-Master-Edge-Deployment/README.md
@@ -141,7 +141,30 @@ examples/YOLO-Master-Edge-Deployment/build-mnn/yolo_master_edge_benchmark \
   --output benchmark_mnn.csv
 ```
 
-`--images` accepts either a directory of images or a text file with one image path per line. The CSV contains `image,preprocess_ms,inference_ms,postprocess_ms,total_ms,detections`, and the runner prints summary latency/FPS.
+`--images` accepts either a directory of images or a text file with one image path per line.
+
+## Benchmark CSV Output
+
+ONNX Runtime, NCNN, and MNN write the same per-image CSV structure:
+
+```text
+image,preprocess_ms,inference_ms,postprocess_ms,total_ms,detections
+```
+
+Column meanings:
+
+- `image`: source image path
+- `preprocess_ms`: OpenCV image load, letterbox, RGB conversion, and tensor packing time
+- `inference_ms`: backend runtime execution time
+- `postprocess_ms`: YOLO decode and NMS time
+- `total_ms`: end-to-end time for one image
+- `detections`: number of detections after confidence filtering and NMS
+
+The aggregate latency summary is printed to stdout, not written to the CSV:
+
+```text
+count,mean_ms,p50_ms,p95_ms,p99_ms,fps
+```
 
 ## Recommended Issue #51 Workflow
 

--- a/examples/YOLO-Master-Edge-Deployment/README.md
+++ b/examples/YOLO-Master-Edge-Deployment/README.md
@@ -9,7 +9,8 @@ It provides a lightweight, reproducible scaffold for exporting YOLO-Master model
 - `edge_utils.py` - shared preprocessing, postprocessing, consistency, and benchmark utilities.
 - `export_edge_models.py` - export helper for ONNX, NCNN, and MNN.
 - `validate_edge_outputs.py` - compare PyTorch/exported backend outputs saved as `.npy` tensors.
-- `cpp/edge_benchmark_stub.cpp` - minimal C++ benchmark entry that can be extended with ONNX Runtime, NCNN, or MNN runtime calls.
+- `cpp/edge_benchmark.cpp` - C++ benchmark runner with backend selection, OpenCV letterbox preprocessing, CSV latency output, and summary stats.
+- `cpp/backends/` - backend interface plus ONNX, NCNN, and MNN implementation slots.
 - `CMakeLists.txt` - portable CMake target for the C++ benchmark entry.
 
 ## Vertical Profiles
@@ -39,15 +40,74 @@ python validate_edge_outputs.py --reference pytorch.npy --candidate ncnn.npy --t
 
 The tool reports max absolute error, mean absolute error, RMSE, and whether the configured tolerance is met.
 
-## CMake Smoke Build
+## CMake Benchmark Build
+
+The C++ runner requires OpenCV for image loading and letterbox preprocessing. Backend SDK calls are currently isolated behind `cpp/backends/` so ONNX Runtime, NCNN, and MNN can be wired independently.
 
 ```bash
 cmake -S . -B build
 cmake --build build
-./build/yolo_master_edge_benchmark --backend onnx --model best.onnx --images val.txt
+./build/yolo_master_edge_benchmark \
+  --backend onnx \
+  --model best.onnx \
+  --images /path/to/VisDrone/images/val \
+  --profile visdrone \
+  --imgsz 960 \
+  --limit 500 \
+  --output benchmark_onnx.csv
 ```
 
-The C++ file is intentionally dependency-light. It establishes the CLI contract and build target, so backend-specific runtime calls can be added without changing benchmark automation.
+`--images` accepts either a directory of images or a text file with one image path per line. Use `--limit 500` for the issue validation subset.
+
+To enable real ONNX Runtime inference, provide an ONNX Runtime package root:
+
+```bash
+cmake -S . -B build-ort \
+  -DWITH_ONNXRUNTIME=ON \
+  -DONNXRUNTIME_ROOT=/path/to/onnxruntime
+cmake --build build-ort
+```
+
+Without `WITH_ONNXRUNTIME=ON`, the ONNX backend remains a buildable stub so the benchmark CLI, preprocessing, and CSV/report plumbing can be developed without backend SDKs installed.
+
+For a local ONNX Runtime C/C++ package, point `ONNXRUNTIME_ROOT` at the directory containing `include/` and `lib/`:
+
+```bash
+cmake -S examples/YOLO-Master-Edge-Deployment \
+  -B examples/YOLO-Master-Edge-Deployment/build-ort \
+  -DWITH_ONNXRUNTIME=ON \
+  -DONNXRUNTIME_ROOT=/path/to/onnxruntime
+cmake --build examples/YOLO-Master-Edge-Deployment/build-ort
+```
+
+For example, Homebrew users can use `-DONNXRUNTIME_ROOT="$(brew --prefix onnxruntime)"`.
+
+Smoke test the ONNX backend with bundled sample images:
+
+```bash
+examples/YOLO-Master-Edge-Deployment/build-ort/yolo_master_edge_benchmark \
+  --backend onnx \
+  --model YOLO-Master-EsMoE-N.onnx \
+  --images ultralytics/assets \
+  --profile visdrone \
+  --imgsz 960 \
+  --limit 2 \
+  --output benchmark_onnx_assets.csv
+```
+
+Example local CPU result with `imgsz=960`:
+
+```text
+backend=onnx model=YOLO-Master-EsMoE-N.onnx profile=visdrone imgsz=960 conf=0.2 iou=0.55 output=benchmark_onnx_assets.csv
+count,mean_ms,p50_ms,p95_ms,p99_ms,fps
+2,402.451,400.866,400.866,400.866,2.48478
+```
+
+The CSV contains one row per image:
+
+```text
+image,preprocess_ms,inference_ms,postprocess_ms,total_ms,detections
+```
 
 ## Recommended Issue #51 Workflow
 

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/backend.h
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/backend.h
@@ -15,4 +15,3 @@ public:
     virtual Tensor infer(const Tensor& input) = 0;
     virtual std::string name() const = 0;
 };
-

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/backend.h
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/backend.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+struct Tensor {
+    std::vector<float> data;
+    std::vector<int64_t> shape;
+};
+
+class Backend {
+public:
+    virtual ~Backend() = default;
+    virtual void load(const std::string& model_path) = 0;
+    virtual Tensor infer(const Tensor& input) = 0;
+    virtual std::string name() const = 0;
+};
+

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/backend_factory.cpp
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/backend_factory.cpp
@@ -1,0 +1,21 @@
+#include "backend_factory.h"
+
+#include <stdexcept>
+
+#include "mnn_backend.h"
+#include "ncnn_backend.h"
+#include "onnx_backend.h"
+
+std::unique_ptr<Backend> create_backend(const std::string& backend) {
+    if (backend == "onnx") {
+        return std::unique_ptr<Backend>(new OnnxBackend());
+    }
+    if (backend == "ncnn") {
+        return std::unique_ptr<Backend>(new NcnnBackend());
+    }
+    if (backend == "mnn") {
+        return std::unique_ptr<Backend>(new MnnBackend());
+    }
+    throw std::invalid_argument("unsupported backend: " + backend);
+}
+

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/backend_factory.cpp
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/backend_factory.cpp
@@ -18,4 +18,3 @@ std::unique_ptr<Backend> create_backend(const std::string& backend) {
     }
     throw std::invalid_argument("unsupported backend: " + backend);
 }
-

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/backend_factory.h
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/backend_factory.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "backend.h"
+
+std::unique_ptr<Backend> create_backend(const std::string& backend);
+

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/backend_factory.h
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/backend_factory.h
@@ -6,4 +6,3 @@
 #include "backend.h"
 
 std::unique_ptr<Backend> create_backend(const std::string& backend);
-

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/mnn_backend.cpp
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/mnn_backend.cpp
@@ -1,0 +1,23 @@
+#include "mnn_backend.h"
+
+#include <stdexcept>
+
+void MnnBackend::load(const std::string& model_path) {
+    if (model_path.empty()) {
+        throw std::invalid_argument("MNN model path is empty");
+    }
+    model_path_ = model_path;
+}
+
+Tensor MnnBackend::infer(const Tensor& input) {
+    // Placeholder until MNN Interpreter loading/inference is wired in.
+    Tensor output;
+    output.shape = {1, 84, 1};
+    output.data.assign(84, input.data.empty() ? 0.0f : input.data.front());
+    return output;
+}
+
+std::string MnnBackend::name() const {
+    return "mnn";
+}
+

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/mnn_backend.cpp
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/mnn_backend.cpp
@@ -1,23 +1,134 @@
 #include "mnn_backend.h"
 
+#include <numeric>
 #include <stdexcept>
+
+#ifdef WITH_MNN
+#include <MNN/Interpreter.hpp>
+#include <MNN/Tensor.hpp>
+#include <MNN/expr/ExprCreator.hpp>
+#endif
+
+namespace {
+#ifdef WITH_MNN
+size_t tensor_size(const std::vector<int64_t>& shape) {
+    size_t size = 1;
+    for (const int64_t dim : shape) {
+        size *= static_cast<size_t>(dim > 0 ? dim : 1);
+    }
+    return size;
+}
+
+void validate_input(const Tensor& input) {
+    if (input.shape.size() != 4 || input.shape[0] != 1 || input.shape[1] != 3) {
+        throw std::invalid_argument("MNN input tensor must have shape [1, 3, H, W]");
+    }
+    const size_t expected_size = std::accumulate(
+        input.shape.begin(),
+        input.shape.end(),
+        static_cast<size_t>(1),
+        [](size_t acc, int64_t value) { return acc * static_cast<size_t>(value); });
+    if (expected_size != input.data.size()) {
+        throw std::invalid_argument("MNN input tensor data size does not match shape");
+    }
+}
+#endif
+}  // namespace
+
+MnnBackend::MnnBackend() = default;
+
+MnnBackend::~MnnBackend() {
+#ifdef WITH_MNN
+    if (interpreter_) {
+        delete interpreter_;
+        interpreter_ = nullptr;
+    }
+#endif
+}
 
 void MnnBackend::load(const std::string& model_path) {
     if (model_path.empty()) {
         throw std::invalid_argument("MNN model path is empty");
     }
     model_path_ = model_path;
+
+#ifdef WITH_MNN
+    interpreter_ = MNN::Interpreter::createFromFile(model_path_.c_str());
+    if (!interpreter_) {
+        throw std::runtime_error("failed to create MNN interpreter: " + model_path_);
+    }
+
+    MNN::ScheduleConfig config;
+    config.type = MNN_FORWARD_CPU;
+    config.numThread = 1;
+    session_ = interpreter_->createSession(config);
+    if (!session_) {
+        throw std::runtime_error("failed to create MNN session: " + model_path_);
+    }
+
+    input_tensor_ = interpreter_->getSessionInput(session_, "images");
+    if (!input_tensor_) {
+        input_tensor_ = interpreter_->getSessionInput(session_, nullptr);
+    }
+    if (!input_tensor_) {
+        throw std::runtime_error("failed to get MNN input tensor from model: " + model_path_);
+    }
+#else
+    // Stub mode keeps the benchmark harness buildable without MNN.
+    // Configure WITH_MNN=ON for real model execution.
+#endif
 }
 
 Tensor MnnBackend::infer(const Tensor& input) {
-    // Placeholder until MNN Interpreter loading/inference is wired in.
+#ifdef WITH_MNN
+    validate_input(input);
+    if (!interpreter_ || !session_ || !input_tensor_) {
+        throw std::runtime_error("MNN backend used before load()");
+    }
+
+    std::vector<int> dims(input.shape.begin(), input.shape.end());
+    interpreter_->resizeTensor(input_tensor_, dims);
+    interpreter_->resizeSession(session_);
+
+    auto* tmp_input = MNN::Tensor::create(
+        dims,
+        halide_type_of<float>(),
+        const_cast<float*>(input.data.data()),
+        MNN::Tensor::CAFFE);
+    if (!tmp_input) {
+        throw std::runtime_error("failed to create MNN input tensor");
+    }
+    input_tensor_->copyFromHostTensor(tmp_input);
+    delete tmp_input;
+
+    interpreter_->runSession(session_);
+
+    auto* output_tensor = interpreter_->getSessionOutput(session_, nullptr);
+    if (!output_tensor) {
+        throw std::runtime_error("failed to get MNN output tensor");
+    }
+
+    MNN::Tensor host_output(output_tensor, MNN::Tensor::CAFFE);
+    output_tensor->copyToHostTensor(&host_output);
+
+    Tensor output;
+    const auto output_shape = host_output.shape();
+    output.shape.assign(output_shape.begin(), output_shape.end());
+    const size_t output_size = tensor_size(output.shape);
+    const float* output_data = host_output.host<float>();
+    if (!output_data) {
+        throw std::runtime_error("MNN output tensor is empty");
+    }
+    output.data.assign(output_data, output_data + output_size);
+    return output;
+#else
     Tensor output;
     output.shape = {1, 84, 1};
     output.data.assign(84, input.data.empty() ? 0.0f : input.data.front());
     return output;
+#endif
 }
 
 std::string MnnBackend::name() const {
     return "mnn";
 }
-

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/mnn_backend.h
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/mnn_backend.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "backend.h"
+
+class MnnBackend final : public Backend {
+public:
+    void load(const std::string& model_path) override;
+    Tensor infer(const Tensor& input) override;
+    std::string name() const override;
+
+private:
+    std::string model_path_;
+};
+

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/mnn_backend.h
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/mnn_backend.h
@@ -22,4 +22,3 @@ private:
     MNN::Tensor* input_tensor_ = nullptr;
 #endif
 };
-

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/mnn_backend.h
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/mnn_backend.h
@@ -2,13 +2,24 @@
 
 #include "backend.h"
 
+#ifdef WITH_MNN
+#include <MNN/Interpreter.hpp>
+#endif
+
 class MnnBackend final : public Backend {
 public:
+    MnnBackend();
+    ~MnnBackend() override;
     void load(const std::string& model_path) override;
     Tensor infer(const Tensor& input) override;
     std::string name() const override;
 
 private:
     std::string model_path_;
+#ifdef WITH_MNN
+    MNN::Interpreter* interpreter_ = nullptr;
+    MNN::Session* session_ = nullptr;
+    MNN::Tensor* input_tensor_ = nullptr;
+#endif
 };
 

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/ncnn_backend.cpp
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/ncnn_backend.cpp
@@ -1,23 +1,239 @@
 #include "ncnn_backend.h"
 
+#include <algorithm>
+#include <filesystem>
+#include <numeric>
 #include <stdexcept>
+
+namespace fs = std::filesystem;
+
+namespace {
+#ifdef WITH_NCNN
+size_t tensor_size(const std::vector<int64_t>& shape) {
+    return std::accumulate(
+        shape.begin(),
+        shape.end(),
+        static_cast<size_t>(1),
+        [](size_t acc, int64_t value) { return acc * static_cast<size_t>(value > 0 ? value : 1); });
+}
+
+void validate_input(const Tensor& input) {
+    if (input.shape.size() != 4 || input.shape[0] != 1 || input.shape[1] != 3) {
+        throw std::invalid_argument("NCNN input tensor must have shape [1, 3, H, W]");
+    }
+    if (tensor_size(input.shape) != input.data.size()) {
+        throw std::invalid_argument("NCNN input tensor data size does not match shape");
+    }
+}
+
+std::vector<fs::path> sorted_files_with_extension(const fs::path& dir, const std::string& extension) {
+    std::vector<fs::path> paths;
+    for (const auto& entry : fs::directory_iterator(dir)) {
+        if (entry.is_regular_file() && entry.path().extension() == extension) {
+            paths.push_back(entry.path());
+        }
+    }
+    std::sort(paths.begin(), paths.end());
+    return paths;
+}
+
+std::pair<std::string, std::string> resolve_ncnn_model_files(const std::string& model_path) {
+    const fs::path path(model_path);
+    if (fs::is_regular_file(path) && path.extension() == ".param") {
+        const fs::path bin = path.parent_path() / (path.stem().string() + ".bin");
+        if (!fs::is_regular_file(bin)) {
+            throw std::runtime_error("NCNN .bin file not found next to param: " + bin.string());
+        }
+        return {path.string(), bin.string()};
+    }
+
+    if (fs::is_directory(path)) {
+        const auto params = sorted_files_with_extension(path, ".param");
+        if (params.empty()) {
+            throw std::runtime_error("NCNN model directory contains no .param file: " + path.string());
+        }
+
+        for (const auto& param : params) {
+            const fs::path bin = param.parent_path() / (param.stem().string() + ".bin");
+            if (fs::is_regular_file(bin)) {
+                return {param.string(), bin.string()};
+            }
+        }
+
+        const auto bins = sorted_files_with_extension(path, ".bin");
+        if (params.size() == 1 && bins.size() == 1) {
+            return {params.front().string(), bins.front().string()};
+        }
+        throw std::runtime_error("NCNN model directory must contain matching .param/.bin files: " + path.string());
+    }
+
+    throw std::runtime_error("NCNN --model must be a .param file or directory containing .param/.bin files: " + model_path);
+}
+
+ncnn::Mat tensor_to_ncnn_mat(const Tensor& input) {
+    const int h = static_cast<int>(input.shape[2]);
+    const int w = static_cast<int>(input.shape[3]);
+    ncnn::Mat mat(w, h, 3);
+    const size_t plane = static_cast<size_t>(h * w);
+    for (int c = 0; c < 3; ++c) {
+        float* dst = mat.channel(c);
+        const float* src = input.data.data() + static_cast<size_t>(c) * plane;
+        std::copy(src, src + plane, dst);
+    }
+    return mat;
+}
+
+Tensor ncnn_2d_mat_to_yolo_tensor(const ncnn::Mat& mat) {
+    const int rows = mat.h;
+    const int cols = mat.w;
+    Tensor output;
+    if (rows > cols && cols >= 5) {
+        output.shape = {1, static_cast<int64_t>(cols), static_cast<int64_t>(rows)};
+        output.data.resize(static_cast<size_t>(rows) * static_cast<size_t>(cols));
+        for (int anchor = 0; anchor < rows; ++anchor) {
+            const float* row = mat.row(anchor);
+            for (int channel = 0; channel < cols; ++channel) {
+                output.data[static_cast<size_t>(channel) * static_cast<size_t>(rows) + static_cast<size_t>(anchor)] =
+                    row[channel];
+            }
+        }
+        return output;
+    }
+
+    output.shape = {1, static_cast<int64_t>(rows), static_cast<int64_t>(cols)};
+    const size_t total = mat.total();
+    output.data.assign(static_cast<const float*>(mat), static_cast<const float*>(mat) + total);
+    return output;
+}
+
+Tensor ncnn_mat_to_tensor(const ncnn::Mat& mat) {
+    Tensor output;
+    if (mat.dims == 1) {
+        output.shape = {1, static_cast<int64_t>(mat.w), 1};
+    } else if (mat.dims == 2) {
+        return ncnn_2d_mat_to_yolo_tensor(mat);
+    } else if (mat.dims == 3) {
+        if (mat.c == 1) {
+            return ncnn_2d_mat_to_yolo_tensor(mat);
+        } else {
+            output.shape = {1, static_cast<int64_t>(mat.c), static_cast<int64_t>(mat.h * mat.w)};
+        }
+    } else if (mat.dims == 4) {
+        output.shape = {
+            static_cast<int64_t>(mat.c),
+            static_cast<int64_t>(mat.d),
+            static_cast<int64_t>(mat.h),
+            static_cast<int64_t>(mat.w)};
+    } else {
+        throw std::runtime_error("unsupported NCNN output tensor rank");
+    }
+
+    const size_t total = mat.total();
+    output.data.resize(total);
+    if (mat.dims == 3 && mat.c > 1) {
+        size_t offset = 0;
+        for (int c = 0; c < mat.c; ++c) {
+            const ncnn::Mat channel = mat.channel(c);
+            const size_t channel_size = static_cast<size_t>(channel.total());
+            std::copy(
+                static_cast<const float*>(channel),
+                static_cast<const float*>(channel) + channel_size,
+                output.data.data() + offset);
+            offset += channel_size;
+        }
+    } else {
+        std::copy(static_cast<const float*>(mat), static_cast<const float*>(mat) + total, output.data.begin());
+    }
+    return output;
+}
+
+const std::vector<const char*>& input_name_candidates() {
+    static const std::vector<const char*> names = {"images", "in0", "input", "data", "input.1"};
+    return names;
+}
+
+const std::vector<const char*>& output_name_candidates() {
+    static const std::vector<const char*> names = {"output0", "out0", "output", "outputs", "output.1"};
+    return names;
+}
+#endif
+}  // namespace
+
+NcnnBackend::NcnnBackend() = default;
+
+NcnnBackend::~NcnnBackend() = default;
 
 void NcnnBackend::load(const std::string& model_path) {
     if (model_path.empty()) {
-        throw std::invalid_argument("NCNN model directory is empty");
+        throw std::invalid_argument("NCNN model path is empty");
     }
     model_path_ = model_path;
+
+#ifdef WITH_NCNN
+    const auto files = resolve_ncnn_model_files(model_path_);
+    param_path_ = files.first;
+    bin_path_ = files.second;
+
+    net_.reset(new ncnn::Net());
+    net_->opt.use_vulkan_compute = false;
+    net_->opt.num_threads = 1;
+
+    if (net_->load_param(param_path_.c_str()) != 0) {
+        throw std::runtime_error("failed to load NCNN param file: " + param_path_);
+    }
+    if (net_->load_model(bin_path_.c_str()) != 0) {
+        throw std::runtime_error("failed to load NCNN bin file: " + bin_path_);
+    }
+#else
+    // Stub mode keeps the benchmark harness buildable without NCNN.
+    // Configure WITH_NCNN=ON for real model execution.
+#endif
 }
 
 Tensor NcnnBackend::infer(const Tensor& input) {
-    // Placeholder until ncnn::Net loading/inference is wired in.
+#ifdef WITH_NCNN
+    validate_input(input);
+    if (!net_) {
+        throw std::runtime_error("NCNN backend used before load()");
+    }
+
+    ncnn::Mat input_mat = tensor_to_ncnn_mat(input);
+    ncnn::Extractor extractor = net_->create_extractor();
+
+    int input_status = -1;
+    for (const char* name : input_name_candidates()) {
+        input_status = extractor.input(name, input_mat);
+        if (input_status == 0) {
+            input_name_ = name;
+            break;
+        }
+    }
+    if (input_status != 0) {
+        throw std::runtime_error("failed to set NCNN input blob; tried images,in0,input,data,input.1");
+    }
+
+    ncnn::Mat output_mat;
+    int output_status = -1;
+    for (const char* name : output_name_candidates()) {
+        output_status = extractor.extract(name, output_mat);
+        if (output_status == 0) {
+            output_name_ = name;
+            break;
+        }
+    }
+    if (output_status != 0) {
+        throw std::runtime_error("failed to extract NCNN output blob; tried output0,out0,output,outputs,output.1");
+    }
+
+    return ncnn_mat_to_tensor(output_mat);
+#else
     Tensor output;
     output.shape = {1, 84, 1};
     output.data.assign(84, input.data.empty() ? 0.0f : input.data.front());
     return output;
+#endif
 }
 
 std::string NcnnBackend::name() const {
     return "ncnn";
 }
-

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/ncnn_backend.cpp
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/ncnn_backend.cpp
@@ -1,0 +1,23 @@
+#include "ncnn_backend.h"
+
+#include <stdexcept>
+
+void NcnnBackend::load(const std::string& model_path) {
+    if (model_path.empty()) {
+        throw std::invalid_argument("NCNN model directory is empty");
+    }
+    model_path_ = model_path;
+}
+
+Tensor NcnnBackend::infer(const Tensor& input) {
+    // Placeholder until ncnn::Net loading/inference is wired in.
+    Tensor output;
+    output.shape = {1, 84, 1};
+    output.data.assign(84, input.data.empty() ? 0.0f : input.data.front());
+    return output;
+}
+
+std::string NcnnBackend::name() const {
+    return "ncnn";
+}
+

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/ncnn_backend.h
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/ncnn_backend.h
@@ -2,13 +2,26 @@
 
 #include "backend.h"
 
+#ifdef WITH_NCNN
+#include <memory>
+#include <net.h>
+#endif
+
 class NcnnBackend final : public Backend {
 public:
+    NcnnBackend();
+    ~NcnnBackend() override;
     void load(const std::string& model_path) override;
     Tensor infer(const Tensor& input) override;
     std::string name() const override;
 
 private:
     std::string model_path_;
+#ifdef WITH_NCNN
+    std::string param_path_;
+    std::string bin_path_;
+    std::unique_ptr<ncnn::Net> net_;
+    std::string input_name_;
+    std::string output_name_;
+#endif
 };
-

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/ncnn_backend.h
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/ncnn_backend.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "backend.h"
+
+class NcnnBackend final : public Backend {
+public:
+    void load(const std::string& model_path) override;
+    Tensor infer(const Tensor& input) override;
+    std::string name() const override;
+
+private:
+    std::string model_path_;
+};
+

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/onnx_backend.cpp
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/onnx_backend.cpp
@@ -1,0 +1,92 @@
+#include "onnx_backend.h"
+
+#include <numeric>
+#include <stdexcept>
+
+OnnxBackend::OnnxBackend()
+#ifdef WITH_ONNXRUNTIME
+    : env_(ORT_LOGGING_LEVEL_WARNING, "yolo_master_edge"),
+      memory_info_(Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault))
+#endif
+{
+}
+
+void OnnxBackend::load(const std::string& model_path) {
+    if (model_path.empty()) {
+        throw std::invalid_argument("ONNX model path is empty");
+    }
+    model_path_ = model_path;
+
+#ifdef WITH_ONNXRUNTIME
+    session_options_.SetIntraOpNumThreads(1);
+    session_options_.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
+    session_.reset(new Ort::Session(env_, model_path.c_str(), session_options_));
+
+    Ort::AllocatorWithDefaultOptions allocator;
+    auto input_name = session_->GetInputNameAllocated(0, allocator);
+    auto output_name = session_->GetOutputNameAllocated(0, allocator);
+    input_name_ = input_name.get();
+    output_name_ = output_name.get();
+#else
+    // Stub mode keeps the benchmark harness buildable without ONNX Runtime.
+    // Configure WITH_ONNXRUNTIME=ON for real model execution.
+#endif
+}
+
+Tensor OnnxBackend::infer(const Tensor& input) {
+#ifdef WITH_ONNXRUNTIME
+    if (!session_) {
+        throw std::runtime_error("ONNX backend used before load()");
+    }
+    if (input.shape.empty() || input.data.empty()) {
+        throw std::invalid_argument("ONNX input tensor is empty");
+    }
+
+    const size_t expected_size = std::accumulate(
+        input.shape.begin(),
+        input.shape.end(),
+        static_cast<size_t>(1),
+        [](size_t acc, int64_t value) { return acc * static_cast<size_t>(value); });
+    if (expected_size != input.data.size()) {
+        throw std::invalid_argument("ONNX input tensor data size does not match shape");
+    }
+
+    Ort::Value input_tensor = Ort::Value::CreateTensor<float>(
+        memory_info_,
+        const_cast<float*>(input.data.data()),
+        input.data.size(),
+        input.shape.data(),
+        input.shape.size());
+
+    const char* input_names[] = {input_name_.c_str()};
+    const char* output_names[] = {output_name_.c_str()};
+    auto outputs = session_->Run(
+        Ort::RunOptions{nullptr},
+        input_names,
+        &input_tensor,
+        1,
+        output_names,
+        1);
+
+    if (outputs.empty() || !outputs[0].IsTensor()) {
+        throw std::runtime_error("ONNX Runtime returned no tensor output");
+    }
+
+    auto shape_info = outputs[0].GetTensorTypeAndShapeInfo();
+    Tensor output;
+    output.shape = shape_info.GetShape();
+    const size_t output_size = shape_info.GetElementCount();
+    const float* output_data = outputs[0].GetTensorData<float>();
+    output.data.assign(output_data, output_data + output_size);
+    return output;
+#else
+    Tensor output;
+    output.shape = {1, 84, 1};
+    output.data.assign(84, input.data.empty() ? 0.0f : input.data.front());
+    return output;
+#endif
+}
+
+std::string OnnxBackend::name() const {
+    return "onnx";
+}

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/onnx_backend.h
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/onnx_backend.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "backend.h"
+
+#ifdef WITH_ONNXRUNTIME
+#include <memory>
+#include <onnxruntime_cxx_api.h>
+#endif
+
+class OnnxBackend final : public Backend {
+public:
+    OnnxBackend();
+    void load(const std::string& model_path) override;
+    Tensor infer(const Tensor& input) override;
+    std::string name() const override;
+
+private:
+    std::string model_path_;
+#ifdef WITH_ONNXRUNTIME
+    Ort::Env env_;
+    Ort::SessionOptions session_options_;
+    std::unique_ptr<Ort::Session> session_;
+    Ort::MemoryInfo memory_info_;
+    std::string input_name_;
+    std::string output_name_;
+#endif
+};

--- a/examples/YOLO-Master-Edge-Deployment/cpp/edge_benchmark.cpp
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/edge_benchmark.cpp
@@ -1,0 +1,307 @@
+#include <algorithm>
+#include <chrono>
+#include <cctype>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "backends/backend_factory.h"
+#include "postprocess.h"
+#include "preprocess.h"
+
+namespace fs = std::filesystem;
+
+struct Args {
+    std::string backend = "onnx";
+    std::string model;
+    std::string images;
+    std::string profile = "visdrone";
+    std::string output = "benchmark.csv";
+    int imgsz = 960;
+    float conf = -1.0f;
+    float iou = -1.0f;
+    int warmup = 5;
+    int runs = 1;
+    int limit = 0;
+};
+
+struct TimingRow {
+    std::string image;
+    double preprocess_ms = 0.0;
+    double inference_ms = 0.0;
+    double postprocess_ms = 0.0;
+    double total_ms = 0.0;
+    int detections = 0;
+};
+
+static void print_usage(const char* program) {
+    std::cerr
+        << "Usage: " << program << " "
+        << "--backend onnx|ncnn|mnn "
+        << "--model MODEL "
+        << "--images IMAGE_LIST "
+        << "[--profile visdrone|sku110k] "
+        << "[--imgsz 960] "
+        << "[--conf 0.20] "
+        << "[--iou 0.55] "
+        << "[--warmup 5] "
+        << "[--runs 1] "
+        << "[--limit 500] "
+        << "[--output benchmark.csv]\n";
+}
+
+static bool require_value(int i, int argc, const char* key) {
+    if (i + 1 >= argc) {
+        std::cerr << "Missing value for " << key << "\n";
+        return false;
+    }
+    return true;
+}
+
+static Args parse_args(int argc, char** argv) {
+    Args args;
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string key = argv[i];
+        if (key == "--help" || key == "-h") {
+            print_usage(argv[0]);
+            std::exit(0);
+        }
+        if (!require_value(i, argc, argv[i])) {
+            print_usage(argv[0]);
+            std::exit(2);
+        }
+
+        const std::string value = argv[++i];
+        if (key == "--backend") {
+            args.backend = value;
+        } else if (key == "--model") {
+            args.model = value;
+        } else if (key == "--images") {
+            args.images = value;
+        } else if (key == "--profile") {
+            args.profile = value;
+        } else if (key == "--output") {
+            args.output = value;
+        } else if (key == "--imgsz") {
+            args.imgsz = std::stoi(value);
+        } else if (key == "--conf") {
+            args.conf = std::stof(value);
+        } else if (key == "--iou") {
+            args.iou = std::stof(value);
+        } else if (key == "--warmup") {
+            args.warmup = std::stoi(value);
+        } else if (key == "--runs") {
+            args.runs = std::stoi(value);
+        } else if (key == "--limit") {
+            args.limit = std::stoi(value);
+        } else {
+            std::cerr << "Unknown argument: " << key << "\n";
+            print_usage(argv[0]);
+            std::exit(2);
+        }
+    }
+
+    if (args.model.empty() || args.images.empty()) {
+        std::cerr << "Missing required --model or --images argument\n";
+        print_usage(argv[0]);
+        std::exit(2);
+    }
+    if (args.backend != "onnx" && args.backend != "ncnn" && args.backend != "mnn") {
+        std::cerr << "Invalid --backend: " << args.backend << "\n";
+        std::exit(2);
+    }
+    if (args.profile != "visdrone" && args.profile != "sku110k") {
+        std::cerr << "Invalid --profile: " << args.profile << "\n";
+        std::exit(2);
+    }
+    if (args.imgsz <= 0 || args.warmup < 0 || args.runs <= 0 || args.limit < 0) {
+        std::cerr << "Invalid numeric argument\n";
+        std::exit(2);
+    }
+
+    if (args.conf < 0.0f) {
+        args.conf = args.profile == "visdrone" ? 0.20f : 0.25f;
+    }
+    if (args.iou < 0.0f) {
+        args.iou = args.profile == "visdrone" ? 0.55f : 0.60f;
+    }
+    return args;
+}
+
+static std::string lowercase(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return value;
+}
+
+static bool is_image_file(const fs::path& path) {
+    const std::string ext = lowercase(path.extension().string());
+    return ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".bmp";
+}
+
+static std::vector<std::string> read_image_list_file(const std::string& path) {
+    std::ifstream file(path);
+    if (!file) {
+        throw std::runtime_error("failed to open image list: " + path);
+    }
+
+    std::vector<std::string> images;
+    std::string line;
+    while (std::getline(file, line)) {
+        if (!line.empty()) {
+            images.push_back(line);
+        }
+    }
+    if (images.empty()) {
+        throw std::runtime_error("image list is empty: " + path);
+    }
+    return images;
+}
+
+static std::vector<std::string> read_image_directory(const fs::path& path) {
+    std::vector<std::string> images;
+    for (const auto& entry : fs::recursive_directory_iterator(path)) {
+        if (entry.is_regular_file() && is_image_file(entry.path())) {
+            images.push_back(entry.path().string());
+        }
+    }
+    std::sort(images.begin(), images.end());
+    if (images.empty()) {
+        throw std::runtime_error("no image files found in directory: " + path.string());
+    }
+    return images;
+}
+
+static std::vector<std::string> collect_images(const std::string& path, int limit) {
+    std::vector<std::string> images;
+    const fs::path input(path);
+    if (fs::is_directory(input)) {
+        images = read_image_directory(input);
+    } else {
+        images = read_image_list_file(path);
+    }
+    if (limit > 0 && static_cast<size_t>(limit) < images.size()) {
+        images.resize(static_cast<size_t>(limit));
+    }
+    return images;
+}
+
+static double elapsed_ms(
+    const std::chrono::steady_clock::time_point& start,
+    const std::chrono::steady_clock::time_point& end) {
+    return std::chrono::duration<double, std::milli>(end - start).count();
+}
+
+static void write_csv(const std::string& path, const std::vector<TimingRow>& rows) {
+    std::ofstream out(path);
+    if (!out) {
+        throw std::runtime_error("failed to write benchmark CSV: " + path);
+    }
+    out << "image,preprocess_ms,inference_ms,postprocess_ms,total_ms,detections\n";
+    for (const auto& row : rows) {
+        out << row.image << ","
+            << row.preprocess_ms << ","
+            << row.inference_ms << ","
+            << row.postprocess_ms << ","
+            << row.total_ms << ","
+            << row.detections << "\n";
+    }
+}
+
+static double percentile(std::vector<double> values, double pct) {
+    if (values.empty()) {
+        return 0.0;
+    }
+    std::sort(values.begin(), values.end());
+    const size_t idx = std::min(
+        values.size() - 1,
+        static_cast<size_t>((pct / 100.0) * static_cast<double>(values.size() - 1)));
+    return values[idx];
+}
+
+static void print_summary(const std::vector<TimingRow>& rows) {
+    std::vector<double> totals;
+    totals.reserve(rows.size());
+    for (const auto& row : rows) {
+        totals.push_back(row.total_ms);
+    }
+
+    const double sum = std::accumulate(totals.begin(), totals.end(), 0.0);
+    const double mean = totals.empty() ? 0.0 : sum / static_cast<double>(totals.size());
+    const double fps = mean > 0.0 ? 1000.0 / mean : 0.0;
+
+    std::cout << "count,mean_ms,p50_ms,p95_ms,p99_ms,fps\n"
+              << totals.size() << ","
+              << mean << ","
+              << percentile(totals, 50.0) << ","
+              << percentile(totals, 95.0) << ","
+              << percentile(totals, 99.0) << ","
+              << fps << "\n";
+}
+
+int main(int argc, char** argv) {
+    try {
+        const Args args = parse_args(argc, argv);
+        const auto images = collect_images(args.images, args.limit);
+        auto backend = create_backend(args.backend);
+        backend->load(args.model);
+
+        const Tensor warmup_input = preprocess_image(images.front(), args.imgsz, args.imgsz).input;
+        for (int i = 0; i < args.warmup; ++i) {
+            backend->infer(warmup_input);
+        }
+
+        std::vector<TimingRow> rows;
+        rows.reserve(images.size() * static_cast<size_t>(args.runs));
+
+        for (int run = 0; run < args.runs; ++run) {
+            for (const auto& image : images) {
+                const auto total_start = std::chrono::steady_clock::now();
+
+                const auto preprocess_start = std::chrono::steady_clock::now();
+                PreprocessResult prep = preprocess_image(image, args.imgsz, args.imgsz);
+                const auto preprocess_end = std::chrono::steady_clock::now();
+
+                const auto inference_start = std::chrono::steady_clock::now();
+                Tensor output = backend->infer(prep.input);
+                const auto inference_end = std::chrono::steady_clock::now();
+
+                const auto postprocess_start = std::chrono::steady_clock::now();
+                const auto detections = postprocess_yolo_output(output, 0, args.conf, args.iou, prep);
+                const auto postprocess_end = std::chrono::steady_clock::now();
+
+                const auto total_end = std::chrono::steady_clock::now();
+
+                TimingRow row;
+                row.image = image;
+                row.preprocess_ms = elapsed_ms(preprocess_start, preprocess_end);
+                row.inference_ms = elapsed_ms(inference_start, inference_end);
+                row.postprocess_ms = elapsed_ms(postprocess_start, postprocess_end);
+                row.total_ms = elapsed_ms(total_start, total_end);
+                row.detections = static_cast<int>(detections.size());
+                rows.push_back(row);
+            }
+        }
+
+        write_csv(args.output, rows);
+        std::cout << "backend=" << backend->name()
+                  << " model=" << args.model
+                  << " profile=" << args.profile
+                  << " imgsz=" << args.imgsz
+                  << " conf=" << args.conf
+                  << " iou=" << args.iou
+                  << " output=" << args.output << "\n";
+        print_summary(rows);
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "error: " << e.what() << "\n";
+        return 1;
+    }
+}

--- a/examples/YOLO-Master-Edge-Deployment/cpp/postprocess.cpp
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/postprocess.cpp
@@ -105,4 +105,3 @@ std::vector<Detection> postprocess_yolo_output(
 
     return nms(std::move(detections), iou_threshold);
 }
-

--- a/examples/YOLO-Master-Edge-Deployment/cpp/postprocess.cpp
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/postprocess.cpp
@@ -1,0 +1,108 @@
+#include "postprocess.h"
+
+#include <algorithm>
+#include <stdexcept>
+
+static float clamp(float value, float low, float high) {
+    return std::max(low, std::min(value, high));
+}
+
+static float box_iou(const Detection& a, const Detection& b) {
+    const float ix1 = std::max(a.x1, b.x1);
+    const float iy1 = std::max(a.y1, b.y1);
+    const float ix2 = std::min(a.x2, b.x2);
+    const float iy2 = std::min(a.y2, b.y2);
+    const float iw = std::max(0.0f, ix2 - ix1);
+    const float ih = std::max(0.0f, iy2 - iy1);
+    const float inter = iw * ih;
+
+    const float area_a = std::max(0.0f, a.x2 - a.x1) * std::max(0.0f, a.y2 - a.y1);
+    const float area_b = std::max(0.0f, b.x2 - b.x1) * std::max(0.0f, b.y2 - b.y1);
+    const float denom = area_a + area_b - inter;
+    return denom > 0.0f ? inter / denom : 0.0f;
+}
+
+static std::vector<Detection> nms(std::vector<Detection> detections, float iou_threshold) {
+    std::sort(detections.begin(), detections.end(), [](const Detection& a, const Detection& b) {
+        return a.confidence > b.confidence;
+    });
+
+    std::vector<Detection> kept;
+    std::vector<bool> suppressed(detections.size(), false);
+    for (size_t i = 0; i < detections.size(); ++i) {
+        if (suppressed[i]) {
+            continue;
+        }
+        kept.push_back(detections[i]);
+        for (size_t j = i + 1; j < detections.size(); ++j) {
+            if (!suppressed[j] && detections[i].class_id == detections[j].class_id &&
+                box_iou(detections[i], detections[j]) > iou_threshold) {
+                suppressed[j] = true;
+            }
+        }
+    }
+    return kept;
+}
+
+std::vector<Detection> postprocess_yolo_output(
+    const Tensor& output,
+    int num_classes,
+    float conf_threshold,
+    float iou_threshold,
+    const PreprocessResult& prep) {
+    if (output.shape.size() != 3) {
+        throw std::invalid_argument("expected YOLO output shape [1, channels, anchors]");
+    }
+    const int64_t batch = output.shape[0];
+    const int64_t channels = output.shape[1];
+    const int64_t anchors = output.shape[2];
+    if (batch != 1 || channels < 5 || anchors <= 0) {
+        throw std::invalid_argument("invalid YOLO output shape");
+    }
+
+    const int inferred_classes = static_cast<int>(channels) - 4;
+    const int classes = num_classes > 0 ? num_classes : inferred_classes;
+    if (classes <= 0 || channels < 4 + classes) {
+        throw std::invalid_argument("invalid class count for YOLO output");
+    }
+    if (output.data.size() < static_cast<size_t>(channels * anchors)) {
+        throw std::invalid_argument("YOLO output data is smaller than shape");
+    }
+
+    std::vector<Detection> detections;
+    for (int64_t anchor = 0; anchor < anchors; ++anchor) {
+        float best_score = 0.0f;
+        int best_class = -1;
+        for (int cls = 0; cls < classes; ++cls) {
+            const float score = output.data[static_cast<size_t>((4 + cls) * anchors + anchor)];
+            if (score > best_score) {
+                best_score = score;
+                best_class = cls;
+            }
+        }
+        if (best_score < conf_threshold) {
+            continue;
+        }
+
+        const float cx = output.data[static_cast<size_t>(0 * anchors + anchor)];
+        const float cy = output.data[static_cast<size_t>(1 * anchors + anchor)];
+        const float w = output.data[static_cast<size_t>(2 * anchors + anchor)];
+        const float h = output.data[static_cast<size_t>(3 * anchors + anchor)];
+
+        Detection det;
+        det.class_id = best_class;
+        det.confidence = best_score;
+        det.x1 = (cx - w * 0.5f - static_cast<float>(prep.pad_w)) / prep.ratio;
+        det.y1 = (cy - h * 0.5f - static_cast<float>(prep.pad_h)) / prep.ratio;
+        det.x2 = (cx + w * 0.5f - static_cast<float>(prep.pad_w)) / prep.ratio;
+        det.y2 = (cy + h * 0.5f - static_cast<float>(prep.pad_h)) / prep.ratio;
+        det.x1 = clamp(det.x1, 0.0f, static_cast<float>(prep.original_w));
+        det.x2 = clamp(det.x2, 0.0f, static_cast<float>(prep.original_w));
+        det.y1 = clamp(det.y1, 0.0f, static_cast<float>(prep.original_h));
+        det.y2 = clamp(det.y2, 0.0f, static_cast<float>(prep.original_h));
+        detections.push_back(det);
+    }
+
+    return nms(std::move(detections), iou_threshold);
+}
+

--- a/examples/YOLO-Master-Edge-Deployment/cpp/postprocess.h
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/postprocess.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <vector>
+
+#include "backends/backend.h"
+#include "preprocess_types.h"
+
+struct Detection {
+    int class_id = -1;
+    float confidence = 0.0f;
+    float x1 = 0.0f;
+    float y1 = 0.0f;
+    float x2 = 0.0f;
+    float y2 = 0.0f;
+};
+
+std::vector<Detection> postprocess_yolo_output(
+    const Tensor& output,
+    int num_classes,
+    float conf_threshold,
+    float iou_threshold,
+    const PreprocessResult& prep);

--- a/examples/YOLO-Master-Edge-Deployment/cpp/preprocess.cpp
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/preprocess.cpp
@@ -1,0 +1,80 @@
+#include "preprocess.h"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
+static cv::Mat letterbox(
+    const cv::Mat& image,
+    int target_h,
+    int target_w,
+    float& ratio,
+    int& pad_w,
+    int& pad_h) {
+    const int original_h = image.rows;
+    const int original_w = image.cols;
+    ratio = std::min(
+        static_cast<float>(target_h) / static_cast<float>(original_h),
+        static_cast<float>(target_w) / static_cast<float>(original_w));
+
+    const int resized_w = static_cast<int>(std::round(static_cast<float>(original_w) * ratio));
+    const int resized_h = static_cast<int>(std::round(static_cast<float>(original_h) * ratio));
+    pad_w = target_w - resized_w;
+    pad_h = target_h - resized_h;
+
+    cv::Mat resized;
+    cv::resize(image, resized, cv::Size(resized_w, resized_h), 0.0, 0.0, cv::INTER_LINEAR);
+
+    const int left = pad_w / 2;
+    const int right = pad_w - left;
+    const int top = pad_h / 2;
+    const int bottom = pad_h - top;
+
+    cv::Mat padded;
+    cv::copyMakeBorder(
+        resized,
+        padded,
+        top,
+        bottom,
+        left,
+        right,
+        cv::BORDER_CONSTANT,
+        cv::Scalar(114, 114, 114));
+
+    pad_w = left;
+    pad_h = top;
+    return padded;
+}
+
+PreprocessResult preprocess_image(const std::string& image_path, int target_h, int target_w) {
+    cv::Mat bgr = cv::imread(image_path, cv::IMREAD_COLOR);
+    if (bgr.empty()) {
+        throw std::runtime_error("failed to read image: " + image_path);
+    }
+
+    PreprocessResult result;
+    result.original_w = bgr.cols;
+    result.original_h = bgr.rows;
+
+    cv::Mat padded = letterbox(bgr, target_h, target_w, result.ratio, result.pad_w, result.pad_h);
+
+    cv::Mat rgb;
+    cv::cvtColor(padded, rgb, cv::COLOR_BGR2RGB);
+    rgb.convertTo(rgb, CV_32FC3, 1.0 / 255.0);
+
+    result.input.shape = {1, 3, target_h, target_w};
+    result.input.data.resize(static_cast<size_t>(3 * target_h * target_w));
+
+    const int plane = target_h * target_w;
+    for (int y = 0; y < target_h; ++y) {
+        const cv::Vec3f* row = rgb.ptr<cv::Vec3f>(y);
+        for (int x = 0; x < target_w; ++x) {
+            const int idx = y * target_w + x;
+            result.input.data[idx] = row[x][0];
+            result.input.data[plane + idx] = row[x][1];
+            result.input.data[2 * plane + idx] = row[x][2];
+        }
+    }
+
+    return result;
+}

--- a/examples/YOLO-Master-Edge-Deployment/cpp/preprocess.h
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/preprocess.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string>
+
+#include <opencv2/opencv.hpp>
+
+#include "preprocess_types.h"
+
+PreprocessResult preprocess_image(const std::string& image_path, int target_h, int target_w);

--- a/examples/YOLO-Master-Edge-Deployment/cpp/preprocess_types.h
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/preprocess_types.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "backends/backend.h"
+
+struct PreprocessResult {
+    Tensor input;
+    int original_w = 0;
+    int original_h = 0;
+    float ratio = 1.0f;
+    int pad_w = 0;
+    int pad_h = 0;
+};
+

--- a/examples/YOLO-Master-Edge-Deployment/cpp/preprocess_types.h
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/preprocess_types.h
@@ -10,4 +10,3 @@ struct PreprocessResult {
     int pad_w = 0;
     int pad_h = 0;
 };
-


### PR DESCRIPTION
Addresses #51
Builds on #94

## Summary

Adds a C++ edge benchmark runner for YOLO-Master exported models with backend selection for ONNX Runtime, NCNN, and MNN.

This supports #51 by providing a reproducible way to benchmark vertical-model edge inference latency/FPS with shared preprocessing, postprocessing, and CSV output.

## Changes

- Add C++ benchmark runner with OpenCV letterbox preprocessing and YOLO postprocessing
- Add backend interface and factory
- Add ONNX Runtime backend support
- Add NCNN backend support for `.param` / `.bin` models
- Add MNN backend support
- Add CMake options for enabling each backend SDK
- Update edge deployment README with build/run commands for all three backends