### PR TITLE
feat: add MoT VisDrone ablation scripts and report

### DIFF
--- a/reports/yolo_master_mot_moa_visdrone_report_20260702.md
+++ b/reports/yolo_master_mot_moa_visdrone_report_20260702.md
@@ -1,0 +1,198 @@
+# YOLO-Master MoT/MoA VisDrone 消融实验正式报告
+
+## 摘要
+
+本报告基于 VisDrone DET 数据集，对 YOLO-Master v0.10 系列中的 MoE 基线、MoT 模块、MoA 模块以及 MoA+MoT 混合结构进行消融实验。实验完成了四个模型变体的 50 epoch 训练、精度评估、实际 FLOPs 和参数量统计、延迟基准测试、训练稳定性检查，以及 MoTBlock 专家路由行为分析。
+
+主要结论如下：
+
+- `YOLO-Master-v0.10-MoA-MoT-N` 获得本轮最高精度，mAP50-95 为 0.12158，mAP50 为 0.22157。
+- 相比 `YOLO-Master-EsMoE-N`，MoA+MoT 的 mAP50-95 绝对提升为 +0.00135，相对提升为 +1.12%，但 P50 latency 增加 +67.9%。
+- `YOLO-Master-v0.10-MoT-N` 单独使用时未带来 mAP50-95 增益，且 latency 成本较高。
+- 四个模型训练均未出现 NaN 或 loss 发散。
+- MoT 路由分析显示，专家激活更接近“层位置相关”：早中层更偏向 DeformableTransformer，末端 MoTBlock 更偏向 WindowTransformer；当前数据不支持“密集、小目标或不规则目标场景下 DeformableTransformer 激活显著上升”的结论。
+
+## 实验目标
+
+本次实验围绕以下问题展开：
+
+1. 在 VisDrone 数据集上比较 `YOLO-Master-EsMoE-N`、`YOLO-Master-v0.10-MoT-N`、`YOLO-Master-v0.10-MoA-N` 三类核心变体。
+2. 额外评估 MoA+MoT 混合结构，判断组合是否产生协同增益。
+3. 测量每个模型的 mAP50-95、mAP50、Latency P50/P95/P99、实际 FLOPs、Params 和训练稳定性。
+4. 对 MoTBlock 中 `LocalConvTransformer`、`WindowTransformer`、`DeformableTransformer` 的路由行为进行解释性分析。
+5. 补充 MoT 边界测试并修复训练或验证中暴露的稳定性问题。
+
+## 实验环境
+
+实验运行在 K8s 训练系统中，使用单节点 8 卡 H200：
+
+| 项目 | 配置 |
+| --- | --- |
+| 工作目录 | `/jpfs/huangyidan3/Rhinoceros——Bird/YOLO-Master-main` |
+| 实验目录 | `runs/mot_ablation_k8s/20260702_144333` |
+| 数据集 | VisDrone DET |
+| 训练集 | 6471 images |
+| 验证集 | 548 images |
+| GPU | 8 x NVIDIA H200 |
+| imgsz | 640 |
+| epochs | 50 |
+| batch | 64 |
+| workers | 8 |
+| AMP | disabled |
+| PyTorch | 2.9.0+cu128 |
+
+关键脚本和配置：
+
+- `scripts/compare_mot_ablation.py`: 模型构建、训练、FLOPs、latency 和 summary 汇总。
+- `scripts/run_mot_ablation_k8s.sh`: K8s 内部实验入口脚本。
+- `scripts/analyze_mot_routing.py`: MoT 路由 hook、专家激活统计和热力图生成。
+- `k8s/run_yolo_master_mot_ablation.yaml`: K8s TrainingJob 配置。
+- `ultralytics/cfg/models/master/v0_10/det/yolo-master-mot-n.yaml`: MoT 配置。
+- `ultralytics/cfg/models/master/v0_10/det/yolo-master-moa-mot-n.yaml`: MoA+MoT 混合配置。
+
+## 模型变体
+
+| Key | 模型 | 说明 |
+| --- | --- | --- |
+| `v010_esmoe` | YOLO-Master-EsMoE-N | v0.10 MoE 基线 |
+| `v010_mot` | YOLO-Master-v0.10-MoT-N | MoT 实验模块 |
+| `v010_moa` | YOLO-Master-v0.10-MoA-N | MoA 对比组 |
+| `v010_moa_mot` | YOLO-Master-v0.10-MoA-MoT-N | MoA+MoT 混合结构 |
+
+## 评估方法
+
+精度使用 VisDrone validation split 评估，指标为 mAP50-95 和 mAP50。FLOPs 使用 `thop` 在 640x640 输入上统计。Latency 使用合成单图输入在 `cuda:0` 上进行 10 次 warmup 和 100 次重复测试，报告 P50/P95/P99。训练稳定性通过 `results.csv` 扫描 loss 是否出现 NaN/Inf，以及最终 loss 是否出现明显发散。
+
+路由分析使用 `v010_mot/weights/best.pt`，在 VisDrone val 前 512 张图像上运行。脚本 hook 每个 MoTBlock router，记录每个专家的平均权重和 top-1 token 占比，并按场景标签聚合：
+
+- 密度：dense / medium / sparse。
+- 尺度：small / mixed / large。
+- 形状：regular / irregular。
+- 遮挡：当前为 unknown，因为准备后的数据集只保留 YOLO labels，没有原始 VisDrone occlusion 字段。
+
+## 主结果
+
+| Variant | mAP50-95 | mAP50 | Latency P50/P95/P99 ms | GFLOPs | Params M | Stability |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| YOLO-Master-EsMoE-N | 0.12023 | 0.21868 | 13.534 / 14.065 / 17.295 | 7.850 | 3.450 | no NaN, no divergence |
+| YOLO-Master-v0.10-MoT-N | 0.12011 | 0.21938 | 22.025 / 22.460 / 24.303 | 8.813 | 4.055 | no NaN, no divergence |
+| YOLO-Master-v0.10-MoA-N | 0.12019 | 0.21893 | 20.515 / 20.860 / 21.621 | 8.121 | 3.577 | no NaN, no divergence |
+| YOLO-Master-v0.10-MoA-MoT-N | 0.12158 | 0.22157 | 22.720 / 23.299 / 24.161 | 8.743 | 3.897 | no NaN, no divergence |
+
+相对 EsMoE 基线的变化：
+
+| Variant | Delta mAP50-95 | Delta mAP50-95 Relative | Delta mAP50 | Delta P50 Latency |
+| --- | ---: | ---: | ---: | ---: |
+| MoT | -0.00012 | -0.10% | +0.00070 | +62.7% |
+| MoA | -0.00004 | -0.03% | +0.00025 | +51.6% |
+| MoA+MoT | +0.00135 | +1.12% | +0.00289 | +67.9% |
+
+## 结果解读
+
+`v010_moa_mot` 是本轮最优精度模型，但收益较小。若“有效协同增益”定义为 mAP50-95 相对提升超过 1%，MoA+MoT 可视为刚刚达标；若定义为绝对 mAP 提升超过 1 个百分点，则本轮结果不达标。与此同时，MoA+MoT 的 P50 latency 从 13.534 ms 增加到 22.720 ms，部署代价明显。
+
+`v010_mot` 单独使用时，mAP50 相比基线提升 +0.00070，但 mAP50-95 略降 -0.00012，说明该配置未在更严格 IoU 范围上获得稳定收益。考虑到其 P50 latency 增加 +62.7%，不建议作为默认替换方案。
+
+`v010_moa` 的精度与基线基本持平，mAP50-95 仅低 -0.00004，但 latency 增加 +51.6%。从本轮 VisDrone 设置看，MoA 单独引入不具备明显性价比优势。
+
+## MoT 路由分析
+
+路由分析共处理 512 张验证图像，捕获 6 个 MoTBlock，共生成 3072 条路由记录和 432 张专家热力图。输出文件位于：
+
+- `runs/mot_ablation_k8s/20260702_144333/routing/routing_records.csv`
+- `runs/mot_ablation_k8s/20260702_144333/routing/routing_summary_by_scene.csv`
+- `runs/mot_ablation_k8s/20260702_144333/routing/heatmaps/`
+
+按模块统计结果：
+
+| Module | Local mean | Window mean | Deformable mean | Top expert |
+| --- | ---: | ---: | ---: | --- |
+| `model.14.m.0` | 0.000 | 0.435 | 0.565 | Deformable |
+| `model.14.m.1` | 0.230 | 0.252 | 0.519 | Deformable |
+| `model.20.m.0` | 0.428 | 0.001 | 0.572 | Deformable |
+| `model.20.m.1` | 0.495 | 0.000 | 0.505 | Deformable |
+| `model.23.m.0` | 0.000 | 0.501 | 0.499 | Window |
+| `model.23.m.1` | 0.000 | 0.500 | 0.500 | Window |
+
+该结果说明，MoT 的专家选择主要受层级位置影响：`model.14` 和 `model.20` 中的 MoTBlock 更偏向 DeformableTransformer，`model.23` 中的 MoTBlock 更偏向 WindowTransformer。
+
+按场景聚合后，DeformableTransformer 的平均权重差异很小：
+
+| 分组维度 | Deformable mean range |
+| --- | ---: |
+| dense / medium / sparse | 0.000009 |
+| small / mixed / large | 0.000050 |
+| regular / irregular | 0.000013 |
+
+因此，本轮实验不能证明 DeformableTransformer 在密集、小目标或不规则目标场景中有显著更高激活。遮挡场景无法做强结论，因为当前准备后的 VisDrone 数据缺少原始 occlusion annotation。
+
+## 场景化建议
+
+1. 精度优先且可以接受延迟上升时，优先选择 `YOLO-Master-v0.10-MoA-MoT-N`。该模型 mAP50-95 为 0.12158，mAP50 为 0.22157，均为四组最高。
+2. 延迟敏感场景应保留 `YOLO-Master-EsMoE-N`。它的 P50/P95/P99 latency 为 13.534/14.065/17.295 ms，显著低于其他三组，同时 mAP50-95 与单独 MoT、MoA 基本持平。
+3. 不建议在当前 VisDrone DET 设置下单独部署 `YOLO-Master-v0.10-MoT-N`。它的 mAP50-95 比基线低 0.00012，P50 latency 却增加 62.7%。
+4. MoT 的路由解释应优先按层级分析，而不是直接按场景归因。早中层 Deformable mean 为 0.505-0.572，末端 Window mean 约 0.500，场景分组差异则小于 0.002。
+5. 若后续要验证遮挡场景假设，必须保留原始 VisDrone annotation 中的 occlusion 字段，并将其传入 `scripts/analyze_mot_routing.py --visdrone-ann-dir`。
+
+## 稳定性与边界修复
+
+本轮补充并验证了 MoT 相关边界测试，覆盖：
+
+- `MoTBlock` 在 `window_size` 大于 feature map 时的降级处理。
+- `_WindowTransformerExpert` shift 操作在奇数尺寸输入时的边界。
+- MoT `exploration_eps` 在 eval 模式下正确禁用。
+
+测试结果：
+
+```text
+tests/test_mot.py tests/test_moa.py: 21 passed
+```
+
+训练过程中还暴露并修复了 DDP final validation 路径中的两个稳定性问题：
+
+- `ultralytics/engine/validator.py` 缺少 `LOCAL_RANK` 和 `torch_distributed_zero_first` 导入。
+- `validator.py` 调用了未定义的 `convert_ndjson_to_yolo_if_needed`，已补充 YAML 原样返回、NDJSON 转换的兼容实现。
+
+这些修复使 8 卡 DDP 训练能够完成 final validation 和 summary 汇总。
+
+## PR 建议
+
+建议拆成两个 PR：
+
+1. 稳定性与测试 PR。包含 `validator.py` DDP final validation 修复、MoT 边界测试补全。这部分是明确 bugfix，建议优先提交。
+2. 实验配置 PR。包含 `yolo-master-moa-mot-n.yaml` 和相关脚本。该 PR 需要明确说明：MoA+MoT 在本轮 VisDrone 上有 +1.12% 相对 mAP50-95 提升，但 latency 上升 +67.9%。如果维护者接受相对提升作为有效增益标准，可以提交；如果要求绝对 +1 mAP point，则建议先继续优化。
+
+## 局限性
+
+- 本轮实验只覆盖 VisDrone DET train/val，未覆盖 COCO。
+- Latency 是单图合成输入的模型前向 benchmark，不包含真实 dataloader、预处理和后处理全链路成本。
+- 当前 VisDrone 数据准备流程未保留原始 occlusion 字段，因此无法验证遮挡场景下 DeformableTransformer 激活是否显著上升。
+- 只完成一次 seed=42 的训练，未做多 seed 方差分析。
+- MoA+MoT 精度提升较小，仍需进一步验证统计稳定性。
+
+## 产物清单
+
+核心结果文件：
+
+- `runs/mot_ablation_k8s/20260702_144333/summary.csv`
+- `runs/mot_ablation_k8s/20260702_144333/build_summary.csv`
+- `runs/mot_ablation_k8s/20260702_144333/latency_0,1,2,3,4,5,6,7_640.csv`
+- `runs/mot_ablation_k8s/20260702_144333/routing/routing_records.csv`
+- `runs/mot_ablation_k8s/20260702_144333/routing/routing_summary_by_scene.csv`
+- `runs/mot_ablation_k8s/20260702_144333/routing/heatmaps/`
+
+模型权重：
+
+- `runs/mot_ablation_k8s/20260702_144333/v010_esmoe/weights/best.pt`
+- `runs/mot_ablation_k8s/20260702_144333/v010_mot/weights/best.pt`
+- `runs/mot_ablation_k8s/20260702_144333/v010_moa/weights/best.pt`
+- `runs/mot_ablation_k8s/20260702_144333/v010_moa_mot/weights/best.pt`
+
+报告文件：
+
+- `runs/mot_ablation_k8s/20260702_144333/technical_summary.md`
+- `reports/yolo_master_mot_moa_visdrone_report_20260702.md`
+
+## 结论
+
+本次 VisDrone 消融实验已经完成训练、评估、稳定性检查和路由解释分析。MoA+MoT 是当前最优精度配置，但其延迟代价较大，暂不建议作为默认部署模型。MoT 的路由行为在本轮实验中呈现明显层级差异，但未呈现场景分组上的显著差异。后续若要进一步确认 MoT 对遮挡和不规则目标的价值，应保留原始 VisDrone annotation，并进行多 seed、多数据集复现实验。

