### PR TITLE
fix(moe): 仅在 accepted epoch 更新 mAP 调度

### DIFF
--- a/tests/test_moe_dynamic_scheduler.py
+++ b/tests/test_moe_dynamic_scheduler.py
@@ -10,7 +10,8 @@ _seaborn_stub.heatmap = lambda *_args, **_kw: None  # type: ignore[attr-defined]
 sys.modules.setdefault("seaborn", _seaborn_stub)
 
 from ultralytics.nn.modules.moe.loss import MoELoss
-from ultralytics.nn.modules.moe.modules import AdaptiveBalanceController
+from ultralytics.engine.trainer import BaseTrainer
+from ultralytics.nn.modules.moe.modules import AdaptiveBalanceController, UltraOptimizedMoE
 from ultralytics.nn.modules.moe.scheduler import (
     MoEDynamicScheduler,
     MoEDynamicSchedulerConfig,
@@ -161,6 +162,25 @@ def test_map_saturation_state_dict_round_trip():
     assert restored.saturation_scale == pytest.approx(scheduler.saturation_scale)
     assert restored.map_history == scheduler.map_history
     assert restored.config.window_size == 3
+
+
+@pytest.mark.parametrize(
+    ("recovered", "validated", "expected_updates"),
+    [(True, True, 0), (False, False, 0), (False, True, 1)],
+)
+def test_map_saturation_updates_only_for_accepted_epoch(recovered, validated, expected_updates):
+    block = UltraOptimizedMoE(8, 8, num_experts=2, top_k=1, router_reduction=2, router_pool_scale=1, num_groups=1)
+    block.map_saturation_scheduler = MapSaturationScheduler(MapSaturationSchedulerConfig(window_size=1))
+    trainer = types.SimpleNamespace(
+        _has_moe=True,
+        args=types.SimpleNamespace(moe_map_saturation_enabled=True),
+        model=torch.nn.Sequential(block),
+        fitness=0.5,
+    )
+
+    BaseTrainer._finalize_moe_map_saturation_epoch(trainer, recovered=recovered, validated=validated)
+
+    assert len(block.map_saturation_scheduler.map_history) == expected_updates
 
 
 def test_map_saturation_config_validation():

--- a/tests/test_moe_dynamic_scheduler.py
+++ b/tests/test_moe_dynamic_scheduler.py
@@ -170,6 +170,7 @@ def test_map_saturation_state_dict_round_trip():
         (True, True, 0.5, 0),
         (False, False, 0.5, 0),
         (False, True, None, 0),
+        (False, True, float("nan"), 0),
         (False, True, 0.5, 1),
     ],
 )

--- a/tests/test_moe_dynamic_scheduler.py
+++ b/tests/test_moe_dynamic_scheduler.py
@@ -165,17 +165,22 @@ def test_map_saturation_state_dict_round_trip():
 
 
 @pytest.mark.parametrize(
-    ("recovered", "validated", "expected_updates"),
-    [(True, True, 0), (False, False, 0), (False, True, 1)],
+    ("recovered", "validated", "fitness", "expected_updates"),
+    [
+        (True, True, 0.5, 0),
+        (False, False, 0.5, 0),
+        (False, True, None, 0),
+        (False, True, 0.5, 1),
+    ],
 )
-def test_map_saturation_updates_only_for_accepted_epoch(recovered, validated, expected_updates):
+def test_map_saturation_updates_only_for_accepted_epoch(recovered, validated, fitness, expected_updates):
     block = UltraOptimizedMoE(8, 8, num_experts=2, top_k=1, router_reduction=2, router_pool_scale=1, num_groups=1)
     block.map_saturation_scheduler = MapSaturationScheduler(MapSaturationSchedulerConfig(window_size=1))
     trainer = types.SimpleNamespace(
         _has_moe=True,
         args=types.SimpleNamespace(moe_map_saturation_enabled=True),
         model=torch.nn.Sequential(block),
-        fitness=0.5,
+        fitness=fitness,
     )
 
     BaseTrainer._finalize_moe_map_saturation_epoch(trainer, recovered=recovered, validated=validated)

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1192,7 +1192,7 @@ class BaseTrainer:
             if self.args.val or final_epoch or self.stopper.possible_stop or self.stop:
                 self._clear_memory(threshold=0.5)  # prevent VRAM spike
                 self.metrics, self.fitness = self.validate()
-                validated = self.fitness is not None
+                validated = self.fitness is not None and math.isfinite(float(self.fitness))
 
             # NaN recovery
             recovered = self._handle_nan_recovery(epoch)
@@ -1248,7 +1248,7 @@ class BaseTrainer:
 
     def _finalize_moe_map_saturation_epoch(self, *, recovered: bool, validated: bool) -> None:
         """Update mAP-driven MoE scheduling only for validated, accepted epochs."""
-        if recovered or not validated or self.fitness is None:
+        if recovered or not validated or self.fitness is None or not math.isfinite(float(self.fitness)):
             return
         if not getattr(self, "_has_moe", False) or not getattr(self.args, "moe_map_saturation_enabled", False):
             return

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1188,28 +1188,16 @@ class BaseTrainer:
 
             # Validation
             final_epoch = epoch + 1 >= self.epochs
+            validated = False
             if self.args.val or final_epoch or self.stopper.possible_stop or self.stop:
                 self._clear_memory(threshold=0.5)  # prevent VRAM spike
                 self.metrics, self.fitness = self.validate()
