### PR TITLE
test(molora): 补充 top-k warmup 状态恢复测试

### DIFF
--- a/tests/test_molora_supplementary.py
+++ b/tests/test_molora_supplementary.py
@@ -135,8 +135,9 @@ class TestStateDictPersistence:
         layer = MoLoRALayer(nn.Conv2d(4, 4, 1), **kwargs)
         layer.train()
         x = torch.randn(1, 4, 2, 2)
-        for _ in range(4):
-            layer(x)
+        with torch.no_grad():
+            for _ in range(4):
+                layer(x)
 
         saved_step = layer._step_count.item()
         saved_top_k = layer._current_top_k()

--- a/tests/test_molora_supplementary.py
+++ b/tests/test_molora_supplementary.py
@@ -130,6 +130,29 @@ class TestStateDictPersistence:
         assert torch.allclose(out1_eval, out2, atol=1e-5), \
             "Outputs differ after state_dict round-trip"
 
+    def test_warmup_state_restored(self):
+        kwargs = dict(r=2, alpha=4, num_experts=3, top_k=3, top_k_warmup=1, warmup_steps=6)
+        layer = MoLoRALayer(nn.Conv2d(4, 4, 1), **kwargs)
+        layer.train()
+        x = torch.randn(1, 4, 2, 2)
+        for _ in range(4):
+            layer(x)
+
+        saved_step = layer._step_count.item()
+        saved_top_k = layer._current_top_k()
+        assert (saved_step, saved_top_k) == (4, 2)
+
+        restored = MoLoRALayer(nn.Conv2d(4, 4, 1), **kwargs)
+        restored.train()
+        assert (restored._step_count.item(), restored._current_top_k()) == (0, 1)
+
+        incompatible = restored.load_state_dict(layer.state_dict())
+
+        assert incompatible.missing_keys == []
+        assert incompatible.unexpected_keys == []
+        assert restored._step_count.item() == saved_step
+        assert restored._current_top_k() == saved_top_k
+
     def test_step_count_persisted(self):
         """_step_count buffer should be in state_dict (persistent=True)."""
         layer = _conv_layer()


### PR DESCRIPTION
## 背景

MoLoRA 的 dynamic top-k warmup 由训练 step 决定，因此 checkpoint 恢复不仅需要保留 `_step_count`，还需要保证恢复后的 effective top-k 与保存前一致。

当前 main 已将 `_step_count` 注册为持久化 buffer，并由 `_current_top_k()` 直接读取该状态，现有生产行为是正确的。

现有测试分别覆盖了：

- `_step_count` 存在于 `state_dict`；
- state-dict round-trip 后 eval 输出一致；
- warmup 调度可以随 step 推进到目标 top-k。

但这些测试没有覆盖完整的恢复链路：在训练态通过真实 forward 推进 warmup 后，加载 state dict 是否能同时恢复 step count 和 effective top-k。

## 修改

在 `tests/test_molora_supplementary.py` 中增加一条聚焦的 CPU 测试：

1. 创建启用 dynamic top-k warmup 的 `MoLoRALayer`；
2. 在 training mode 下通过 4 次真实 forward 推进 warmup；
3. 确认保存前状态为 `step=4, top_k=2`；
4. 创建配置相同的新实例，并确认其初始状态为 `step=0, top_k=1`；
5. 加载原实例的 `state_dict`；
6. 确认恢复后的 step count 和 effective top-k 与保存前一致；
7. 确认没有 missing 或 unexpected keys。

选择 warmup 中间状态而不是最终状态，可以验证实际训练进度得到了恢复，而不只是最终配置的 `top_k` 恰好一致。

## 价值

该测试固定了 MoLoRA checkpoint 恢复的一项行为契约：

> 恢复训练状态后，所有由该状态决定的 effective routing 行为也应保持一致。

如果未来的性能优化、状态缓存或 checkpoint 加载调整导致 warmup 重新从初始状态开始，该测试会直接失败。

这可以防止一种不会抛出异常、但会静默改变训练行为的回归。warmup 回退可能改变：

- 每个 step 激活的专家数量；
- 路由分布和专家利用率；
- 训练计算量和资源消耗；
- 恢复前后的优化轨迹与实验可复现性。

## 范围

- 只修改一个测试文件；
- 不修改生产代码；
- 不恢复 CPU mirror；
- 不增加 load hook 或兼容分支；
- 不改变现有 API；
- 测试可在 CPU 上确定性运行。

## 验证

CPU 环境，`CUDA_VISIBLE_DEVICES=""`：

```text
python -m pytest \
  tests/test_molora_supplementary.py::TestStateDictPersistence::test_warmup_state_restored \
  -q
1 passed

python -m pytest tests/test_molora_supplementary.py -q
24 passed

python -m pytest tests/test_molora.py -q
73 passed

python tests/lora_e2e_smoke.py
passed

python tests/lora_rankless_smoke.py
passed

git diff --check
passed
```

## 犀牛鸟计划关联

本人已参与 2026 腾讯犀牛鸟开源人才培养计划，并完成专属 Issue #52、#54 的认领。

本 PR 的具体技术来源是 Issue #52：在专家剪枝与 LoRA 恢复实验中发现 MoLoRA dynamic top-k warmup 的 checkpoint 恢复风险。当前 main 已不再需要旧的生产代码修复，因此本 PR 只补充一条聚焦的行为回归测试。

Related to #52.
