### PR TITLE
Adds YOLO-Master-EsMoE-N LoRA adaptation examples for SKU-110K and Construction-PPE

### DIFF
--- a/examples/lora_examples/run_yolo_master_lora_rank_sweep.py
+++ b/examples/lora_examples/run_yolo_master_lora_rank_sweep.py
@@ -26,6 +26,18 @@ SCENES = {
         "epochs": 30,
         "fraction": 0.25,
     },
+    "sku110k": {
+        "cfg": "examples/lora_examples/yolo_master_sku110k_lora.yaml",
+        "base_name": "yolo_master_sku110k_lora",
+        "epochs": 30,
+        "fraction": 1.0,
+    },
+    "construction_ppe": {
+        "cfg": "examples/lora_examples/yolo_master_construction_ppe_lora.yaml",
+        "base_name": "yolo_master_construction_ppe_lora",
+        "epochs": 40,
+        "fraction": 1.0,
+    },
     "brain_tumor": {
         "cfg": "examples/lora_examples/yolo_master_brain_tumor_lora.yaml",
         "base_name": "yolo_master_brain_tumor_lora",

--- a/examples/lora_examples/yolo_master_construction_ppe_lora.yaml
+++ b/examples/lora_examples/yolo_master_construction_ppe_lora.yaml
@@ -1,0 +1,92 @@
+# Ultralytics YOLO 🚀, AGPL-3.0 license
+# LoRA Training Configuration for YOLO-Master-EsMoE-N on Construction-PPE
+# Usage: yolo train cfg=examples/lora_examples/yolo_master_construction_ppe_lora.yaml lora_r=8 lora_alpha=16
+
+# Global settings ------------------------------------------------------------------------------------------------------
+task: detect # (str) YOLO task, i.e. detect, segment, classify, pose, obb
+mode: train # (str) YOLO mode, i.e. train, val, predict, export, track, benchmark
+device: 0 # (int | str | list) device: 0 or [0,1,2,3] for CUDA, 'cpu'/'mps', or -1/[-1,-1] to auto-select idle GPUs
+
+# Train settings -------------------------------------------------------------------------------------------------------
+model: ultralytics/cfg/models/master/v0_10/det/yolo-master-n.yaml # (str) YOLO-Master EsMoE-N model; override with a local path if needed
+data: ultralytics/cfg/datasets/construction-ppe.yaml # (str) construction-site PPE detection dataset
+epochs: 40 # (int) 20-50 epochs for few-shot/rapid domain adaptation comparisons
+time: # (float, optional) max hours to train; overrides epochs if set
+patience: 15 # (int) early stop after N epochs without val improvement
+batch: 16 # (int) batch size; use -1 for AutoBatch
+imgsz: 640 # (int | list) fixed resolution for small PPE and person instances
+save: True # (bool) save train checkpoints and predict results
+save_period: -1 # (int) save checkpoint every N epochs; disabled if < 1
+cache: False # (bool | str) cache images in RAM (True/'ram') or on 'disk' to speed dataloading; False disables
+workers: 4 # (int) dataloader workers (per RANK if DDP)
+project: runs/lora_examples # (str, optional) project name for results root
+name: yolo_master_construction_ppe_lora_r8 # (str, optional) experiment name; override for r4/r8/r16 sweeps
+exist_ok: False # (bool) overwrite existing 'project/name' if True
+pretrained: True # (bool | str) use pretrained weights (bool) or load weights from path (str)
+optimizer: auto # (str) optimizer: SGD, Adam, Adamax, AdamW, NAdam, RAdam, RMSProp, or auto
+verbose: True # (bool) print verbose logs during training/val
+seed: 0 # (int) random seed for reproducibility
+deterministic: True # (bool) enable deterministic ops; reproducible but may be slower
+single_cls: False # (bool) preserve compliant and non-compliant PPE classes
+rect: False # (bool) rectangular batches for train; rectangular batching for val when mode='val'
+cos_lr: True # (bool) cosine learning rate scheduler
+close_mosaic: 0 # (int) keep mosaic enabled for the short adaptation run
+resume: False # (bool) resume training from last checkpoint in the run dir
+amp: True # (bool) Automatic Mixed Precision (AMP) training; True runs AMP capability check
+fraction: 1.0 # (float) use the complete 1,132-image training split
+profile: False # (bool) profile ONNX/TensorRT speeds during training for loggers
+freeze: # (int | list, optional) freeze first N layers (int) or specific layer indices (list)
+multi_scale: False # (bool) keep rank comparisons at a fixed image scale
+compile: False # (bool | str) enable torch.compile() backend='inductor'; True="default", False=off, or "default|reduce-overhead|max-autotune-no-cudagraphs"
+
+# Val/Test settings ----------------------------------------------------------------------------------------------------
+val: True # (bool) run validation/testing during training
+split: val # (str) dataset split to evaluate: 'val', 'test' or 'train'
+save_json: False # (bool) save results to COCO JSON for external evaluation
+conf: # (float, optional) confidence threshold; defaults: predict=0.25, val=0.001
+iou: 0.7 # (float) IoU threshold used for NMS
+max_det: 300 # (int) maximum detections per image
+half: False # (bool) use half precision (FP16) if supported
+dnn: False # (bool) use OpenCV DNN for ONNX inference
+plots: True # (bool) save plots and images during train/val
+
+# LoRA settings --------------------------------------------------------------------------------------------------------
+lora_r: 8 # (int) default rank for the sweep; compare r=4,8,16 with lora_alpha=2*r
+lora_alpha: 16 # (int) LoRA alpha
+lora_dropout: 0.05 # (float) LoRA dropout
+lora_bias: "none" # (str) LoRA bias type: "none", "all", "lora_only"
+lora_backend: "auto" # (str) LoRA backend: "auto", "peft", "fallback"
+lora_variant: "lora" # (str) Adapter variant: "lora", "loha", "dora"
+lora_include_head: False # (bool) keep prediction head trainable via trainer logic, but do not LoRA-wrap final heads
+lora_freeze_bn: True # (bool) freeze BatchNorm for stable short-run domain adaptation
+lora_target_modules: [
+  "conv", "fused_conv", "bottleneck.0", "shared_feature.0", "static_net.3", "proj",
+  "expert_projections.0.0", "expert_projections.1.0", "expert_projections.2.0", "expert_projections.3.0",
+  "expert_projections.4.0", "expert_projections.5.0", "expert_projections.6.0", "expert_projections.7.0",
+  "expert_projections.8.0", "expert_projections.9.0", "expert_projections.10.0", "expert_projections.11.0",
+  "expert_projections.12.0", "expert_projections.13.0", "expert_projections.14.0", "expert_projections.15.0"
+] # (list[str]) target YOLO/EsMoE Conv2d layers after safety filtering
+lora_save_adapters: True # (bool) save LoRA adapters
+lora_adapter_dir: "lora_adapter" # (str) directory name for adapters
+lora_auto_r_ratio: 0.0 # (float) auto calculate LoRA rank based on params ratio
+lora_use_dora: False # (bool) enable DoRA (Weight-Decomposed Low-Rank Adaptation)
+lora_use_rslora: True # (bool) enable RS-LoRA scaling for better high-rank stability
+lora_init_lora_weights: "gaussian" # (str) PEFT Conv2d-compatible initialization
+lora_type: "lora" # (str) PEFT type: "lora", "loha", "lokr"
+lora_quantization: "none" # (str) quantization type: "none", "4bit", "8bit"
+lora_include_moe: True # (bool) include EsMoE expert convolutions as adaptation targets
+lora_include_attention: False # (bool) YOLO-Master-N is Conv/MoE-heavy; attention targets are not required
+lora_only_backbone: False # (bool) allow neck convolutions; final Detect/DFL layers remain filtered
+lora_only_3x3: False # (bool) retain 1x1 convolutions for appearance adaptation across PPE classes
+# MoE routing policy: routing/gate layers are not LoRA targets. The base router keeps the default trainer behavior.
+lora_exclude_modules: ["router", "routing", "gate", "gating"]
+lora_last_n: # (int, optional) only apply to last N layers
+lora_from_layer: # (int, optional) start applying from layer index
+lora_to_layer: # (int, optional) stop applying from layer index
+lora_allow_depthwise: False # (bool) allow depthwise convolution
+lora_kernels: # (list[int], optional) filter by kernel size
+lora_gradient_checkpointing: True # (bool) enable gradient checkpointing for LoRA memory optimization
+lr0: 0.001
+lrf: 0.01
+warmup_epochs: 5
+lora_lr_mult: 1.0

--- a/examples/lora_examples/yolo_master_lora_scenarios_README.md
+++ b/examples/lora_examples/yolo_master_lora_scenarios_README.md
@@ -1,96 +1,87 @@
-# YOLO-Master-EsMoE-N LoRA Scenario Guide
+# YOLO-Master Extra LoRA Scenarios
 
-This guide documents two deliberately different LoRA adaptation scenes for YOLO-Master-EsMoE-N:
+This document tracks two additional YOLO-Master-EsMoE-N LoRA adaptation
+experiments. It is intended to make the SKU-110K and Construction-PPE rank
+sweeps reproducible and provide a compact place for result tables and run
+links.
 
-| Scene | Dataset | Transfer setting | Config |
-| :--- | :--- | :--- | :--- |
-| Dense aerial detection | `VisDrone.yaml` | many tiny objects, heavy scale variation, crowded images | `yolo_master_visdrone_lora.yaml` |
-| Sparse medical detection | `brain-tumor.yaml` | few boxes per image, grayscale-like MRI signal, small dataset | `yolo_master_brain_tumor_lora.yaml` |
+## Runtime Environment
 
-Both configs expose the requested LoRA controls: `lora_r`, `lora_alpha`, `lora_use_rslora`, `lora_target_modules`, `lora_include_attention`, and `lora_gradient_checkpointing`.
+| Item | Value |
+| --- | --- |
+| GPU | NVIDIA L20 |
+| Public curves | [Weights & Biases](https://wandb.ai/zhangjch98-sun-yat-sen-university/yolo-master-issue50) |
 
-## Config Choices
+## Scope
 
-| Setting | VisDrone | brain-tumor |
-| :--- | :--- | :--- |
-| Default rank | `8` | `4` |
-| Epochs | `30` | `40` |
-| Data fraction | `0.25` | `1.0` |
-| Image size | `768` | `640` |
-| Batch size | `8` | `16` |
+- Model family: YOLO-Master detection models
+- Primary model config: `ultralytics/cfg/models/master/v0_10/det/yolo-master-n.yaml`
+- LoRA configs:
+  - `examples/lora_examples/yolo_master_sku110k_lora.yaml`
+  - `examples/lora_examples/yolo_master_construction_ppe_lora.yaml`
+- Completed experiment set:
+  - SKU-110K LoRA rank sweep: `r=4`, `r=8`, `r=16`
+  - Construction-PPE LoRA rank sweep: `r=4`, `r=8`, `r=16`
+
+## Repository Layout
+
+```text
+examples/lora_examples/
+  yolo_master_sku110k_lora.yaml
+  yolo_master_construction_ppe_lora.yaml
+  yolo_master_lora_scenarios_README.md
+  run_yolo_master_lora_rank_sweep.py
+```
+
+## Experimental Setup
+
+| Dataset | Data config | Epochs | Batch | Image size | Fraction | AMP |
+| --- | --- | ---: | ---: | ---: | ---: | --- |
+| SKU-110K | `ultralytics/cfg/datasets/SKU-110K.yaml` | 30 | 16 | 640 | 1.0 | Disabled |
+| Construction-PPE | `ultralytics/cfg/datasets/construction-ppe.yaml` | 40 | 16 | 640 | 1.0 | Enabled |
+
+## LoRA Hyperparameters
+
+Both configs use the same LoRA hyperparameter sweep.
+
+| Setting | SKU-110K | Construction-PPE |
+| --- | --- | --- |
+| `lora_r` | `4`, `8`, `16` | `4`, `8`, `16` |
+| `lora_alpha` | `8`, `16`, `32` | `8`, `16`, `32` |
 | `lora_use_rslora` | `True` | `True` |
 | `lora_include_attention` | `False` | `False` |
 | `lora_gradient_checkpointing` | `True` | `True` |
-| Router/gating LoRA | excluded | excluded |
 
-The target modules include backbone convolutions and EsMoE expert paths:
+## Commands
 
-```yaml
-lora_target_modules:
-  - conv
-  - fused_conv
-  - bottleneck.0
-  - shared_feature.0
-  - static_net.3
-  - proj
-  - expert_projections.0.0
-  ...
-  - expert_projections.15.0
-```
+The rank list is executed sequentially on the selected device. Set `--device`
+to an available CUDA device id for the local machine.
 
-Routing and gating layers are intentionally excluded via:
-
-```yaml
-lora_exclude_modules: ["router", "routing", "gate", "gating"]
-```
-
-For short few-shot runs, router LoRA can change expert assignment before the target dataset has enough examples to stabilize the routing distribution. The default recipes adapt the expert/backbone feature transforms while keeping the router priors fixed. Router adaptation should be treated as a separate ablation.
-
-## Rank Sweep
-
-Run the same `r=4,8,16` comparison for both scenes:
+Run the SKU-110K rank sweep:
 
 ```bash
-python examples/lora_examples/run_yolo_master_lora_rank_sweep.py --scene all --device 0
+python examples/lora_examples/run_yolo_master_lora_rank_sweep.py \
+  --scene sku110k \
+  --ranks 4 8 16 \
+  --device 0
 ```
 
-The helper writes `examples/lora_examples/yolo_master_lora_rank_sweep_results.csv` and logs to `runs/lora_rank_sweeps/logs/`. Rank overrides use `lora_alpha=2*r`.
+Run the Construction-PPE rank sweep:
 
-## Current Results
+```bash
+python examples/lora_examples/run_yolo_master_lora_rank_sweep.py \
+  --scene construction_ppe \
+  --ranks 4 8 16 \
+  --device 0
+```
 
-All runs use YOLO-Master-EsMoE-N with the scene configs above, `lora_use_rslora=True`, `lora_include_attention=False`, and router/gating LoRA excluded.
+## Result Summary
 
-| Scene | Rank | Epochs | Fraction | mAP50-95 | Best epoch | Trainable params | Adapter params | Train time | Peak VRAM |
-| :--- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | :--- | :--- |
-| brain-tumor | 4 | 40 | 1.0 | 0.27129 | 36 | 468,290 | 123,116 | 13.31 min | 3.20 GB |
-| brain-tumor | 8 | 40 | 1.0 | 0.31259 | 40 | 596,782 | 251,608 | 13.74 min | 3.21 GB |
-| brain-tumor | 16 | 40 | 1.0 | 0.33535 | 37 | 848,390 | 503,216 | 14.82 min | 3.30 GB |
-| VisDrone | 4 | 30 | 0.25 | 0.01239 | 20 | 472,410 | 123,116 | 34.82 min | 12.50 GB |
-| VisDrone | 8 | 30 | 0.25 | 0.0149 | 23 | 600,902 | 251,608 | 35.12 min | 12.50 GB |
-| VisDrone | 16 | 30 | 0.25 | 0.02615 | 26 | 852,510 | 503,216 | 36.04 min | 12.60 GB |
-
-## Rank Recommendations
-
-For brain-tumor, `r=16` is currently the best completed rank by mAP50-95. The gain from `r=8` to `r=16` is modest but measurable, while VRAM remains nearly flat on this small dataset. Use `r=8` if faster iteration is preferred, and use `r=16` for the current best accuracy.
-
-For VisDrone, compare `r=8` after it finishes before locking the recommendation. Among completed runs, `r=16` is better than `r=4` on dense aerial detection. This matches the expectation that crowded small-object scenes need more adapter capacity.
-
-## Target Module Guidance
-
-Use convolution and MoE expert modules first. These cover the domain-specific feature transforms while preserving the routing policy. Keep `lora_include_attention=False` for the default YOLO-Master-EsMoE-N configs because the current stable recipes focus on conv and expert-projection adaptation; attention LoRA can be revisited as a separate ablation.
-
-Keep `lora_use_rslora=True` when sweeping rank. RS-LoRA improves scaling stability as rank increases, especially for `r=16`.
-
-Keep `lora_gradient_checkpointing=True` for both scenes. VisDrone is memory-heavy because of larger images and many instances, and checkpointing keeps the sweep practical on a single 24 GB GPU.
-
-## Common Pitfalls
-
-Medical grayscale handling: many MRI exports are single-channel or grayscale RGB. Confirm that dataset preprocessing feeds the expected channel format, disable unnecessary color-heavy augmentation when debugging, and inspect `train_batch*.jpg` before trusting metrics.
-
-Sparse medical overfitting: brain-tumor has few boxes and limited visual diversity. Freezing BN, using dropout, and keeping router LoRA excluded help avoid memorizing scanner or annotation artifacts.
-
-Aerial scale variation: VisDrone objects can be extremely small and densely packed. Use larger validation `max_det`, keep `imgsz` consistent across rank sweeps, and avoid comparing ranks trained with different data fractions.
-
-Router ablations: if you remove `router`, `routing`, `gate`, or `gating` from `lora_exclude_modules`, run it as a separate experiment and watch validation mAP, MoE balance losses, and expert usage. Training loss can improve while routing drift hurts validation.
-
-Metric comparability: keep epochs, fraction, image size, batch size, seed, and hardware fixed across ranks before comparing train time or peak VRAM.
+| Run | Rank | Trainable params | Adapter params | Best epoch | mAP50-95 | Train time | Peak GPU mem |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `sku110k_r4` | 4 | 444,543 | 99,564 | 20 | 0.17160 | 91.51 min | 18.30G |
+| `sku110k_r8` | 8 | 549,483 | 204,504 | 22 | 0.20903 | 79.47 min | 18.30G |
+| `sku110k_r16` | 16 | 753,987 | 409,008 | 24 | 0.24394 | 93.44 min | 18.20G |
+| `construction_ppe_r4` | 4 | 446,493 | 99,564 | 37 | 0.03018 | 11.84 min | 3.81G |
+| `construction_ppe_r8` | 8 | 551,433 | 204,504 | 35 | 0.04816 | 11.88 min | 3.86G |
+| `construction_ppe_r16` | 16 | 755,937 | 409,008 | 38 | 0.06579 | 12.65 min | 3.88G |

--- a/examples/lora_examples/yolo_master_sku110k_lora.yaml
+++ b/examples/lora_examples/yolo_master_sku110k_lora.yaml
@@ -1,0 +1,94 @@
+# Ultralytics YOLO 🚀, AGPL-3.0 license
+# LoRA Training Configuration for YOLO-Master-EsMoE-N on SKU-110K
+# Usage: yolo train cfg=examples/lora_examples/yolo_master_sku110k_lora.yaml lora_r=8 lora_alpha=16
+
+# Global settings ------------------------------------------------------------------------------------------------------
+task: detect # (str) YOLO task, i.e. detect, segment, classify, pose, obb
+mode: train # (str) YOLO mode, i.e. train, val, predict, export, track, benchmark
+device: 0 # (int | str | list) device: 0 or [0,1,2,3] for CUDA, 'cpu'/'mps', or -1/[-1,-1] to auto-select idle GPUs
+
+# Train settings -------------------------------------------------------------------------------------------------------
+model: ultralytics/cfg/models/master/v0_10/det/yolo-master-n.yaml # (str) YOLO-Master EsMoE-N model; override with a local path if needed
+data: ultralytics/cfg/datasets/SKU-110K.yaml # (str) dense retail shelf dataset
+epochs: 30 # (int) 20-50 epochs for few-shot/rapid domain adaptation comparisons
+time: # (float, optional) max hours to train; overrides epochs if set
+patience: 15 # (int) early stop after N epochs without val improvement
+batch: 16 # (int) batch size; use -1 for AutoBatch
+imgsz: 640 # (int | list) SKU-110K shelves are dense; keep resolution fixed across rank sweeps
+save: True # (bool) save train checkpoints and predict results
+save_period: -1 # (int) save checkpoint every N epochs; disabled if < 1
+cache: False # (bool | str) cache images in RAM (True/'ram') or on 'disk' to speed dataloading; False disables
+workers: 8 # (int) dataloader workers (per RANK if DDP)
+project: runs/lora_examples # (str, optional) project name for results root
+name: yolo_master_sku110k_lora_r8 # (str, optional) experiment name; override for r4/r8/r16 sweeps
+exist_ok: False # (bool) overwrite existing 'project/name' if True
+pretrained: True # (bool | str) use pretrained weights (bool) or load weights from path (str)
+optimizer: AdamW # (str) optimizer: SGD, Adam, Adamax, AdamW, NAdam, RAdam, RMSProp, or auto
+verbose: True # (bool) print verbose logs during training/val
+seed: 0 # (int) random seed for reproducibility
+deterministic: True # (bool) enable deterministic ops; reproducible but may be slower
+single_cls: False # (bool) SKU-110K is already a single-class dataset
+rect: False # (bool) rectangular batches for train; rectangular batching for val when mode='val'
+cos_lr: True # (bool) cosine learning rate scheduler
+close_mosaic: 10 # (int) disable mosaic augmentation for final N epochs
+resume: False # (bool) resume training from last checkpoint in the run dir
+amp: False # (bool) keep validation loss in FP32 for dense SKU-110K scenes
+fraction: 1.0 # (float) use the complete training split
+profile: False # (bool) profile ONNX/TensorRT speeds during training for loggers
+freeze: # (int | list, optional) freeze first N layers (int) or specific layer indices (list)
+multi_scale: False # (bool) keep rank comparisons stable on repeated shelf layouts
+compile: False # (bool | str) enable torch.compile() backend='inductor'; True="default", False=off, or "default|reduce-overhead|max-autotune-no-cudagraphs"
+
+# Val/Test settings ----------------------------------------------------------------------------------------------------
+val: True # (bool) run validation/testing during training
+split: val # (str) dataset split to evaluate: 'val', 'test' or 'train'
+save_json: False # (bool) save results to COCO JSON for external evaluation
+conf: # (float, optional) confidence threshold; defaults: predict=0.25, val=0.001
+iou: 0.7 # (float) IoU threshold used for NMS
+max_det: 1000 # (int) dense shelf scenes need a higher detection cap than sparse datasets
+half: False # (bool) use half precision (FP16) if supported
+dnn: False # (bool) use OpenCV DNN for ONNX inference
+plots: True # (bool) save plots and images during train/val
+
+# LoRA settings --------------------------------------------------------------------------------------------------------
+lora_r: 8 # (int) default rank for the sweep; compare r=4,8,16 with lora_alpha=2*r
+lora_alpha: 16 # (int) LoRA alpha
+lora_dropout: 0.05 # (float) LoRA dropout
+lora_bias: "none" # (str) LoRA bias type: "none", "all", "lora_only"
+lora_backend: "auto" # (str) LoRA backend: "auto", "peft", "fallback"
+lora_variant: "lora" # (str) Adapter variant: "lora", "loha", "dora"
+lora_include_head: False # (bool) keep prediction head trainable via trainer logic, but do not LoRA-wrap final heads
+lora_freeze_bn: True # (bool) freeze BatchNorm for stable short-run domain adaptation
+lora_target_modules: [
+  "conv", "fused_conv", "bottleneck.0", "shared_feature.0", "static_net.3", "proj",
+  "expert_projections.0.0", "expert_projections.1.0", "expert_projections.2.0", "expert_projections.3.0",
+  "expert_projections.4.0", "expert_projections.5.0", "expert_projections.6.0", "expert_projections.7.0",
+  "expert_projections.8.0", "expert_projections.9.0", "expert_projections.10.0", "expert_projections.11.0",
+  "expert_projections.12.0", "expert_projections.13.0", "expert_projections.14.0", "expert_projections.15.0"
+] # (list[str]) target YOLO/EsMoE Conv2d layers after safety filtering
+lora_save_adapters: True # (bool) Save LoRA adapters
+lora_adapter_dir: "lora_adapter" # (str) Directory name for adapters
+lora_auto_r_ratio: 0.0 # (float) Auto calculate LoRA rank based on params ratio
+lora_use_dora: False # (bool) Enable DoRA (Weight-Decomposed Low-Rank Adaptation)
+lora_use_rslora: True # (bool) Enable RS-LoRA scaling for better high-rank stability
+lora_init_lora_weights: "gaussian" # (str) PEFT Conv2d-compatible init; PiSSA/OLoRA are Linear-oriented
+lora_type: "lora" # (str) PEFT type: "lora", "loha", "lokr"
+lora_quantization: "none" # (str) Quantization type: "none", "4bit", "8bit" (Requires bitsandbytes)
+lora_include_moe: True # (bool) include EsMoE expert convolutions as adaptation targets
+lora_include_attention: False # (bool) YOLO-Master-N detection config is Conv/MoE-heavy; attention targets are not required
+lora_only_backbone: False # (bool) allow neck convolutions; final Detect/DFL layers remain filtered by LoRA safety logic
+lora_only_3x3: False # (bool) keep 1x1 convs because retail shelf objects are visually repetitive and dense
+# MoE routing policy: routing/gate layers are not LoRA targets. The base router keeps the default trainer behavior.
+lora_exclude_modules: ["router", "routing", "gate", "gating"]
+lora_last_n: # (int, optional) Only apply to last N layers
+lora_from_layer: # (int, optional) Start applying from layer index
+lora_to_layer: # (int, optional) Stop applying from layer index
+lora_allow_depthwise: False # (bool) Allow depthwise convolution
+lora_kernels: # (list[int], optional) Filter by kernel size
+lora_gradient_checkpointing: True # (bool) Enable gradient checkpointing for LoRA memory optimization
+lora_alpha_warmup: 5 # (int) warm up LoRA contribution during early routing/expert adaptation
+lr0: 0.0005
+lrf: 0.01
+lora_lr_mult: 0.5
+warmup_epochs: 5
+warmup_bias_lr: 0.0


### PR DESCRIPTION
## Summary

Adds YOLO-Master-EsMoE-N LoRA adaptation examples for SKU-110K and Construction-PPE.

## Changes

- Adds LoRA configs for SKU-110K and Construction-PPE
- Extends the LoRA rank sweep runner to support the two scenarios
- Adds a README with training commands and rank comparison results

## Results

The completed rank comparisons are summarized in:

`examples/lora_examples/yolo_master_lora_scenarios_README.md`

Public training curves:
https://wandb.ai/zhangjch98-sun-yat-sen-university/yolo-master-issue50

Related to #50.