--- a/scripts/analyze_mot_routing.py
+++ b/scripts/analyze_mot_routing.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Analyze MoT expert routing patterns on image datasets.
+
+The script runs a YOLO-Master model, hooks every MoTBlock router, and writes
+per-image/per-block expert activation summaries. It is intended for the
+scenario analysis in MoT ablations: dense vs sparse scenes, small vs large
+objects, and optional VisDrone occlusion groups.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import cv2  # noqa: E402
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import torch  # noqa: E402
+import yaml  # noqa: E402
+
+from ultralytics import YOLO  # noqa: E402
+from ultralytics.nn.modules.mot import MoTBlock  # noqa: E402
+
+
+EXPERT_NAMES = ("LocalConvTransformer", "WindowTransformer", "DeformableTransformer")
+IMG_SUFFIXES = {".bmp", ".jpg", ".jpeg", ".png", ".tif", ".tiff", ".webp"}
+
+
+def torch_device(device: str) -> str:
+    device = str(device or "cpu").strip().lower()
+    if device in {"cpu", "mps"} or device.startswith("cuda"):
+        return device
+    if device.isdigit():
+        return f"cuda:{device}" if torch.cuda.is_available() else "cpu"
+    if "," in device:
+        first = next((x.strip() for x in device.split(",") if x.strip()), "0")
+        return f"cuda:{first}" if torch.cuda.is_available() else "cpu"
+    return device
+
+
+def resolve_dataset_path(data_yaml: Path, value: str | list[str]) -> list[Path]:
+    with data_yaml.open() as f:
+        data = yaml.safe_load(f)
+    base = Path(data.get("path", data_yaml.parent))
+    if not base.is_absolute():
+        base = (data_yaml.parent / base).resolve()
+    values = value if isinstance(value, list) else [value]
+    paths = []
+    for item in values:
+        p = Path(item)
+        if not p.is_absolute():
+            p = base / p
+        paths.append(p)
+    return paths
+
+
+def image_paths_from_data(data_yaml: Path, split: str, limit: int) -> list[Path]:
+    with data_yaml.open() as f:
+        data = yaml.safe_load(f)
+    if split not in data:
+        raise SystemExit(f"{data_yaml} has no split '{split}'")
+    images: list[Path] = []
+    for p in resolve_dataset_path(data_yaml, data[split]):
+        if p.is_file() and p.suffix == ".txt":
+            root = p.parent
+            for line in p.read_text().splitlines():
+                if line.strip():
+                    q = Path(line.strip())
+                    images.append(q if q.is_absolute() else root / q)
+        elif p.is_file() and p.suffix.lower() in IMG_SUFFIXES:
+            images.append(p)
+        elif p.is_dir():
+            images.extend(x for x in sorted(p.rglob("*")) if x.suffix.lower() in IMG_SUFFIXES)
+    return images[:limit] if limit > 0 else images
+
+
+def image_paths_from_source(source: Path, limit: int) -> list[Path]:
+    if source.is_file() and source.suffix == ".txt":
+        root = source.parent
+        images = [Path(x.strip()) for x in source.read_text().splitlines() if x.strip()]
+        images = [x if x.is_absolute() else root / x for x in images]
+    elif source.is_file():
+        images = [source]
+    else:
+        images = [x for x in sorted(source.rglob("*")) if x.suffix.lower() in IMG_SUFFIXES]
+    return images[:limit] if limit > 0 else images
+
+
+def infer_label_path(image_path: Path) -> Path:
+    parts = list(image_path.parts)
+    if "images" in parts:
+        idx = len(parts) - 1 - parts[::-1].index("images")
+        parts[idx] = "labels"
+        return Path(*parts).with_suffix(".txt")
+    return image_path.with_suffix(".txt")
+
+
+def read_yolo_labels(image_path: Path) -> np.ndarray:
+    label_path = infer_label_path(image_path)
+    if not label_path.exists():
+        return np.zeros((0, 5), dtype=np.float32)
+    rows = []
+    for line in label_path.read_text().splitlines():
+        parts = line.strip().split()
+        if len(parts) >= 5:
+            rows.append([float(x) for x in parts[:5]])
+    return np.asarray(rows, dtype=np.float32) if rows else np.zeros((0, 5), dtype=np.float32)
+
+
+def read_visdrone_occlusion(image_path: Path, ann_dir: Path | None) -> str:
+    if ann_dir is None:
+        return "unknown"
+    ann = ann_dir / f"{image_path.stem}.txt"
+    if not ann.exists():
+        return "unknown"
+    occ = []
+    for line in ann.read_text().splitlines():
+        parts = line.strip().split(",")
+        if len(parts) >= 8 and parts[4] != "0":
+            try:
+                occ.append(int(parts[7]))
+            except ValueError:
+                pass
+    if not occ:
+        return "unknown"
+    ratio = sum(x >= 1 for x in occ) / len(occ)
+    return "occluded" if ratio >= 0.3 else "clear"
+
+
+def scene_tags(labels: np.ndarray, dense_threshold: int, small_area: float, large_area: float) -> dict[str, str]:
+    count = int(labels.shape[0])
+    if count >= dense_threshold:
+        density = "dense"
+    elif count <= max(1, dense_threshold // 4):
+        density = "sparse"
+    else:
+        density = "medium"
+
+    if count == 0:
+        scale = "empty"
+        irregular = "unknown"
+    else:
+        areas = labels[:, 3] * labels[:, 4]
+        median_area = float(np.median(areas))
+        if median_area <= small_area:
+            scale = "small"
+        elif median_area >= large_area:
+            scale = "large"
+        else:
+            scale = "mixed"
+        ratios = labels[:, 3] / np.clip(labels[:, 4], 1e-6, None)
+        irregular = "irregular" if float(np.mean((ratios > 3.0) | (ratios < 1.0 / 3.0))) >= 0.3 else "regular"
+    return {"object_count": str(count), "density": density, "scale": scale, "shape": irregular}
+
+
+def preprocess(image_path: Path, imgsz: int, device: str) -> torch.Tensor:
+    im = cv2.imread(str(image_path))
+    if im is None:
+        raise RuntimeError(f"failed to read image: {image_path}")
+    im = cv2.cvtColor(im, cv2.COLOR_BGR2RGB)
+    im = cv2.resize(im, (imgsz, imgsz), interpolation=cv2.INTER_LINEAR)
+    tensor = torch.from_numpy(im).permute(2, 0, 1).float().unsqueeze(0) / 255.0
+    return tensor.to(torch.device(device))
+
+
+def summarize_weights(weights: torch.Tensor) -> dict[str, float]:
+    w = weights[0].float().cpu()  # [E,H,W] or [E,1,1]
+    means = w.flatten(1).mean(dim=1).numpy()
+    winners = w.argmax(dim=0).flatten().numpy()
+    total = max(1, winners.size)
+    row: dict[str, float] = {}
+    for idx, name in enumerate(EXPERT_NAMES):
+        row[f"{name}_mean_weight"] = float(means[idx])
+        row[f"{name}_top1_token_frac"] = float((winners == idx).sum() / total)
+    row["top_expert"] = EXPERT_NAMES[int(np.argmax(means))]
+    return row
+
+
+def save_heatmap(weights: torch.Tensor, out_dir: Path, stem: str, module_name: str) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    w = weights[0].float().cpu().numpy()
+    safe_module = module_name.replace(".", "_")
+    for idx, name in enumerate(EXPERT_NAMES):
+        plt.figure(figsize=(4, 4))
+        plt.imshow(w[idx], cmap="magma")
+        plt.axis("off")
+        plt.title(name)
+        plt.tight_layout()
+        plt.savefig(out_dir / f"{stem}_{safe_module}_{idx}_{name}.png", dpi=160)
+        plt.close()
+
+
+def write_csv(path: Path, rows: list[dict[str, str | float]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = sorted({k for row in rows for k in row})
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def aggregate(rows: list[dict[str, str | float]]) -> list[dict[str, str | float]]:
+    groups: dict[tuple[str, str, str, str], list[dict[str, str | float]]] = defaultdict(list)
+    for row in rows:
+        groups[(str(row["density"]), str(row["scale"]), str(row["shape"]), str(row["occlusion"]))].append(row)
+    out = []
+    metric_keys = [f"{name}_mean_weight" for name in EXPERT_NAMES] + [f"{name}_top1_token_frac" for name in EXPERT_NAMES]
+    for key, group in sorted(groups.items()):
+        item: dict[str, str | float] = {
+            "density": key[0],
+            "scale": key[1],
+            "shape": key[2],
+            "occlusion": key[3],
+            "samples": len(group),
+        }
+        for metric in metric_keys:
+            vals = [float(row[metric]) for row in group if metric in row]
+            item[metric] = float(np.mean(vals)) if vals else 0.0
+        out.append(item)
+    return out
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True, help="Path to a trained .pt model or YAML config.")
+    parser.add_argument("--data", type=Path, help="Dataset YAML. Use with --split.")
+    parser.add_argument("--split", default="val")
+    parser.add_argument("--source", type=Path, help="Image, directory, or txt file. Overrides --data.")
+    parser.add_argument("--out", type=Path, default=ROOT / "runs/mot_routing")
+    parser.add_argument("--device", default="0")
+    parser.add_argument("--imgsz", type=int, default=640)
+    parser.add_argument("--limit", type=int, default=256)
+    parser.add_argument("--dense-threshold", type=int, default=20)
+    parser.add_argument("--small-area", type=float, default=0.01)
+    parser.add_argument("--large-area", type=float, default=0.08)
+    parser.add_argument("--visdrone-ann-dir", type=Path)
+    parser.add_argument("--save-heatmaps", type=int, default=24)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    device = torch_device(args.device)
+    images = image_paths_from_source(args.source, args.limit) if args.source else image_paths_from_data(args.data, args.split, args.limit)
+    if not images:
+        raise SystemExit("no images found")
+
+    yolo = YOLO(str(args.model))
+    model = yolo.model.eval().to(torch.device(device))
+    captures: list[tuple[str, torch.Tensor]] = []
+    hooks = []
+    for name, module in model.named_modules():
+        if isinstance(module, MoTBlock):
+            hooks.append(module.router.register_forward_hook(lambda _m, _i, out, n=name: captures.append((n, out[0].detach()))))
+    if not hooks:
+        raise SystemExit(f"no MoTBlock modules found in {args.model}")
+
+    rows: list[dict[str, str | float]] = []
+    heatmaps_left = args.save_heatmaps
+    with torch.inference_mode():
+        for idx, image_path in enumerate(images):
+            captures.clear()
+            x = preprocess(image_path, args.imgsz, device)
+            _ = model(x)
+            labels = read_yolo_labels(image_path)
+            tags = scene_tags(labels, args.dense_threshold, args.small_area, args.large_area)
+            tags["occlusion"] = read_visdrone_occlusion(image_path, args.visdrone_ann_dir)
+            for module_name, weights in captures:
+                row: dict[str, str | float] = {
+                    "image": str(image_path),
+                    "module": module_name,
+                    **tags,
+                    **summarize_weights(weights),
+                }
+                rows.append(row)
+                if heatmaps_left > 0:
+                    save_heatmap(weights, args.out / "heatmaps", image_path.stem, module_name)
+            heatmaps_left -= 1
+            if (idx + 1) % 25 == 0:
+                print(f"[routing] processed {idx + 1}/{len(images)} images")
+
+    for hook in hooks:
+        hook.remove()
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    write_csv(args.out / "routing_records.csv", rows)
+    write_csv(args.out / "routing_summary_by_scene.csv", aggregate(rows))
+    (args.out / "routing_summary_by_scene.json").write_text(
+        json.dumps(aggregate(rows), indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    print(f"[routing] wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/download_hf_dataset.py
+++ b/scripts/download_hf_dataset.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Download Hugging Face datasets for YOLO-Master experiments.
+
+Default target is a YOLO-formatted VisDrone mirror that can be used for the
+MoE/MoA/MoT ablation experiments. The script is adapted from the shared
+`/jpfs/huangyidan3/DPO/dataset/download_hf_dataset.py` downloader, but all
+paths and repo IDs are CLI arguments instead of hard-coded values.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from pathlib import Path
+
+from huggingface_hub import snapshot_download
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-id", default="banu4prasad/VisDrone-Dataset", help="Hugging Face dataset repo ID.")
+    parser.add_argument(
+        "--local-dir",
+        type=Path,
+        default=Path("/jpfs/huangyidan3/datasets/VisDrone-HF"),
+        help="Directory where the dataset snapshot will be stored.",
+    )
+    parser.add_argument("--endpoint", default=os.getenv("HF_ENDPOINT", "https://hf-mirror.com"))
+    parser.add_argument("--allow-patterns", nargs="*", help="Optional file patterns to download.")
+    parser.add_argument("--ignore-patterns", nargs="*", help="Optional file patterns to skip.")
+    parser.add_argument("--no-force", action="store_true", help="Do not force re-download existing files.")
+    parser.add_argument("--max-workers", type=int, default=4, help="Concurrent HF downloads.")
+    parser.add_argument("--retries", type=int, default=5, help="Retry attempts for transient mirror failures.")
+    parser.add_argument("--no-validate", action="store_true", help="Skip YOLO VisDrone train/val completeness checks.")
+    return parser.parse_args()
+
+
+def count_files(path: Path) -> int:
+    if not path.is_dir():
+        return 0
+    return sum(1 for item in path.iterdir() if item.is_file())
+
+
+def validate_visdrone_snapshot(root: Path) -> None:
+    checks = {
+        "train images": (root / "VisDrone2019-DET-train" / "images", 1000),
+        "train labels": (root / "VisDrone2019-DET-train" / "labels", 1000),
+        "val images": (root / "VisDrone2019-DET-val" / "images", 100),
+        "val labels": (root / "VisDrone2019-DET-val" / "labels", 100),
+    }
+    errors = []
+    for name, (path, minimum) in checks.items():
+        found = count_files(path)
+        if found < minimum:
+            errors.append(f"{name}: found {found}, expected >= {minimum} at {path}")
+    if errors:
+        raise RuntimeError("HF snapshot is incomplete for YOLO training:\n  " + "\n  ".join(errors))
+
+
+def main() -> int:
+    args = parse_args()
+    args.local_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"准备从 Hugging Face Hub 下载数据集: {args.repo_id}")
+    print(f"将要保存到本地目录: {args.local_dir}")
+    print(f"endpoint: {args.endpoint}")
+
+    last_error = None
+    for attempt in range(1, args.retries + 1):
+        try:
+            snapshot_download(
+                repo_id=args.repo_id,
+                repo_type="dataset",
+                local_dir=str(args.local_dir),
+                endpoint=args.endpoint,
+                force_download=not args.no_force,
+                allow_patterns=args.allow_patterns,
+                ignore_patterns=args.ignore_patterns,
+                max_workers=args.max_workers,
+            )
+            if not args.no_validate:
+                validate_visdrone_snapshot(args.local_dir)
+            last_error = None
+            break
+        except Exception as exc:
+            last_error = exc
+            print(f"\n下载失败 attempt={attempt}/{args.retries}: {exc}")
+            if attempt < args.retries:
+                time.sleep(min(60, 5 * attempt))
+    if last_error is not None:
+        raise last_error
+
+    print("\n数据集下载完成。目录内容:")
+    for path in sorted(args.local_dir.iterdir()):
+        print(path.name)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/download_visdrone.py
+++ b/scripts/download_visdrone.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Download and prepare VisDrone2019-DET train/val in YOLO format."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import time
+import zipfile
+from pathlib import Path
+
+import requests
+import yaml
+from PIL import Image
+from tqdm import tqdm
+
+
+URLS = {
+    "train": "https://github.com/ultralytics/assets/releases/download/v0.0.0/VisDrone2019-DET-train.zip",
+    "val": "https://github.com/ultralytics/assets/releases/download/v0.0.0/VisDrone2019-DET-val.zip",
+}
+
+NAMES = {
+    0: "pedestrian",
+    1: "people",
+    2: "bicycle",
+    3: "car",
+    4: "van",
+    5: "truck",
+    6: "tricycle",
+    7: "awning-tricycle",
+    8: "bus",
+    9: "motor",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path("/jpfs/huangyidan3/datasets/VisDrone"))
+    parser.add_argument("--download-dir", type=Path, default=Path("/jpfs/huangyidan3/datasets/downloads/VisDrone"))
+    parser.add_argument("--yaml-out", type=Path, default=Path("/jpfs/huangyidan3/datasets/VisDrone.yaml"))
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--retries", type=int, default=5)
+    parser.add_argument("--skip-download", action="store_true", help="Use existing split directories or zip files only.")
+    return parser.parse_args()
+
+
+def valid_zip(path: Path) -> bool:
+    if not path.exists() or path.stat().st_size == 0:
+        return False
+    try:
+        with zipfile.ZipFile(path) as zf:
+            return zf.testzip() is None
+    except zipfile.BadZipFile:
+        return False
+
+
+def download(url: str, dst: Path, retries: int) -> None:
+    if valid_zip(dst):
+        print(f"Using existing valid zip {dst}")
+        return
+    if dst.exists():
+        print(f"Removing incomplete or corrupt zip {dst}")
+        dst.unlink()
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    part = dst.with_suffix(dst.suffix + ".part")
+    last_error = None
+    for attempt in range(1, retries + 1):
+        try:
+            if part.exists():
+                part.unlink()
+            with requests.get(url, stream=True, timeout=30) as response:
+                response.raise_for_status()
+                total = int(response.headers.get("content-length", 0))
+                with part.open("wb") as f, tqdm(total=total, unit="B", unit_scale=True, desc=dst.name) as bar:
+                    for chunk in response.iter_content(chunk_size=1024 * 1024):
+                        if chunk:
+                            f.write(chunk)
+                            bar.update(len(chunk))
+            part.replace(dst)
+            if valid_zip(dst):
+                return
+            raise zipfile.BadZipFile(f"downloaded file failed zip validation: {dst}")
+        except Exception as exc:
+            last_error = exc
+            print(f"Download failed attempt={attempt}/{retries}: {exc}")
+            if attempt < retries:
+                time.sleep(min(60, 5 * attempt))
+    raise RuntimeError(f"failed to download {url}") from last_error
+
+
+def extract(zip_path: Path, root: Path, split: str) -> Path:
+    source = root / f"VisDrone2019-DET-{split}"
+    if source.exists():
+        return source
+    print(f"Extracting {zip_path} -> {root}")
+    with zipfile.ZipFile(zip_path) as zf:
+        zf.extractall(root)
+    if not source.exists():
+        raise SystemExit(f"missing extracted directory: {source}")
+    return source
+
+
+def convert_split(root: Path, split: str) -> None:
+    source = root / f"VisDrone2019-DET-{split}"
+    images_dir = root / "images" / split
+    labels_dir = root / "labels" / split
+    images_dir.mkdir(parents=True, exist_ok=True)
+    labels_dir.mkdir(parents=True, exist_ok=True)
+
+    source_images = source / "images"
+    if source_images.exists():
+        for image in tqdm(list(source_images.glob("*.jpg")), desc=f"Linking {split} images"):
+            target = images_dir / image.name
+            if not target.exists():
+                try:
+                    target.symlink_to(image)
+                except OSError:
+                    shutil.copy2(image, target)
+
+    source_labels = source / "labels"
+    if source_labels.exists():
+        for label in tqdm(list(source_labels.glob("*.txt")), desc=f"Linking {split} labels"):
+            target = labels_dir / label.name
+            if not target.exists():
+                try:
+                    target.symlink_to(label)
+                except OSError:
+                    shutil.copy2(label, target)
+        return
+
+    for ann in tqdm(list((source / "annotations").glob("*.txt")), desc=f"Converting {split} labels"):
+        image_path = images_dir / ann.with_suffix(".jpg").name
+        if not image_path.exists():
+            continue
+        width, height = Image.open(image_path).size
+        dw, dh = 1.0 / width, 1.0 / height
+        lines = []
+        for raw in ann.read_text(encoding="utf-8").strip().splitlines():
+            row = raw.split(",")
+            if len(row) < 6 or row[4] == "0":
+                continue
+            x, y, w, h = map(int, row[:4])
+            cls = int(row[5]) - 1
+            if cls < 0 or cls > 9:
+                continue
+            xc = (x + w / 2) * dw
+            yc = (y + h / 2) * dh
+            lines.append(f"{cls} {xc:.6f} {yc:.6f} {w * dw:.6f} {h * dh:.6f}\n")
+        (labels_dir / ann.name).write_text("".join(lines), encoding="utf-8")
+
+
+def write_yaml(root: Path, yaml_out: Path) -> None:
+    yaml_out.parent.mkdir(parents=True, exist_ok=True)
+    yaml_out.write_text(
+        yaml.safe_dump(
+            {"path": str(root), "train": "images/train", "val": "images/val", "names": NAMES},
+            sort_keys=False,
+            allow_unicode=True,
+        ),
+        encoding="utf-8",
+    )
+    print(f"Wrote {yaml_out}")
+
+
+def main() -> int:
+    args = parse_args()
+    if args.overwrite and args.root.exists():
+        shutil.rmtree(args.root)
+    args.root.mkdir(parents=True, exist_ok=True)
+
+    for split, url in URLS.items():
+        zip_path = args.download_dir / Path(url).name
+        if not args.skip_download:
+            download(url, zip_path, args.retries)
+        if zip_path.exists():
+            extract(zip_path, args.root, split)
+        elif not (args.root / f"VisDrone2019-DET-{split}").exists():
+            raise SystemExit(f"missing {zip_path} or extracted split directory for {split}")
+        convert_split(args.root, split)
+    write_yaml(args.root, args.yaml_out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/download_visdrone_dataset.sh
+++ b/scripts/download_visdrone_dataset.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Download and validate VisDrone data for YOLO-Master experiments.
+
+Usage:
+  scripts/download_visdrone_dataset.sh [official|hf|torrent]
+
+Examples:
+  scripts/download_visdrone_dataset.sh official
+  DATA_SOURCE=hf HF_MAX_WORKERS=1 scripts/download_visdrone_dataset.sh
+  scripts/download_visdrone_dataset.sh torrent
+
+Environment:
+  PROJECT_DIR             Repo root. Defaults to this script's parent repo.
+  DATA_SOURCE             official, hf, or torrent. Defaults to official.
+  DATASET_ROOT            Prepared YOLO dataset root.
+  DATASET_YAML            Output Ultralytics data yaml.
+  VISDRONE_DOWNLOAD_DIR   Official zip cache directory.
+  RETRIES                 Download retries. Defaults to 10.
+  OVERWRITE               Set to 1 to recreate prepared dataset.
+  HF_DATASET_REPO         Hugging Face dataset repo.
+  HF_SNAPSHOT_DIR         Hugging Face snapshot directory.
+  HF_ENDPOINT             Hugging Face endpoint. Defaults to https://hf-mirror.com.
+  HF_MAX_WORKERS          HF parallel downloads. Defaults to 1 to reduce 429s.
+  HF_ALLOW_PATTERNS       Space-separated HF allow patterns.
+  TORRENT_FILE            Local .torrent file.
+  TORRENT_DOWNLOAD_DIR    Directory for torrent payload.
+  TORRENT_STAGE_DIR       Directory where inner VisDrone.zip is extracted.
+  TORRENT_SEED_TIME       aria2 seed time after download. Defaults to 0.
+USAGE
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="${PROJECT_DIR:-$(cd "${script_dir}/.." && pwd)}"
+DATA_SOURCE="${1:-${DATA_SOURCE:-official}}"
+
+DATASET_ROOT="${DATASET_ROOT:-/jpfs/huangyidan3/datasets/VisDrone}"
+DATASET_YAML="${DATASET_YAML:-/jpfs/huangyidan3/datasets/VisDrone.yaml}"
+VISDRONE_DOWNLOAD_DIR="${VISDRONE_DOWNLOAD_DIR:-/jpfs/huangyidan3/datasets/downloads/VisDrone}"
+RETRIES="${RETRIES:-10}"
+OVERWRITE="${OVERWRITE:-0}"
+
+HF_DATASET_REPO="${HF_DATASET_REPO:-banu4prasad/VisDrone-Dataset}"
+HF_SNAPSHOT_DIR="${HF_SNAPSHOT_DIR:-/jpfs/huangyidan3/datasets/hf/VisDrone-Dataset}"
+HF_ENDPOINT="${HF_ENDPOINT:-https://hf-mirror.com}"
+HF_MAX_WORKERS="${HF_MAX_WORKERS:-1}"
+HF_ALLOW_PATTERNS="${HF_ALLOW_PATTERNS:-README.md visdrone.yaml VisDrone2019-DET-train/** VisDrone2019-DET-val/**}"
+
+TORRENT_FILE="${TORRENT_FILE:-${PROJECT_DIR}/VisDrone.torrent}"
+TORRENT_DOWNLOAD_DIR="${TORRENT_DOWNLOAD_DIR:-${VISDRONE_DOWNLOAD_DIR}/torrent}"
+TORRENT_STAGE_DIR="${TORRENT_STAGE_DIR:-${VISDRONE_DOWNLOAD_DIR}/torrent_stage}"
+TORRENT_SEED_TIME="${TORRENT_SEED_TIME:-0}"
+
+count_files() {
+  local dir="$1"
+  if [[ -d "${dir}" ]]; then
+    find "${dir}" -maxdepth 1 \( -type f -o -type l \) | wc -l
+  else
+    echo 0
+  fi
+}
+
+validate_layout() {
+  local root="$1"
+  local train_images=0
+  local train_labels=0
+  local val_images=0
+  local val_labels=0
+
+  if [[ -d "${root}/images/train" ]]; then
+    train_images="$(count_files "${root}/images/train")"
+    train_labels="$(count_files "${root}/labels/train")"
+    val_images="$(count_files "${root}/images/val")"
+    val_labels="$(count_files "${root}/labels/val")"
+  else
+    train_images="$(count_files "${root}/VisDrone2019-DET-train/images")"
+    train_labels="$(count_files "${root}/VisDrone2019-DET-train/labels")"
+    val_images="$(count_files "${root}/VisDrone2019-DET-val/images")"
+    val_labels="$(count_files "${root}/VisDrone2019-DET-val/labels")"
+  fi
+
+  echo "Validation counts:"
+  echo "  train/images: ${train_images}"
+  echo "  train/labels: ${train_labels}"
+  echo "  val/images:   ${val_images}"
+  echo "  val/labels:   ${val_labels}"
+
+  if (( train_images < 1000 || train_labels < 1000 || val_images < 100 || val_labels < 100 )); then
+    echo "ERROR: VisDrone dataset is incomplete and cannot be used for training." >&2
+    return 1
+  fi
+
+  if [[ ! -s "${DATASET_YAML}" ]]; then
+    echo "ERROR: missing dataset yaml: ${DATASET_YAML}" >&2
+    return 1
+  fi
+}
+
+if [[ "${DATA_SOURCE}" == "-h" || "${DATA_SOURCE}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+cd "${PROJECT_DIR}"
+
+echo "Project: ${PROJECT_DIR}"
+echo "Data source: ${DATA_SOURCE}"
+echo "Dataset root: ${DATASET_ROOT}"
+echo "Dataset yaml: ${DATASET_YAML}"
+
+case "${DATA_SOURCE}" in
+  official)
+    args=(
+      --root "${DATASET_ROOT}"
+      --download-dir "${VISDRONE_DOWNLOAD_DIR}"
+      --yaml-out "${DATASET_YAML}"
+      --retries "${RETRIES}"
+    )
+    if [[ "${OVERWRITE}" == "1" ]]; then
+      args+=(--overwrite)
+    fi
+    python scripts/download_visdrone.py "${args[@]}"
+    ;;
+  hf)
+    read -r -a hf_allow_patterns <<< "${HF_ALLOW_PATTERNS}"
+    python scripts/download_hf_dataset.py \
+      --repo-id "${HF_DATASET_REPO}" \
+      --local-dir "${HF_SNAPSHOT_DIR}" \
+      --endpoint "${HF_ENDPOINT}" \
+      --allow-patterns "${hf_allow_patterns[@]}" \
+      --max-workers "${HF_MAX_WORKERS}" \
+      --retries "${RETRIES}" \
+      --no-force
+
+    prepare_args=(
+      --snapshot-dir "${HF_SNAPSHOT_DIR}"
+      --out-dir "${DATASET_ROOT}"
+      --yaml-out "${DATASET_YAML}"
+    )
+    if [[ "${OVERWRITE}" == "1" ]]; then
+      prepare_args+=(--overwrite)
+    fi
+    python scripts/prepare_visdrone_hf.py "${prepare_args[@]}"
+    ;;
+  torrent)
+    if ! command -v aria2c >/dev/null 2>&1; then
+      echo "ERROR: aria2c is required for torrent downloads." >&2
+      exit 1
+    fi
+    if [[ ! -s "${TORRENT_FILE}" ]]; then
+      echo "ERROR: missing torrent file: ${TORRENT_FILE}" >&2
+      exit 1
+    fi
+    if ! command -v unzip >/dev/null 2>&1; then
+      echo "ERROR: unzip is required to extract the torrent payload." >&2
+      exit 1
+    fi
+
+    mkdir -p "${TORRENT_DOWNLOAD_DIR}" "${TORRENT_STAGE_DIR}" "${VISDRONE_DOWNLOAD_DIR}" "${DATASET_ROOT}"
+    torrent_zip="$(find "${TORRENT_DOWNLOAD_DIR}" -type f -name 'VisDrone.zip' | head -n 1)"
+    if [[ -z "${torrent_zip}" ]]; then
+      aria2c \
+        --continue=true \
+        --seed-time="${TORRENT_SEED_TIME}" \
+        --dir="${TORRENT_DOWNLOAD_DIR}" \
+        "${TORRENT_FILE}"
+      torrent_zip="$(find "${TORRENT_DOWNLOAD_DIR}" -type f -name 'VisDrone.zip' | head -n 1)"
+    else
+      echo "Using existing torrent payload: ${torrent_zip}"
+    fi
+
+    if [[ -z "${torrent_zip}" ]]; then
+      echo "ERROR: torrent finished but VisDrone.zip was not found under ${TORRENT_DOWNLOAD_DIR}" >&2
+      exit 1
+    fi
+
+    marker="${TORRENT_STAGE_DIR}/.extract_complete"
+    if [[ "${OVERWRITE}" == "1" || ! -s "${marker}" ]]; then
+      if [[ "${OVERWRITE}" == "1" ]]; then
+        find "${TORRENT_STAGE_DIR}" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+      fi
+      unzip -q -o "${torrent_zip}" -d "${TORRENT_STAGE_DIR}"
+      printf '%s\n' "${torrent_zip}" > "${marker}"
+    fi
+
+    train_zip="$(find "${TORRENT_STAGE_DIR}" -type f -name 'VisDrone2019-DET-train.zip' | head -n 1)"
+    val_zip="$(find "${TORRENT_STAGE_DIR}" -type f -name 'VisDrone2019-DET-val.zip' | head -n 1)"
+    train_dir="$(find "${TORRENT_STAGE_DIR}" -type d -name 'VisDrone2019-DET-train' | head -n 1)"
+
+    if [[ -n "${train_zip}" && -n "${val_zip}" ]]; then
+      ln -sf "${train_zip}" "${VISDRONE_DOWNLOAD_DIR}/VisDrone2019-DET-train.zip"
+      ln -sf "${val_zip}" "${VISDRONE_DOWNLOAD_DIR}/VisDrone2019-DET-val.zip"
+      python scripts/download_visdrone.py \
+        --root "${DATASET_ROOT}" \
+        --download-dir "${VISDRONE_DOWNLOAD_DIR}" \
+        --yaml-out "${DATASET_YAML}" \
+        --retries "${RETRIES}" \
+        --skip-download
+    elif [[ -n "${train_dir}" ]]; then
+      raw_root="$(dirname "${train_dir}")"
+      if [[ ! -d "${raw_root}/VisDrone2019-DET-val" ]]; then
+        echo "ERROR: found train split but not val split under ${raw_root}" >&2
+        exit 1
+      fi
+      for split in train val; do
+        target="${DATASET_ROOT}/VisDrone2019-DET-${split}"
+        source="${raw_root}/VisDrone2019-DET-${split}"
+        if [[ ! -e "${target}" ]]; then
+          ln -s "${source}" "${target}"
+        fi
+      done
+      python scripts/download_visdrone.py \
+        --root "${DATASET_ROOT}" \
+        --download-dir "${VISDRONE_DOWNLOAD_DIR}" \
+        --yaml-out "${DATASET_YAML}" \
+        --retries "${RETRIES}" \
+        --skip-download
+    else
+      echo "ERROR: could not find VisDrone2019-DET train/val zips or directories in ${TORRENT_STAGE_DIR}" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "ERROR: unknown data source '${DATA_SOURCE}'. Use official, hf, or torrent." >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+validate_layout "${DATASET_ROOT}"
+
+echo "VisDrone dataset is ready."
+echo "Use DATA=${DATASET_YAML} for training and evaluation."

--- a/scripts/prepare_visdrone_hf.py
+++ b/scripts/prepare_visdrone_hf.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Prepare a Hugging Face VisDrone snapshot for Ultralytics training."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import zipfile
+from pathlib import Path
+
+import yaml
+
+
+VISDRONE_NAMES = {
+    0: "pedestrian",
+    1: "people",
+    2: "bicycle",
+    3: "car",
+    4: "van",
+    5: "truck",
+    6: "tricycle",
+    7: "awning-tricycle",
+    8: "bus",
+    9: "motor",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--snapshot-dir", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, default=Path("/jpfs/huangyidan3/datasets/VisDrone"))
+    parser.add_argument("--yaml-out", type=Path, default=Path("/jpfs/huangyidan3/datasets/VisDrone-hf.yaml"))
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def extract_archives(snapshot_dir: Path, out_dir: Path, overwrite: bool) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    archives = sorted(snapshot_dir.rglob("*.zip"))
+    if not archives:
+        return
+    marker = out_dir / ".extract_complete"
+    if marker.exists() and not overwrite:
+        return
+    if overwrite and out_dir.exists():
+        for child in out_dir.iterdir():
+            if child.is_dir():
+                shutil.rmtree(child)
+            else:
+                child.unlink()
+    for archive in archives:
+        print(f"Extracting {archive} -> {out_dir}")
+        with zipfile.ZipFile(archive) as zf:
+            zf.extractall(out_dir)
+    marker.write_text("ok\n", encoding="utf-8")
+
+
+def find_dataset_root(out_dir: Path) -> tuple[Path, str]:
+    split_train = out_dir / "VisDrone2019-DET-train"
+    split_val = out_dir / "VisDrone2019-DET-val"
+    if (split_train / "images").exists() and (split_train / "labels").exists() and (split_val / "images").exists():
+        return out_dir, "split_dirs"
+
+    candidates = []
+    for image_dir in out_dir.rglob("images/train"):
+        root = image_dir.parents[1]
+        if (root / "labels/train").exists() and (root / "images/val").exists() and (root / "labels/val").exists():
+            candidates.append(root)
+    if (out_dir / "images/train").exists() and (out_dir / "labels/train").exists():
+        return out_dir, "images_labels"
+    if candidates:
+        return sorted(candidates, key=lambda p: len(p.parts))[0], "images_labels"
+    raise SystemExit(f"could not find YOLO VisDrone layout under {out_dir}")
+
+
+def write_yaml(dataset_root: Path, layout: str, yaml_out: Path) -> None:
+    if layout == "split_dirs":
+        test = "VisDrone2019-DET-test-dev/images" if (dataset_root / "VisDrone2019-DET-test-dev/images").exists() else ""
+        data = {
+            "path": str(dataset_root),
+            "train": "VisDrone2019-DET-train/images",
+            "val": "VisDrone2019-DET-val/images",
+            "test": test,
+            "names": VISDRONE_NAMES,
+        }
+    else:
+        data = {
+            "path": str(dataset_root),
+            "train": "images/train",
+            "val": "images/val",
+            "test": "images/test" if (dataset_root / "images/test").exists() else "",
+            "names": VISDRONE_NAMES,
+        }
+    yaml_out.parent.mkdir(parents=True, exist_ok=True)
+    yaml_out.write_text(yaml.safe_dump(data, sort_keys=False, allow_unicode=True), encoding="utf-8")
+    print(f"Wrote {yaml_out}")
+
+
+def main() -> int:
+    args = parse_args()
+    extract_archives(args.snapshot_dir, args.out_dir, args.overwrite)
+    dataset_root, layout = find_dataset_root(args.out_dir)
+    print(f"VisDrone dataset root: {dataset_root} ({layout})")
+    write_yaml(dataset_root, layout, args.yaml_out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_mot_ablation_k8s.sh
+++ b/scripts/run_mot_ablation_k8s.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="${PROJECT_DIR:-/jpfs/huangyidan3/Rhinoceros——Bird/YOLO-Master-main}"
+RUN_ID="${RUN_ID:-$(date +%Y%m%d_%H%M%S)}"
+PROJECT="${PROJECT:-${PROJECT_DIR}/runs/mot_ablation_k8s/${RUN_ID}}"
+DATA="${DATA:-/jpfs/huangyidan3/datasets/VisDrone.yaml}"
+DOWNLOAD_DATA="${DOWNLOAD_DATA:-0}"
+DOWNLOAD_DATA_SOURCE="${DOWNLOAD_DATA_SOURCE:-official}"
+HF_DATASET_REPO="${HF_DATASET_REPO:-banu4prasad/VisDrone-Dataset}"
+HF_SNAPSHOT_DIR="${HF_SNAPSHOT_DIR:-/jpfs/huangyidan3/datasets/hf/VisDrone-Dataset}"
+HF_ALLOW_PATTERNS="${HF_ALLOW_PATTERNS:-README.md visdrone.yaml VisDrone2019-DET-train/** VisDrone2019-DET-val/**}"
+HF_MAX_WORKERS="${HF_MAX_WORKERS:-4}"
+HF_RETRIES="${HF_RETRIES:-8}"
+DATASET_ROOT="${DATASET_ROOT:-/jpfs/huangyidan3/datasets/VisDrone}"
+DATASET_YAML="${DATASET_YAML:-/jpfs/huangyidan3/datasets/VisDrone.yaml}"
+VISDRONE_DOWNLOAD_DIR="${VISDRONE_DOWNLOAD_DIR:-/jpfs/huangyidan3/datasets/downloads/VisDrone}"
+VISDRONE_RETRIES="${VISDRONE_RETRIES:-10}"
+MODELS="${MODELS:-v010_esmoe v010_mot v010_moa v010_moa_mot}"
+SUMMARY_MODELS="${SUMMARY_MODELS:-${MODELS}}"
+DEVICE="${DEVICE:-0,1,2,3,4,5,6,7}"
+IMGSZ="${IMGSZ:-640}"
+WARMUP="${WARMUP:-10}"
+REPS="${REPS:-100}"
+FLOPS_METHOD="${FLOPS_METHOD:-thop}"
+EPOCHS="${EPOCHS:-50}"
+BATCH="${BATCH:-64}"
+WORKERS="${WORKERS:-8}"
+SEED="${SEED:-42}"
+AMP="${AMP:-1}"
+RUN_TRAIN="${RUN_TRAIN:-0}"
+RUN_BUILD_BENCHMARK="${RUN_BUILD_BENCHMARK:-1}"
+RUN_ROUTE_ANALYSIS="${RUN_ROUTE_ANALYSIS:-0}"
+ROUTE_MODEL="${ROUTE_MODEL:-${PROJECT}/v010_mot/weights/best.pt}"
+ROUTE_LIMIT="${ROUTE_LIMIT:-512}"
+VISDRONE_ANN_DIR="${VISDRONE_ANN_DIR:-}"
+SKIP_INSTALL="${SKIP_INSTALL:-0}"
+SETUP_SCRIPT="${SETUP_SCRIPT:-${PROJECT_DIR}/scripts/setup_k8s_env.sh}"
+
+cd "${PROJECT_DIR}"
+mkdir -p "${PROJECT}/logs"
+
+echo "=========================================="
+echo "YOLO-Master MoT Ablation"
+echo "project=${PROJECT}"
+echo "data=${DATA}"
+echo "models=${MODELS}"
+echo "summary_models=${SUMMARY_MODELS}"
+echo "device=${DEVICE}"
+echo "run_train=${RUN_TRAIN}"
+echo "run_build_benchmark=${RUN_BUILD_BENCHMARK}"
+echo "=========================================="
+
+if [[ "${SKIP_INSTALL}" != "1" ]]; then
+  bash "${SETUP_SCRIPT}" 2>&1 | tee "${PROJECT}/logs/setup_env.log"
+fi
+
+if [[ "${DOWNLOAD_DATA}" == "1" ]]; then
+  if [[ "${DOWNLOAD_DATA_SOURCE}" == "hf" ]]; then
+    read -r -a hf_allow_patterns <<< "${HF_ALLOW_PATTERNS}"
+    python scripts/download_hf_dataset.py \
+      --repo-id "${HF_DATASET_REPO}" \
+      --local-dir "${HF_SNAPSHOT_DIR}" \
+      --allow-patterns "${hf_allow_patterns[@]}" \
+      --max-workers "${HF_MAX_WORKERS}" \
+      --retries "${HF_RETRIES}" \
+      --no-force
+    python scripts/prepare_visdrone_hf.py \
+      --snapshot-dir "${HF_SNAPSHOT_DIR}" \
+      --out-dir "${DATASET_ROOT}" \
+      --yaml-out "${DATASET_YAML}"
+  else
+    python scripts/download_visdrone.py \
+      --root "${DATASET_ROOT}" \
+      --download-dir "${VISDRONE_DOWNLOAD_DIR}" \
+      --yaml-out "${DATASET_YAML}" \
+      --retries "${VISDRONE_RETRIES}"
+  fi
+  DATA="${DATASET_YAML}"
+fi
+
+python -m pytest tests/test_mot.py tests/test_moa.py -q 2>&1 | tee "${PROJECT}/logs/pytest_mot_moa.log"
+
+if [[ "${RUN_BUILD_BENCHMARK}" == "1" ]]; then
+  python scripts/compare_mot_ablation.py \
+    --models ${MODELS} \
+    --project "${PROJECT}" \
+    --data "${DATA}" \
+    --device "${DEVICE}" \
+    --imgsz "${IMGSZ}" \
+    --check-build \
+    --benchmark \
+    --warmup "${WARMUP}" \
+    --reps "${REPS}" \
+    --flops-method "${FLOPS_METHOD}" \
+    --exist-ok 2>&1 | tee "${PROJECT}/logs/build_benchmark.log"
+fi
+
+if [[ "${RUN_TRAIN}" == "1" ]]; then
+  train_amp_arg="--amp"
+  if [[ "${AMP}" == "0" || "${AMP}" == "false" || "${AMP}" == "False" ]]; then
+    train_amp_arg="--no-amp"
+  fi
+  python scripts/compare_mot_ablation.py \
+    --models ${MODELS} \
+    --project "${PROJECT}" \
+    --data "${DATA}" \
+    --device "${DEVICE}" \
+    --imgsz "${IMGSZ}" \
+    --train \
+    --epochs "${EPOCHS}" \
+    --batch "${BATCH}" \
+    --workers "${WORKERS}" \
+    --seed "${SEED}" \
+    "${train_amp_arg}" \
+    --plots \
+    --exist-ok 2>&1 | tee "${PROJECT}/logs/train.log"
+fi
+
+if [[ "${RUN_ROUTE_ANALYSIS}" == "1" ]]; then
+  route_args=(
+    --model "${ROUTE_MODEL}"
+    --data "${DATA}"
+    --split val
+    --out "${PROJECT}/routing"
+    --device "${DEVICE}"
+    --imgsz "${IMGSZ}"
+    --limit "${ROUTE_LIMIT}"
+  )
+  if [[ -n "${VISDRONE_ANN_DIR}" ]]; then
+    route_args+=(--visdrone-ann-dir "${VISDRONE_ANN_DIR}")
+  fi
+  python scripts/analyze_mot_routing.py "${route_args[@]}" 2>&1 | tee "${PROJECT}/logs/routing.log"
+fi
+
+python scripts/compare_mot_ablation.py \
+  --models ${SUMMARY_MODELS} \
+  --project "${PROJECT}" \
+  --summary-only 2>&1 | tee "${PROJECT}/logs/summary.log"
+
+echo "Artifacts written under ${PROJECT}"

--- a/scripts/setup_k8s_env.sh
+++ b/scripts/setup_k8s_env.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PIP_INDEX_URL="${PIP_INDEX_URL:-https://mirrors.jd.com/pypi/web/simple}"
+PIP_TRUSTED_HOST="${PIP_TRUSTED_HOST:-mirrors.jd.com}"
+PIP_TIMEOUT="${PIP_TIMEOUT:-120}"
+PIP_RETRIES="${PIP_RETRIES:-5}"
+PIP_UPGRADE_TOOLS="${PIP_UPGRADE_TOOLS:-0}"
+PIP_EXTRAS="${PIP_EXTRAS:-}"
+PIP_EXTRA_PACKAGES="${PIP_EXTRA_PACKAGES:-pytest}"
+
+pip_args=(
+  --index-url "${PIP_INDEX_URL}"
+  --trusted-host "${PIP_TRUSTED_HOST}"
+  --timeout "${PIP_TIMEOUT}"
+  --retries "${PIP_RETRIES}"
+)
+
+echo "Using pip index: ${PIP_INDEX_URL}"
+if [[ "${PIP_UPGRADE_TOOLS}" == "1" ]]; then
+  python -m pip install "${pip_args[@]}" -U pip setuptools wheel
+fi
+
+if [[ -n "${PIP_EXTRAS}" ]]; then
+  python -m pip install "${pip_args[@]}" -e ".[${PIP_EXTRAS}]"
+else
+  python -m pip install "${pip_args[@]}" -e .
+fi
+
+if [[ -n "${PIP_EXTRA_PACKAGES}" ]]; then
+  read -r -a extra_packages <<< "${PIP_EXTRA_PACKAGES}"
+  python -m pip install "${pip_args[@]}" "${extra_packages[@]}"
+fi


### PR DESCRIPTION
## Summary

This PR adds reproducibility scripts and the final report for the MoT/MoA VisDrone ablation study.

Added scripts:
- `scripts/analyze_mot_routing.py`: hooks MoTBlock routers and exports expert activation statistics/heatmaps.
- `scripts/download_hf_dataset.py`: downloads the VisDrone HF mirror with validation checks.
- `scripts/download_visdrone.py`: downloads and prepares official VisDrone2019-DET train/val data in YOLO format.
- `scripts/download_visdrone_dataset.sh`: wrapper for official/HF/torrent VisDrone preparation paths.
- `scripts/prepare_visdrone_hf.py`: converts an HF VisDrone snapshot into an Ultralytics dataset YAML.
- `scripts/run_mot_ablation_k8s.sh`: experiment runner used for the MoT/MoA ablation workflow.
- `scripts/setup_k8s_env.sh`: environment setup helper for the experiment runner.

Final report:
- `reports/yolo_master_mot_moa_visdrone_report_20260702.md`

The report covers EsMoE, MoT, MoA, and MoA+MoT variants on VisDrone, including mAP50-95/mAP50, latency P50/P95/P99, FLOPs, Params, training stability, routing behavior analysis, and scenario recommendations.

Not included:
- datasets or generated run outputs
- K8s YAML files
- the detailed intermediate report `reports/yolo_master_mot_moa_visdrone_detailed_report_20260706.md`
