### PR TITLE
fix(lora,ddp): prevent MoE control-path LoRA ready-twice crash

### DIFF
--- a/tests/test_lora_moe_ddp_control_paths.py
+++ b/tests/test_lora_moe_ddp_control_paths.py
@@ -1,0 +1,45 @@
+"""Regression: LoRA must not target MoE control paths that break DDP."""
+import torch
+import torch.nn as nn
+
+from ultralytics.nn.modules.moe.gated import AdaptiveGateMoE
+from ultralytics.utils.lora.config import LoRAConfigBuilder
+
+
+def test_lora_auto_detect_excludes_complexity_estimator_when_include_moe_false():
+    moe = AdaptiveGateMoE(32, 32, num_experts=4, top_k=2)
+    # Wrap like a YOLO sequential layer index
+    model = nn.Sequential(nn.Identity(), moe)
+    targets = LoRAConfigBuilder.auto_detect_targets(model, r=8, include_moe=False)
+    assert not any("complexity_estimator" in t for t in targets)
+    assert not any("se_gate" in t for t in targets)
+    assert not any("expert" in t.lower() for t in targets)
+
+
+def test_lora_auto_detect_always_excludes_complexity_even_if_include_moe_true():
+    moe = AdaptiveGateMoE(32, 32, num_experts=4, top_k=2)
+    model = nn.Sequential(moe)
+    targets = LoRAConfigBuilder.auto_detect_targets(model, r=8, include_moe=True)
+    assert not any("complexity_estimator" in t for t in targets)
+    assert not any("se_gate" in t for t in targets)
+
+
+def test_adaptive_gate_complexity_gate_detaches_from_estimator():
+    """Discrete complexity gate must not leave half-used grads into estimator."""
+    torch.manual_seed(0)
+    m = AdaptiveGateMoE(32, 32, num_experts=4, top_k=2).train()
+    x = torch.randn(2, 32, 8, 8, requires_grad=True)
+    out = m(x)
+    out.mean().backward()
+    # Estimator params should have no grad (detached discrete gate)
+    for p in m.complexity_estimator.parameters():
+        assert p.grad is None or float(p.grad.abs().sum()) == 0.0
+
+
+def test_is_under_moe_block_detects_nested_control_path():
+    moe = AdaptiveGateMoE(16, 16, num_experts=4, top_k=2)
+    model = nn.Sequential(moe)
+    modules = dict(model.named_modules())
+    assert LoRAConfigBuilder._is_under_moe_block("0.complexity_estimator.1", modules)
+    assert LoRAConfigBuilder._is_under_moe_block("0.proj", modules)
+    assert not LoRAConfigBuilder._is_under_moe_block("does.not.exist", modules)

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -392,6 +392,43 @@ class BaseTrainer:
             world_size=self.world_size,
         )
 
+    def _disable_gradient_checkpointing_for_ddp_moe_lora(self):
+        """Disable GC for LoRA+MoE DDP to avoid 'marked as ready twice'.
+
+        PyTorch DDP docs: gradient checkpointing is unsupported with
+        ``find_unused_parameters=True`` when unused parameters exist. MoE sparse
+        routing leaves expert (and sometimes control-path LoRA) params unused
+        each step, so keep find_unused=True and turn GC off instead.
+        """
+        disabled = False
+        roots = [self.model]
+        if hasattr(self.model, "model"):
+            roots.append(self.model.model)
+            if hasattr(self.model.model, "model"):
+                roots.append(self.model.model.model)
+        for root in roots:
+            if getattr(root, "use_gradient_checkpointing", False):
+                root.use_gradient_checkpointing = False
+                disabled = True
+        # Freeze leftover LoRA adapters on MoE control paths from older configs
+        # that incorrectly targeted complexity_estimator / se_gate.
+        frozen = 0
+        for name, param in self.model.named_parameters():
+            lname = name.lower()
+            if "lora_" not in lname:
+                continue
+            if "complexity_estimator" in lname or "se_gate" in lname:
+                if param.requires_grad:
+                    param.requires_grad_(False)
+                    frozen += 1
+        if disabled or frozen:
+            LOGGER.warning(
+                "[LoRA+MoE+DDP] Disabled gradient checkpointing"
+                + (f" and froze {frozen} control-path LoRA params" if frozen else "")
+                + " to avoid DDP 'marked as ready twice' "
+                "(find_unused_parameters=True is incompatible with GC on unused adapters)."
+            )
+
     def _setup_train(self):
         """Build dataloaders and optimizer on correct rank process."""
         ckpt = self.setup_model()