-
-                # Update MapSaturationScheduler with validation fitness (mAP)
-                if getattr(self, '_has_moe', False) and getattr(self.args, 'moe_map_saturation_enabled', False):
-                    from ultralytics.nn.modules.moe.utils import is_core_moe_block
-                    for m in self.model.modules():
-                        if not is_core_moe_block(m):
-                            continue
-                        scheduler = getattr(m, 'map_saturation_scheduler', None)
-                        if scheduler is not None:
-                            scheduler.update(self.fitness)
-                            if RANK in {-1, 0} and scheduler.last_state is not None:
-                                LOGGER.debug(
-                                    f"[MoE] MapSaturationScheduler updated: "
-                                    f"scale={scheduler.last_state.saturation_scale:.4f}, "
-                                    f"plateau={scheduler.last_state.plateau_detected}"
-                                )
+                validated = True
 
             # NaN recovery
-            if self._handle_nan_recovery(epoch):
+            recovered = self._handle_nan_recovery(epoch)
+            self._finalize_moe_map_saturation_epoch(recovered=recovered, validated=validated)
+            if recovered:
                 continue
 
             self.nan_recovery_attempts = 0
@@ -1257,6 +1245,28 @@ class BaseTrainer:
         self._clear_memory()
         unset_deterministic()
         self.run_callbacks("teardown")
+
+    def _finalize_moe_map_saturation_epoch(self, *, recovered: bool, validated: bool) -> None:
+        """Update mAP-driven MoE scheduling only for validated, accepted epochs."""
+        if recovered or not validated:
+            return
+        if not getattr(self, "_has_moe", False) or not getattr(self.args, "moe_map_saturation_enabled", False):
+            return
+
+        from ultralytics.nn.modules.moe.utils import is_core_moe_block
+
+        for module in self.model.modules():
+            if not is_core_moe_block(module):
+                continue
+            scheduler = getattr(module, "map_saturation_scheduler", None)
+            if scheduler is None:
+                continue
+            scheduler.update(self.fitness)
+            if RANK in {-1, 0} and scheduler.last_state is not None:
+                LOGGER.debug(
+                    f"[MoE] MapSaturationScheduler updated: scale={scheduler.last_state.saturation_scale:.4f}, "
+                    f"plateau={scheduler.last_state.plateau_detected}"
+                )
 
     def auto_batch(self, max_num_obj=0):
         """Calculate optimal batch size based on model and device memory constraints."""

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -1192,7 +1192,7 @@ class BaseTrainer:
             if self.args.val or final_epoch or self.stopper.possible_stop or self.stop:
                 self._clear_memory(threshold=0.5)  # prevent VRAM spike
                 self.metrics, self.fitness = self.validate()
-                validated = True
+                validated = self.fitness is not None
 
             # NaN recovery
             recovered = self._handle_nan_recovery(epoch)
@@ -1248,7 +1248,7 @@ class BaseTrainer:
 
     def _finalize_moe_map_saturation_epoch(self, *, recovered: bool, validated: bool) -> None:
         """Update mAP-driven MoE scheduling only for validated, accepted epochs."""
-        if recovered or not validated:
+        if recovered or not validated or self.fitness is None:
             return
         if not getattr(self, "_has_moe", False) or not getattr(self.args, "moe_map_saturation_enabled", False):
             return


### PR DESCRIPTION
## 问题

`MapSaturationScheduler` 当前在 validation 完成后、NaN recovery 判定前更新。

如果本 epoch 随后被 recovery 逻辑拒绝，模型 checkpoint 会恢复，但外置 scheduler 的 history 和 saturation scale 不会回滚。下一次重试因此会使用一个由 rejected epoch 推进过的调度状态。

期望行为是：只有完成 validation 且未被 recovery 拒绝的 accepted epoch 才能提交 MapSaturation 状态。

本 PR 从此前 #109 涉及的多个问题中，仅提取 accepted-epoch 提交语义这一项，不重新引入旧的 Gini scheduler 或 epoch usage accumulator。

## 修改

- 记录当前 epoch 是否实际执行 validation
- 在 NaN recovery 判定完成后再 finalize MapSaturation 状态
- 仅在 `validated && !recovered` 且 fitness 为有限数值时更新 scheduler
- 增加 recovered、未验证、缺失 fitness、非有限 fitness 和正常 accepted epoch 五种边界测试

## 兼容性与范围

- 不修改公共 API、配置项或 checkpoint 格式
- MapSaturation 默认关闭路径保持不变
- 非 MoE 训练路径保持不变
- 不修改 scheduler 公式、router、MoT、MoA 或 MoLoRA 行为

## 验证

CPU 聚焦测试：

```bash
CUDA_VISIBLE_DEVICES="" python -m pytest \
  tests/test_moe_dynamic_scheduler.py -q
# 21 passed

CUDA_VISIBLE_DEVICES="" python -m pytest \
  tests/test_moe_dynamic_schedule.py \
  tests/test_ddp_lifecycle_ema_nan.py -q
# 10 passed
```

其他检查：

- import smoke: passed
- `git diff --check`: passed
- 对两个改动文件执行 Ruff 时，候选与纯净 base 均有相同的两处既有 F401；本 PR 新增 Ruff 问题为 0
- 未执行 GPU 或完整训练 smoke test

## CI 基线说明

当前 GitHub Actions 的 `lint-and-import`、`moe-stability-test` 和 `version-check` 失败也存在于本 PR 的精确 base SHA `53232f7`：

- [PR run](https://github.com/Tencent/YOLO-Master/actions/runs/29334613972)
- [Base run](https://github.com/Tencent/YOLO-Master/actions/runs/29332090225)

`ddp-cpu-smoke` 和开源代码扫描已通过。

Related to #52.