@@ -716,6 +753,12 @@ class BaseTrainer:
                     "DDP uses broadcast_buffers=False: BatchNorm running statistics are rank-local. "
                     "EMA/rank0 validation follows rank0 statistics; use an explicitly tested SyncBatchNorm setup if global BN is required."
                 )
+            # PyTorch DDP does not support gradient checkpointing together with
+            # find_unused_parameters=True when unused LoRA/MoE params exist
+            # ("marked as ready twice"). MoE sparse dispatch requires unused
+            # detection, so disable GC for LoRA+MoE multi-GPU runs.
+            if is_lora and getattr(self, "_has_moe", False):
+                self._disable_gradient_checkpointing_for_ddp_moe_lora()
             self.model = nn.parallel.DistributedDataParallel(
                 self.model,
                 device_ids=[LOCAL_RANK] if self.device.type == "cuda" else None,

--- a/ultralytics/nn/modules/moe/blocks_advanced.py
+++ b/ultralytics/nn/modules/moe/blocks_advanced.py
@@ -196,27 +196,27 @@ class AdaptiveGateMoE(nn.Module):
             nn.init.normal_(self.routing.global_fc.weight, std=0.05)
 
     def _safe_complexity(self, x_dynamic):
-        """Compute complexity score with NaN/Inf protection."""
+        """Compute complexity score with NaN/Inf protection (graph-safe)."""
         raw = self.complexity_estimator(x_dynamic).mean()
-        if torch.isnan(raw) or torch.isinf(raw):
-            return torch.tensor(1.0, device=raw.device, dtype=raw.dtype)
-        # Smooth clamping: keep in [0.3, 1.5] to avoid degenerate top_k
-        return raw.clamp(0.3, 1.5)
+        return torch.nan_to_num(raw, nan=1.0, posinf=1.5, neginf=0.3).clamp(0.3, 1.5)
 
     def _apply_complexity_gate(self, routing_weights, routing_indices, routing_stats, complexity):
         """Apply complexity-aware Top-K masking without CPU synchronization.
 
         Older versions converted the scalar complexity score to Python with
-        `.item()` and then sliced Top-K tensors. That forces GPU/MPS sync and
+        ``.item()`` and then sliced Top-K tensors. That forces GPU/MPS sync and
         creates dynamic tensor shapes. Keeping the full Top-K shape while
         zeroing low-rank weights preserves the adaptive behavior with a much
         friendlier execution path.
+
+        Detach before discrete round/compare so control-path LoRA adapters do
+        not trigger DDP "marked as ready twice" under find_unused_parameters.
         """
         top_k = routing_weights.shape[1]
         if top_k <= 1:
             return routing_weights, routing_indices, routing_stats, top_k
 
-        safe_complexity = torch.nan_to_num(complexity, nan=1.0, posinf=1.0, neginf=1.0).clamp(0.3, 1.5)
+        safe_complexity = torch.nan_to_num(complexity, nan=1.0, posinf=1.0, neginf=1.0).clamp(0.3, 1.5).detach()
         keep_count = torch.round(safe_complexity * top_k).clamp(1, top_k)
         expert_rank = torch.arange(1, top_k + 1, device=routing_weights.device, dtype=keep_count.dtype)
         mask = (expert_rank.view(1, top_k, 1, 1) <= keep_count).to(routing_weights.dtype)

--- a/ultralytics/nn/modules/moe/gated.py
+++ b/ultralytics/nn/modules/moe/gated.py
@@ -382,27 +382,32 @@ class AdaptiveGateMoE(nn.Module):
             nn.init.normal_(self.routing.global_fc.weight, std=0.05)
 
     def _safe_complexity(self, x_dynamic):
-        """Compute complexity score with NaN/Inf protection."""
+        """Compute complexity score with NaN/Inf protection (graph-safe)."""
         raw = self.complexity_estimator(x_dynamic).mean()
-        if torch.isnan(raw) or torch.isinf(raw):
-            return torch.tensor(1.0, device=raw.device, dtype=raw.dtype)
-        # Smooth clamping: keep in [0.3, 1.5] to avoid degenerate top_k
-        return raw.clamp(0.3, 1.5)
+        # Avoid Python data-dependent branches (isnan.item sync) that interact
+        # poorly with DDP unused-parameter detection under LoRA.
+        return torch.nan_to_num(raw, nan=1.0, posinf=1.5, neginf=0.3).clamp(0.3, 1.5)
 
     def _apply_complexity_gate(self, routing_weights, routing_indices, routing_stats, complexity):
         """Apply complexity-aware Top-K masking without CPU synchronization.
 
         Older versions converted the scalar complexity score to Python with
-        `.item()` and then sliced Top-K tensors. That forces GPU/MPS sync and
+        ``.item()`` and then sliced Top-K tensors. That forces GPU/MPS sync and
         creates dynamic tensor shapes. Keeping the full Top-K shape while
         zeroing low-rank weights preserves the adaptive behavior with a much
         friendlier execution path.
+
+        The discrete ``round`` / compare path has no useful gradient into the
+        complexity estimator, so we ``detach()`` before gating. This prevents
+        LoRA adapters on ``complexity_estimator`` from entering a half-used
+        autograd state that triggers DDP "marked as ready twice" under
+        ``find_unused_parameters=True`` + gradient checkpointing.
         """
         top_k = routing_weights.shape[1]
         if top_k <= 1:
             return routing_weights, routing_indices, routing_stats, top_k
 
-        safe_complexity = torch.nan_to_num(complexity, nan=1.0, posinf=1.0, neginf=1.0).clamp(0.3, 1.5)
+        safe_complexity = torch.nan_to_num(complexity, nan=1.0, posinf=1.0, neginf=1.0).clamp(0.3, 1.5).detach()
         keep_count = torch.round(safe_complexity * top_k).clamp(1, top_k)
         expert_rank = torch.arange(1, top_k + 1, device=routing_weights.device, dtype=keep_count.dtype)
         mask = (expert_rank.view(1, top_k, 1, 1) <= keep_count).to(routing_weights.dtype)

--- a/ultralytics/utils/lora/api.py
+++ b/ultralytics/utils/lora/api.py
@@ -1021,19 +1021,29 @@ def apply_lora(
 
     # 6. Gradient Checkpointing (VRAM Optimization) - Actually activate
     if config.gradient_checkpointing:
-        from torch.utils.checkpoint import checkpoint
-        
-        # Enable the flag on the model for tasks.py to consume
-        if hasattr(model, "model"):
-            model.model.use_gradient_checkpointing = True
-            if hasattr(model.model, "model"):
-                model.model.model.use_gradient_checkpointing = True
-                # Patch C3k2 / Conv layers to use checkpointing if they support it
-                _activate_gradient_checkpointing(model.model.model)
-        
-        # Set directly on the top-level model (LoRADetectionModel)
-        model.use_gradient_checkpointing = True
-        LOGGER.info("[LoRA] ✅ Gradient checkpointing activated (reduces VRAM by ~30-50%).")
+        from ultralytics.nn.modules.moe.utils import model_has_core_moe
+
+        if model_has_core_moe(model):
+            # MoE DDP training requires find_unused_parameters=True; combining
+            # that with gradient checkpointing triggers
+            # "parameter ... marked as ready twice" for unused LoRA adapters.
+            LOGGER.warning(
+                "[LoRA] Skipping gradient checkpointing on MoE models "
+                "(incompatible with DDP find_unused_parameters=True). "
+                "Set lora_gradient_checkpointing=False to silence this warning."
+            )
+        else:
+            # Enable the flag on the model for tasks.py to consume
+            if hasattr(model, "model"):
+                model.model.use_gradient_checkpointing = True
+                if hasattr(model.model, "model"):
+                    model.model.model.use_gradient_checkpointing = True
+                    # Patch C3k2 / Conv layers to use checkpointing if they support it
+                    _activate_gradient_checkpointing(model.model.model)
+
+            # Set directly on the top-level model (LoRADetectionModel)
+            model.use_gradient_checkpointing = True
+            LOGGER.info("[LoRA] ✅ Gradient checkpointing activated (reduces VRAM by ~30-50%).")
 
     # 6.5 MPS Compatibility Check & Warning
     device_type = None

--- a/ultralytics/utils/lora/config.py
+++ b/ultralytics/utils/lora/config.py
@@ -310,7 +310,21 @@ class LoRAConfigBuilder:
 
     # Pre-compiled regex for performance
     _PAT_BACKBONE_EXCLUDE = re.compile(r"(head|detect|box|cls|pred|fpn|pan|seg|pose|enc_score_head|enc_bbox_head|dec_score_head|dec_bbox_head)", re.IGNORECASE)
-    _PAT_MOE = re.compile(r"(expert|moe)", re.IGNORECASE)
+    # MoE expert / block names. Kept broad so ``include_moe=False`` actually
+    # excludes the whole MoE block, not only modules whose name contains "expert".
+    _PAT_MOE = re.compile(
+        r"(expert|moe|fused_experts|shared_(?:feature|expand|expert)|static_net|"
+        r"complexity_estimator|se_gate|routing|router|dual.?stream|gate_router)",
+        re.IGNORECASE,
+    )
+    # Always excluded from LoRA even when ``include_moe=True``: discrete/scalar
+    # control paths (often Conv2d→1ch) cause DDP "ready twice" under
+    # find_unused_parameters + gradient checkpointing because their grads are
+    # severed by round/compare while still appearing in the forward graph.
+    _PAT_MOE_CONTROL = re.compile(
+        r"(complexity_estimator|se_gate)(\.|$)",
+        re.IGNORECASE,
+    )
     _PAT_ATTN = re.compile(r"attn", re.IGNORECASE)
     # YOLO12 Area-Attention pattern: matches Conv2d-based qkv/proj/pe submodules.
     # Excluded from LoRA targets by default to avoid breaking softmax numerical stability.
@@ -352,6 +366,21 @@ class LoRAConfigBuilder:
         # Fallback: look for first numeric segment anywhere (after a dot or at start)
         match = LoRAConfigBuilder._PAT_INDEX_ANY.search(name)
         return int(match.group(1)) if match else -1
+
+    @staticmethod
+    def _is_under_moe_block(name: str, modules_by_name: dict) -> bool:
+        """Return True if ``name`` is inside a MoE block (ancestor has num_experts>0)."""
+        parts = name.split(".")
+        for i in range(len(parts)):
+            parent = modules_by_name.get(".".join(parts[: i + 1]))
+            if parent is None:
+                continue
+            if int(getattr(parent, "num_experts", 0) or 0) <= 0:
+                continue
+            mod = getattr(parent.__class__, "__module__", "") or ""
+            if mod.startswith("ultralytics.nn.modules.moe") or mod.endswith(".moe.modules") or ".moe." in mod:
+                return True
+        return False
 
     @staticmethod
     def auto_detect_targets(
@@ -433,11 +462,18 @@ class LoRAConfigBuilder:
                 )
 
         # Iterate through all sub-modules
+        modules_by_name = dict(model.named_modules())
         for name, module in model.named_modules():
             if not name: continue 
             
             # 0. Explicit Exclusion
             if name in exclude_set:
+                continue
+
+            # 0.25 Under-MoE-block exclusion: when include_moe=False, skip any
+            # submodule that lives inside a MoE block (num_experts>0), even if
+            # its own name does not contain "expert"/"moe" (e.g. proj/bn/se_gate).
+            if not include_moe and LoRAConfigBuilder._is_under_moe_block(name, modules_by_name):
                 continue
 
             # 0.5 Planner hint filter
@@ -541,6 +577,12 @@ class LoRAConfigBuilder:
 
             # MoE Check
             if not include_moe and LoRAConfigBuilder._PAT_MOE.search(lname):
+                continue
+
+            # MoE control paths: always skip (scalar gates / SE routers).
+            # Attaching LoRA here is both low-value and unsafe under DDP+AMP
+            # (unused-grad control tensors + gradient checkpointing → ready twice).
+            if LoRAConfigBuilder._PAT_MOE_CONTROL.search(lname):
                 continue
 
             # Attention Check: also handle Conv2d-based attention.


### PR DESCRIPTION
## Summary
- Exclude MoE control paths (`complexity_estimator` / `se_gate`) and whole MoE-block submodules from LoRA auto-detect when `include_moe=False` (old `expert|moe` regex missed these).
- Detach discrete complexity gating and disable gradient checkpointing for LoRA+MoE DDP runs to avoid `Parameter ... marked as ready twice` under `find_unused_parameters=True`.
- Freeze leftover control-path LoRA adapters from older configs; add regression tests.

Follow-up to #124 (AMP `index_add_` dtype fix already merged). This covers the subsequent DDP LoRA crash on `complexity_estimator.1.lora_B.default.weight`.

## Test plan
- [x] `pytest tests/test_lora_moe_ddp_control_paths.py`
- [x] `pytest tests/test_moe_ddp_fixes.py`
- [ ] Re-run DDP LoRA+MoE training on ablation machine after syncing `main`


Made with [Cursor](https://cursor.com)