### PR TITLE
Improve MoT boundary handling and analysis tooling

### DIFF
--- a/scripts/analyze_mot_routing.py
+++ b/scripts/analyze_mot_routing.py
@@ -34,6 +34,15 @@ from ultralytics.nn.modules.mot import MoTBlock  # noqa: E402
 
 EXPERT_NAMES = ("LocalConvTransformer", "WindowTransformer", "DeformableTransformer")
 IMG_SUFFIXES = {".bmp", ".jpg", ".jpeg", ".png", ".tif", ".tiff", ".webp"}
+ROUTING_METRICS = tuple(
+    f"{name}_{suffix}" for name in EXPERT_NAMES for suffix in ("mean_weight", "top1_token_frac")
+)
+SCENE_CONTRASTS = {
+    "density": ("dense", "sparse"),
+    "scale": ("small", "large"),
+    "shape": ("irregular", "regular"),
+    "occlusion": ("occluded", "clear"),
+}
 
 
 def torch_device(device: str) -> str:
@@ -137,11 +146,40 @@ def read_visdrone_occlusion(image_path: Path, ann_dir: Path | None) -> str:
     return "occluded" if ratio >= 0.3 else "clear"
 
 
-def scene_tags(labels: np.ndarray, dense_threshold: int, small_area: float, large_area: float) -> dict[str, str]:
+def derive_scene_thresholds(
+    labels_by_image: list[np.ndarray], quantile_low: float = 0.25, quantile_high: float = 0.75
+) -> dict[str, float]:
+    """Derive balanced, dataset-specific density and scale thresholds before model inference."""
+    if not 0 <= quantile_low < quantile_high <= 1:
+        raise ValueError(f"scene quantiles must satisfy 0 <= low < high <= 1, got {quantile_low}, {quantile_high}")
+    if not labels_by_image:
+        raise ValueError("cannot derive scene thresholds without labels")
+    counts = np.asarray([len(labels) for labels in labels_by_image], dtype=np.float64)
+    median_areas = np.asarray(
+        [float(np.median(labels[:, 3] * labels[:, 4])) for labels in labels_by_image if len(labels)], dtype=np.float64
+    )
+    if not len(median_areas):
+        raise ValueError("cannot derive scale thresholds from empty labels")
+    return {
+        "sparse_threshold": float(np.quantile(counts, quantile_low)),
+        "dense_threshold": float(np.quantile(counts, quantile_high)),
+        "small_area": float(np.quantile(median_areas, quantile_low)),
+        "large_area": float(np.quantile(median_areas, quantile_high)),
+    }
+
+
+def scene_tags(
+    labels: np.ndarray,
+    dense_threshold: float,
+    small_area: float,
+    large_area: float,
+    sparse_threshold: float | None = None,
+) -> dict[str, str]:
     count = int(labels.shape[0])
+    sparse_threshold = max(1.0, dense_threshold / 4) if sparse_threshold is None else sparse_threshold
     if count >= dense_threshold:
         density = "dense"
-    elif count <= max(1, dense_threshold // 4):
+    elif count <= sparse_threshold:
         density = "sparse"
     else:
         density = "medium"
@@ -163,12 +201,27 @@ def scene_tags(labels: np.ndarray, dense_threshold: int, small_area: float, larg
     return {"object_count": str(count), "density": density, "scale": scale, "shape": irregular}
 
 
+def letterbox_image(im: np.ndarray, imgsz: int, color: int = 114) -> np.ndarray:
+    """Resize without aspect-ratio distortion and center-pad to a square inference canvas."""
+    height, width = im.shape[:2]
+    if height <= 0 or width <= 0 or imgsz <= 0:
+        raise ValueError(f"invalid letterbox shape: image={im.shape}, imgsz={imgsz}")
+    scale = min(imgsz / height, imgsz / width)
+    new_width, new_height = int(round(width * scale)), int(round(height * scale))
+    if (new_width, new_height) != (width, height):
+        im = cv2.resize(im, (new_width, new_height), interpolation=cv2.INTER_LINEAR)
+    pad_w, pad_h = imgsz - new_width, imgsz - new_height
+    left, right = int(round(pad_w / 2 - 0.1)), int(round(pad_w / 2 + 0.1))
+    top, bottom = int(round(pad_h / 2 - 0.1)), int(round(pad_h / 2 + 0.1))
+    return cv2.copyMakeBorder(im, top, bottom, left, right, cv2.BORDER_CONSTANT, value=(color,) * 3)
+
+
 def preprocess(image_path: Path, imgsz: int, device: str) -> torch.Tensor:
     im = cv2.imread(str(image_path))
     if im is None:
         raise RuntimeError(f"failed to read image: {image_path}")
     im = cv2.cvtColor(im, cv2.COLOR_BGR2RGB)
-    im = cv2.resize(im, (imgsz, imgsz), interpolation=cv2.INTER_LINEAR)
+    im = letterbox_image(im, imgsz)
     tensor = torch.from_numpy(im).permute(2, 0, 1).float().unsqueeze(0) / 255.0
     return tensor.to(torch.device(device))
 
@@ -192,7 +245,8 @@ def save_heatmap(weights: torch.Tensor, out_dir: Path, stem: str, module_name: s
     safe_module = module_name.replace(".", "_")
     for idx, name in enumerate(EXPERT_NAMES):
         plt.figure(figsize=(4, 4))
-        plt.imshow(w[idx], cmap="magma")
+        image = plt.imshow(w[idx], cmap="magma", vmin=0.0, vmax=1.0)
+        plt.colorbar(image, fraction=0.046, pad=0.04, label="routing weight")
         plt.axis("off")
         plt.title(name)
         plt.tight_layout()
@@ -210,23 +264,167 @@ def write_csv(path: Path, rows: list[dict[str, str | float]]) -> None:
 
 
 def aggregate(rows: list[dict[str, str | float]]) -> list[dict[str, str | float]]:
-    groups: dict[tuple[str, str, str, str], list[dict[str, str | float]]] = defaultdict(list)
+    groups: dict[tuple[str, str, str, str, str], list[dict[str, str | float]]] = defaultdict(list)
     for row in rows:
-        groups[(str(row["density"]), str(row["scale"]), str(row["shape"]), str(row["occlusion"]))].append(row)
+        groups[
+            (
+                str(row["module"]),
+                str(row["density"]),
+                str(row["scale"]),
+                str(row["shape"]),
+                str(row["occlusion"]),
+            )
+        ].append(row)
     out = []
-    metric_keys = [f"{name}_mean_weight" for name in EXPERT_NAMES] + [f"{name}_top1_token_frac" for name in EXPERT_NAMES]
     for key, group in sorted(groups.items()):
         item: dict[str, str | float] = {
-            "density": key[0],
-            "scale": key[1],
-            "shape": key[2],
-            "occlusion": key[3],
+            "module": key[0],
+            "density": key[1],
+            "scale": key[2],
+            "shape": key[3],
+            "occlusion": key[4],
             "samples": len(group),
         }
-        for metric in metric_keys:
+        for metric in ROUTING_METRICS:
             vals = [float(row[metric]) for row in group if metric in row]
             item[metric] = float(np.mean(vals)) if vals else 0.0
         out.append(item)
+    return out
+
+
+def _image_level_values(
+    rows: list[dict[str, str | float]], factor: str, metric: str, module: str | None = None
+) -> dict[str, np.ndarray]:
+    """Average repeated layer records per image so tests use images, not layers, as independent samples."""
+    grouped: dict[tuple[str, str], list[float]] = defaultdict(list)
+    for row in rows:
+        if module is not None and str(row["module"]) != module:
+            continue
+        group = str(row[factor])
+        if group and metric in row:
+            grouped[(group, str(row["image"]))].append(float(row[metric]))
+    values: dict[str, list[float]] = defaultdict(list)
+    for (group, _image), samples in grouped.items():
+        values[group].append(float(np.mean(samples)))
+    return {group: np.asarray(samples, dtype=np.float64) for group, samples in values.items()}
+
+
+def aggregate_marginal(rows: list[dict[str, str | float]]) -> list[dict[str, str | float]]:
+    """Aggregate each scene factor separately, globally and per MoT block, at the image level."""
+    modules = sorted({str(row["module"]) for row in rows})
+    out: list[dict[str, str | float]] = []
+    for scope, module in [("global", None), *(("module", name) for name in modules)]:
+        for factor in SCENE_CONTRASTS:
+            by_metric = {metric: _image_level_values(rows, factor, metric, module) for metric in ROUTING_METRICS}
+            groups = sorted({group for values in by_metric.values() for group in values})
+            for group in groups:
+                item: dict[str, str | float] = {
+                    "scope": scope,
+                    "module": module or "all",
+                    "factor": factor,
+                    "group": group,
+                    "images": max((len(values.get(group, ())) for values in by_metric.values()), default=0),
+                }
+                for metric, values in by_metric.items():
+                    samples = values.get(group, np.empty(0))
+                    item[metric] = float(samples.mean()) if len(samples) else 0.0
+                out.append(item)
+    return out
+
+
+def _hedges_g(a: np.ndarray, b: np.ndarray) -> float:
+    """Bias-corrected standardized mean difference (positive means group A is higher)."""
+    n_a, n_b = len(a), len(b)
+    pooled_df = n_a + n_b - 2
+    if n_a < 2 or n_b < 2 or pooled_df <= 0:
+        return float("nan")
+    pooled_var = ((n_a - 1) * a.var(ddof=1) + (n_b - 1) * b.var(ddof=1)) / pooled_df
+    if pooled_var <= 0:
+        return 0.0 if float(a.mean()) == float(b.mean()) else float("inf")
+    correction = 1.0 - 3.0 / (4.0 * (n_a + n_b) - 9.0)
+    return float(correction * (a.mean() - b.mean()) / np.sqrt(pooled_var))
+
+
+def _bootstrap_difference_ci(
+    a: np.ndarray, b: np.ndarray, rng: np.random.Generator, n_resamples: int
+) -> tuple[float, float]:
+    """Return a percentile 95% bootstrap CI for the difference in image-level means."""
+    a_idx = rng.integers(0, len(a), size=(n_resamples, len(a)))
+    b_idx = rng.integers(0, len(b), size=(n_resamples, len(b)))
+    differences = a[a_idx].mean(axis=1) - b[b_idx].mean(axis=1)
+    low, high = np.quantile(differences, (0.025, 0.975))
+    return float(low), float(high)
+
+
+def _benjamini_hochberg(rows: list[dict[str, str | float]]) -> None:
+    """Add FDR-adjusted q-values in place across every valid scene contrast."""
+    valid = [(index, float(row["permutation_p"])) for index, row in enumerate(rows) if "permutation_p" in row]
+    if not valid:
+        return
+    ordered = sorted(valid, key=lambda item: item[1])
+    adjusted = [0.0] * len(ordered)
+    running = 1.0
+    for rank in range(len(ordered), 0, -1):
+        value = min(running, ordered[rank - 1][1] * len(ordered) / rank)
+        adjusted[rank - 1] = value
+        running = value
+    for (index, _), value in zip(ordered, adjusted):
+        rows[index]["fdr_q"] = float(value)
+
+
+def scene_contrasts(
+    rows: list[dict[str, str | float]], n_resamples: int = 10_000, seed: int = 42
+) -> list[dict[str, str | float]]:
+    """Compute global and per-layer scene contrasts with robust uncertainty and multiplicity control."""
+    from scipy.stats import permutation_test
+
+    rng = np.random.default_rng(seed)
+    modules = sorted({str(row["module"]) for row in rows})
+    metrics = ("DeformableTransformer_mean_weight", "DeformableTransformer_top1_token_frac")
+    out: list[dict[str, str | float]] = []
+
+    def mean_difference(a, b, axis=0):
+        return np.mean(a, axis=axis) - np.mean(b, axis=axis)
+
+    for scope, module in [("global", None), *(("module", name) for name in modules)]:
+        for factor, (group_a, group_b) in SCENE_CONTRASTS.items():
+            for metric in metrics:
+                grouped = _image_level_values(rows, factor, metric, module)
+                a, b = grouped.get(group_a, np.empty(0)), grouped.get(group_b, np.empty(0))
+                item: dict[str, str | float] = {
+                    "scope": scope,
+                    "module": module or "all",
+                    "factor": factor,
+                    "group_a": group_a,
+                    "group_b": group_b,
+                    "metric": metric,
+                    "n_a": len(a),
+                    "n_b": len(b),
+                }
+                if len(a) >= 2 and len(b) >= 2:
+                    ci_low, ci_high = _bootstrap_difference_ci(a, b, rng, n_resamples)
+                    result = permutation_test(
+                        (a, b),
+                        mean_difference,
+                        vectorized=True,
+                        n_resamples=n_resamples,
+                        batch=256,
+                        alternative="two-sided",
+                        rng=rng,
+                    )
+                    item.update(
+                        {
+                            "mean_a": float(a.mean()),
+                            "mean_b": float(b.mean()),
+                            "mean_difference": float(a.mean() - b.mean()),
+                            "ci95_low": ci_low,
+                            "ci95_high": ci_high,
+                            "hedges_g": _hedges_g(a, b),
+                            "permutation_p": float(result.pvalue),
+                        }
+                    )
+                out.append(item)
+    _benjamini_hochberg(out)
     return out
 
 
@@ -243,8 +441,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--dense-threshold", type=int, default=20)
     parser.add_argument("--small-area", type=float, default=0.01)
     parser.add_argument("--large-area", type=float, default=0.08)
+    parser.add_argument("--scene-quantiles", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--scene-quantile-low", type=float, default=0.25)
+    parser.add_argument("--scene-quantile-high", type=float, default=0.75)
     parser.add_argument("--visdrone-ann-dir", type=Path)
     parser.add_argument("--save-heatmaps", type=int, default=24)
+    parser.add_argument("--stats-resamples", type=int, default=10_000)
+    parser.add_argument("--stats-seed", type=int, default=42)
     return parser.parse_args()
 
 
@@ -254,6 +457,22 @@ def main() -> int:
     images = image_paths_from_source(args.source, args.limit) if args.source else image_paths_from_data(args.data, args.split, args.limit)
     if not images:
         raise SystemExit("no images found")
+
+    label_cache = {image_path: read_yolo_labels(image_path) for image_path in images}
+    if args.scene_quantiles:
+        thresholds = derive_scene_thresholds(
+            list(label_cache.values()), args.scene_quantile_low, args.scene_quantile_high
+        )
+        threshold_mode = "dataset_quantiles"
+    else:
+        thresholds = {
+            "sparse_threshold": float(max(1, args.dense_threshold // 4)),
+            "dense_threshold": float(args.dense_threshold),
+            "small_area": float(args.small_area),
+            "large_area": float(args.large_area),
+        }
+        threshold_mode = "fixed"
+    print(f"[routing] scene thresholds ({threshold_mode}): {thresholds}")
 
     yolo = YOLO(str(args.model))
     model = yolo.model.eval().to(torch.device(device))
@@ -272,8 +491,8 @@ def main() -> int:
             captures.clear()
             x = preprocess(image_path, args.imgsz, device)
             _ = model(x)
-            labels = read_yolo_labels(image_path)
-            tags = scene_tags(labels, args.dense_threshold, args.small_area, args.large_area)
+            labels = label_cache[image_path]
+            tags = scene_tags(labels, **thresholds)
             tags["occlusion"] = read_visdrone_occlusion(image_path, args.visdrone_ann_dir)
             for module_name, weights in captures:
                 row: dict[str, str | float] = {
@@ -293,11 +512,32 @@ def main() -> int:
         hook.remove()
 
     args.out.mkdir(parents=True, exist_ok=True)
-    write_csv(args.out / "routing_records.csv", rows)
-    write_csv(args.out / "routing_summary_by_scene.csv", aggregate(rows))
-    (args.out / "routing_summary_by_scene.json").write_text(
-        json.dumps(aggregate(rows), indent=2, ensure_ascii=False),
+    (args.out / "scene_thresholds.json").write_text(
+        json.dumps(
+            {
+                "mode": threshold_mode,
+                "quantile_low": args.scene_quantile_low if args.scene_quantiles else None,
+                "quantile_high": args.scene_quantile_high if args.scene_quantiles else None,
+                **thresholds,
+            },
+            indent=2,
+            ensure_ascii=False,
+        ),
         encoding="utf-8",
+    )
+    write_csv(args.out / "routing_records.csv", rows)
+    scene_summary = aggregate(rows)
+    marginal_summary = aggregate_marginal(rows)
+    contrasts = scene_contrasts(rows, n_resamples=args.stats_resamples, seed=args.stats_seed)
+    write_csv(args.out / "routing_summary_by_scene.csv", scene_summary)
+    write_csv(args.out / "routing_summary_marginal.csv", marginal_summary)
+    write_csv(args.out / "routing_scene_contrasts.csv", contrasts)
+    (args.out / "routing_summary_by_scene.json").write_text(
+        json.dumps(scene_summary, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    (args.out / "routing_scene_contrasts.json").write_text(
+        json.dumps(contrasts, indent=2, ensure_ascii=False), encoding="utf-8"
     )
     print(f"[routing] wrote {args.out}")
     return 0

--- a/scripts/benchmark_mot_checkpoints.py
+++ b/scripts/benchmark_mot_checkpoints.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Benchmark trained MoT ablation checkpoints on identical real images."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+import time
+from pathlib import Path
+
+import torch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from scripts.analyze_mot_routing import image_paths_from_data, letterbox_image  # noqa: E402
+from scripts.compare_mot_ablation import (  # noqa: E402
+    SPECS,
+    count_modules,
+    normalize_torch_device,
+    percentile,
+    sync_device,
+)
+from ultralytics import YOLO  # noqa: E402
+from ultralytics.nn.modules.moa import C2fMoA, MoABlock  # noqa: E402
+from ultralytics.nn.modules.mot import C2fMoT, MoTBlock  # noqa: E402
+
+import cv2  # noqa: E402
+
+
+def load_image_tensor(image_path: Path, imgsz: int, device: str) -> torch.Tensor:
+    """Load one image with detector-style letterboxing; preprocessing is excluded from latency."""
+    image = cv2.imread(str(image_path))
+    if image is None:
+        raise RuntimeError(f"failed to read image: {image_path}")
+    image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+    image = letterbox_image(image, imgsz)
+    tensor = torch.from_numpy(image).permute(2, 0, 1).contiguous().float().unsqueeze(0) / 255.0
+    return tensor.to(torch.device(device))
+
+
+def profile_image_flops(model: torch.nn.Module, tensor: torch.Tensor) -> float:
+    """Profile actual operations executed for one routed input and return GFLOPs."""
+    with torch.inference_mode(), torch.profiler.profile(with_flops=True) as profile:
+        model(tensor)
+    return float(sum(event.flops for event in profile.key_averages()) / 1e9)
+
+
+def benchmark_model(
+    model: torch.nn.Module,
+    image_paths: list[Path],
+    device: str,
+    imgsz: int,
+    warmup: int,
+    flops_images: int,
+) -> tuple[list[dict[str, str | float]], list[dict[str, str | float]]]:
+    """Measure synchronized model-only latency for every image and FLOPs for a fixed prefix."""
+    if not image_paths:
+        raise ValueError("benchmark requires at least one image")
+    if warmup < 0 or flops_images < 0:
+        raise ValueError("warmup and flops_images must be non-negative")
+    first = load_image_tensor(image_paths[0], imgsz, device)
+    with torch.inference_mode():
+        for _ in range(warmup):
+            model(first)
+            sync_device(device)
+
+    latency_rows: list[dict[str, str | float]] = []
+    flops_rows: list[dict[str, str | float]] = []
+    for index, image_path in enumerate(image_paths):
+        tensor = first if index == 0 else load_image_tensor(image_path, imgsz, device)
+        sync_device(device)
+        started = time.perf_counter()
+        with torch.inference_mode():
+            model(tensor)
+        sync_device(device)
+        latency_rows.append({"image": str(image_path), "latency_ms": (time.perf_counter() - started) * 1000.0})
+        if index < flops_images:
+            flops_rows.append({"image": str(image_path), "flops_g": profile_image_flops(model, tensor)})
+    return latency_rows, flops_rows
+
+
+def summarize_benchmark(
+    key: str,
+    checkpoint: Path,
+    model: torch.nn.Module,
+    latency_rows: list[dict[str, str | float]],
+    flops_rows: list[dict[str, str | float]],
+    device: str,
+    imgsz: int,
+    warmup: int,
+) -> dict[str, str | float | int]:
+    """Build one auditable summary row while retaining raw samples in separate tables."""
+    times = [float(row["latency_ms"]) for row in latency_rows]
+    flops = [float(row["flops_g"]) for row in flops_rows]
+    torch_device = torch.device(device)
+    return {
+        "key": key,
+        "label": SPECS[key].label,
+        "checkpoint": str(checkpoint),
+        "images": len(times),
+        "warmup": warmup,
+        "imgsz": imgsz,
+        "batch_size": 1,
+        "input_dtype": "float32",
+        "latency_scope": "model_forward_only_perf_counter_with_device_sync",
+        "latency_ms_mean": sum(times) / len(times),
+        "latency_ms_p50": percentile(times, 0.50),
+        "latency_ms_p95": percentile(times, 0.95),
+        "latency_ms_p99": percentile(times, 0.99),
+        "latency_ms_min": min(times),
+        "latency_ms_max": max(times),
+        "flops_images": len(flops),
+        "flops_g_mean": sum(flops) / len(flops) if flops else "",
+        "flops_g_min": min(flops) if flops else "",
+        "flops_g_max": max(flops) if flops else "",
+        "flops_method": "torch_profiler_actual_routed_input",
+        "params": sum(parameter.numel() for parameter in model.parameters()),
+        "params_m": sum(parameter.numel() for parameter in model.parameters()) / 1e6,
+        "moablocks": count_modules(model, MoABlock),
+        "c2fmoa": count_modules(model, C2fMoA),
+        "motblocks": count_modules(model, MoTBlock),
+        "c2fmot": count_modules(model, C2fMoT),
+        "device": device,
+        "device_name": torch.cuda.get_device_name(torch_device) if device.startswith("cuda") else device,
+        "torch_version": torch.__version__,
+        "cuda_version": str(torch.version.cuda or ""),
+        "cudnn_version": str(torch.backends.cudnn.version() or ""),
+    }
+
+
+def write_csv(path: Path, rows: list[dict[str, object]]) -> None:
+    """Write a nonempty row collection to CSV."""
+    if not rows:
+        raise ValueError(f"refusing to write empty benchmark table: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fields = list(dict.fromkeys(key for row in rows for key in row))
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project", type=Path, required=True, help="Project containing <model>/weights/best.pt.")
+    parser.add_argument("--models", nargs="+", choices=tuple(SPECS), default=["v10", "v10_mot", "v10_moa", "v10_moa_mot"])
+    parser.add_argument("--data", type=Path, required=True)
+    parser.add_argument("--split", default="val")
+    parser.add_argument("--device", default="0")
+    parser.add_argument("--imgsz", type=int, default=640)
+    parser.add_argument("--limit", type=int, default=0, help="0 benchmarks the complete split.")
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--flops-images", type=int, default=16)
+    parser.add_argument("--out", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    device = normalize_torch_device(args.device)
+    data = args.data.resolve()
+    images = image_paths_from_data(data, args.split, args.limit)
+    if not images:
+        raise SystemExit(f"no images found for {data}:{args.split}")
+
+    summaries = []
+    all_latency_rows: list[dict[str, object]] = []
+    all_flops_rows: list[dict[str, object]] = []
+    for key in args.models:
+        checkpoint = args.project.resolve() / key / "weights" / "best.pt"
+        if not checkpoint.exists():
+            raise FileNotFoundError(checkpoint)
+        model = YOLO(str(checkpoint)).model.eval().float().to(torch.device(device))
+        latency_rows, flops_rows = benchmark_model(
+            model, images, device, args.imgsz, args.warmup, args.flops_images
+        )
+        summaries.append(
+            summarize_benchmark(key, checkpoint, model, latency_rows, flops_rows, device, args.imgsz, args.warmup)
+        )
+        all_latency_rows.extend({"key": key, **row} for row in latency_rows)
+        all_flops_rows.extend({"key": key, **row} for row in flops_rows)
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    write_csv(args.out / "checkpoint_benchmark_summary.csv", summaries)
+    write_csv(args.out / "checkpoint_latency_samples.csv", all_latency_rows)
+    if all_flops_rows:
+        write_csv(args.out / "checkpoint_flops_samples.csv", all_flops_rows)
+    (args.out / "checkpoint_benchmark_summary.json").write_text(
+        json.dumps(summaries, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_mot.py
+++ b/tests/test_mot.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from ultralytics.engine.trainer import BaseTrainer
@@ -155,20 +156,19 @@ def test_mot_window_expert_handles_window_larger_than_feature_map():
 
 
 def test_mot_window_expert_shift_spatial_alignment():
-    """Shifted-window expert output must keep input spatial dims and stay finite.
-
-    The shift/un-shift residual alignment is the subtle correctness point: an
-    identity-ish check ensures no cyclic spatial misalignment leaks through.
-    """
+    """A zeroed shifted expert must be an exact identity even for odd H/W."""
     from ultralytics.nn.modules.mot.mot import _WindowTransformerExpert
 
     torch.manual_seed(0)
-    block = MoTBlock(32, num_heads=4, top_k=2, window_size=5, n_points=2, window_shift=True).eval()
+    expert = _WindowTransformerExpert(32, num_heads=4, window_size=5, shift_size=2).eval()
+    torch.nn.init.zeros_(expert.proj.weight)
+    torch.nn.init.zeros_(expert.ffn[-1].weight)
+    torch.nn.init.zeros_(expert.ffn[-1].bias)
     x = torch.randn(2, 32, 9, 11)
     with torch.no_grad():
-        out, _ = block(x)
+        out = expert(x)
     assert out.shape == x.shape
-    assert torch.isfinite(out).all()
+    assert torch.equal(out, x)
 
 
 def test_mot_window_expert_shift_handles_odd_spatial_sizes():
@@ -181,6 +181,17 @@ def test_mot_window_expert_shift_handles_odd_spatial_sizes():
         out = expert(x)
     assert out.shape == x.shape
     assert torch.isfinite(out).all()
+
+
+def test_mot_window_expert_preserves_and_validates_explicit_shift():
+    """The public shift argument must not be silently replaced by win//2."""
+    from ultralytics.nn.modules.mot.mot import _WindowTransformerExpert
+
+    assert _WindowTransformerExpert(16, num_heads=4, window_size=7, shift_size=1).shift_size == 1
+    with pytest.raises(ValueError, match="window_size must be positive"):
+        _WindowTransformerExpert(16, num_heads=4, window_size=0)
+    with pytest.raises(ValueError, match="shift_size must satisfy"):
+        _WindowTransformerExpert(16, num_heads=4, window_size=7, shift_size=7)
 
 
 def test_mot_router_disables_exploration_eps_in_eval():

--- a/tests/test_mot_checkpoint_benchmark.py
+++ b/tests/test_mot_checkpoint_benchmark.py
@@ -1,0 +1,56 @@
+"""Tests for trained-checkpoint, real-image MoT benchmarking."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+import torch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/benchmark_mot_checkpoints.py"
+
+
+def load_script():
+    spec = importlib.util.spec_from_file_location("_mot_checkpoint_benchmark_test", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_checkpoint_benchmark_uses_all_real_images_and_preserves_grad_mode(tmp_path, monkeypatch):
+    module = load_script()
+    paths = []
+    for index, shape in enumerate(((20, 40), (40, 20), (30, 30))):
+        path = tmp_path / f"image_{index}.jpg"
+        cv2.imwrite(str(path), np.full((*shape, 3), 127, dtype=np.uint8))
+        paths.append(path)
+    model = torch.nn.Conv2d(3, 4, 1).eval()
+    monkeypatch.setattr(module, "profile_image_flops", lambda _model, _tensor: 0.001)
+    torch.set_grad_enabled(True)
+
+    latency, flops = module.benchmark_model(model, paths, "cpu", imgsz=32, warmup=1, flops_images=2)
+
+    assert torch.is_grad_enabled()
+    assert [Path(row["image"]).name for row in latency] == [path.name for path in paths]
+    assert all(float(row["latency_ms"]) > 0 for row in latency)
+    assert len(flops) == 2
+    summary = module.summarize_benchmark("v10", tmp_path / "best.pt", model, latency, flops, "cpu", 32, 1)
+    assert summary["images"] == 3
+    assert summary["flops_images"] == 2
+    assert summary["latency_ms_p50"] > 0
+
+
+@pytest.mark.parametrize("warmup,flops", [(-1, 0), (0, -1)])
+def test_checkpoint_benchmark_rejects_invalid_sampling(tmp_path, warmup, flops):
+    module = load_script()
+    path = tmp_path / "image.jpg"
+    cv2.imwrite(str(path), np.zeros((8, 8, 3), dtype=np.uint8))
+    with pytest.raises(ValueError, match="must be non-negative"):
+        module.benchmark_model(torch.nn.Identity(), [path], "cpu", 8, warmup, flops)

--- a/tests/test_mot_routing_analysis.py
+++ b/tests/test_mot_routing_analysis.py
@@ -1,0 +1,97 @@
+"""Statistical regression tests for real-image MoT routing analysis."""
+
+import numpy as np
+import pytest
+
+from scripts.analyze_mot_routing import (
+    aggregate,
+    aggregate_marginal,
+    derive_scene_thresholds,
+    letterbox_image,
+    scene_contrasts,
+    scene_tags,
+)
+
+
+def synthetic_rows():
+    rows = []
+    for index in range(40):
+        high = index < 20
+        for module_index, module in enumerate(("model.5.m.0", "model.8.m.0")):
+            deform = (0.8 if high else 0.2) + module_index * 0.01
+            rows.append(
+                {
+                    "image": f"image_{index}.jpg",
+                    "module": module,
+                    "density": "dense" if high else "sparse",
+                    "scale": "small" if high else "large",
+                    "shape": "irregular" if high else "regular",
+                    "occlusion": "occluded" if high else "clear",
+                    "LocalConvTransformer_mean_weight": 1.0 - deform,
+                    "LocalConvTransformer_top1_token_frac": 1.0 - deform,
+                    "WindowTransformer_mean_weight": 0.0,
+                    "WindowTransformer_top1_token_frac": 0.0,
+                    "DeformableTransformer_mean_weight": deform,
+                    "DeformableTransformer_top1_token_frac": deform,
+                }
+            )
+    return rows
+
+
+def test_scene_aggregation_preserves_layer_identity_and_image_counts():
+    rows = synthetic_rows()
+    joint = aggregate(rows)
+    marginal = aggregate_marginal(rows)
+
+    assert {row["module"] for row in joint} == {"model.5.m.0", "model.8.m.0"}
+    global_occlusion = [
+        row for row in marginal if row["scope"] == "global" and row["factor"] == "occlusion"
+    ]
+    assert {row["images"] for row in global_occlusion} == {20}
+
+
+def test_letterbox_preserves_aspect_ratio_and_centers_padding():
+    image = np.full((100, 200, 3), 255, dtype=np.uint8)
+
+    output = letterbox_image(image, 640)
+
+    assert output.shape == (640, 640, 3)
+    assert np.all(output[:160] == 114)
+    assert np.all(output[160:480] == 255)
+    assert np.all(output[480:] == 114)
+
+
+def test_scene_quantiles_create_reproducible_balanced_thresholds():
+    labels = []
+    for count, area in ((1, 0.001), (2, 0.004), (10, 0.02), (20, 0.08)):
+        rows = np.zeros((count, 5), dtype=np.float32)
+        rows[:, 3] = np.sqrt(area)
+        rows[:, 4] = np.sqrt(area)
+        labels.append(rows)
+
+    thresholds = derive_scene_thresholds(labels, 0.25, 0.75)
+
+    assert thresholds["sparse_threshold"] == pytest.approx(1.75)
+    assert thresholds["dense_threshold"] == pytest.approx(12.5)
+    assert scene_tags(labels[0], **thresholds)["density"] == "sparse"
+    assert scene_tags(labels[-1], **thresholds)["density"] == "dense"
+    assert scene_tags(labels[0], **thresholds)["scale"] == "small"
+    assert scene_tags(labels[-1], **thresholds)["scale"] == "large"
+
+
+def test_scene_contrasts_report_effect_uncertainty_permutation_and_fdr():
+    contrasts = scene_contrasts(synthetic_rows(), n_resamples=499, seed=7)
+    result = next(
+        row
+        for row in contrasts
+        if row["scope"] == "global"
+        and row["factor"] == "occlusion"
+        and row["metric"] == "DeformableTransformer_mean_weight"
+    )
+
+    assert result["n_a"] == result["n_b"] == 20
+    assert result["mean_difference"] > 0.5
+    assert result["ci95_low"] > 0
+    assert result["hedges_g"] > 5
+    assert result["permutation_p"] <= 0.01
+    assert result["fdr_q"] <= 0.05

--- a/ultralytics/nn/modules/mot/mot.py
+++ b/ultralytics/nn/modules/mot/mot.py
@@ -211,12 +211,18 @@ class _WindowTransformerExpert(nn.Module):
                  shift_size: int = 0):
         super().__init__()
         assert dim % num_heads == 0
+        if window_size <= 0:
+            raise ValueError(f"window_size must be positive, got {window_size}")
+        if not 0 <= shift_size < window_size:
+            raise ValueError(
+                f"shift_size must satisfy 0 <= shift_size < window_size, got {shift_size} and {window_size}"
+            )
         self.num_heads = num_heads
         self.head_dim = dim // num_heads
         self.scale = self.head_dim ** -0.5
         self.win = window_size
-        # Fixed cyclic shift (0 = regular window, win//2 = shifted window).
-        self.shift_size = (window_size // 2) if shift_size else 0
+        # Fixed cyclic shift supplied by the caller (0 = regular window).
+        self.shift_size = int(shift_size)
 
         self.qkv = nn.Linear(dim, dim * 3, bias=False)
         self.proj = nn.Linear(dim, dim, bias=False)

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1768,6 +1768,8 @@ def parse_model(d, ch, verbose=True):
             C2PSA,
             A2C2f,
             A2C2fMoE,
+            C2fMoA,
+            C2fMoT,
             WaveC2f,
             DyC2f,
             A3C2f,
@@ -1810,6 +1812,8 @@ def parse_model(d, ch, verbose=True):
                 if scale in "lx":  # for L/X sizes
                     args.extend((True, 1.2))
             if m is A2C2fMoE:
+                legacy = False
+            if m is C2fMoA or m is C2fMoT:
                 legacy = False
             if m is C2fCIB:
                 legacy = False


### PR DESCRIPTION
## Summary

This PR delivers the reviewable code portion of Tencent/YOLO-Master Issue #54:

- fix `C2fMoA`/`C2fMoT` model parsing so repeat counts are inserted correctly instead of shifting MoT YAML arguments;
- preserve and validate the explicit shifted-window offset in `_WindowTransformerExpert`;
- extend real-image MoT routing analysis with detector-style letterboxing, dataset-derived scene groups, per-layer heatmaps, image-level aggregation, bootstrap confidence intervals, permutation tests, Hedges' g, and BH-FDR correction;
- add trained-checkpoint benchmarking that retains raw P50/P95/P99 latency samples, profiles actually executed routed FLOPs, and reports parameter/module counts and runtime metadata.

## Why

Issue #54 asks for reproducible MoT/MoA/EsMoE ablation, real latency/FLOPs measurement, expert-routing explainability, and explicit boundary coverage. During validation, two correctness defects were confirmed:

1. `C2fMoA` and `C2fMoT` were absent from `repeat_modules`, so model YAML repeat counts could shift positional arguments (for example, interpreting `window_size=7` as `top_k=7`).
2. `_WindowTransformerExpert` replaced every nonzero explicit shift with `window_size // 2`, silently ignoring the caller's requested value.

The routing script also resized images by distortion and could treat multiple layer rows from one image as independent samples. The updated analysis preserves aspect ratio and uses the image as the statistical unit.

## Experimental outcome

The complete VisDrone experiment used seed 42, 640 px, batch 16, FP32, and 300 epochs for EsMoE, MoT, MoA, and MoA+MoT. EsMoE was the strongest measured model at 0.19937 mAP50-95 and 16.92 ms P50. Neither the heavy mixture nor the preregistered lightweight candidates met the Issue #54 synergy threshold.

Because no hybrid candidate produced stable meaningful gain, this PR intentionally does **not** add the experimental YAMLs as recommended configurations. The full negative result, routing contrasts, and deployment recommendations are published separately in the linked GitHub Discussion.

## Validation

- clean-worktree focused suite: `22 passed`;
- Ruff on all changed scripts and tests: passed;
- explicit coverage includes oversized windows, odd shifted spatial sizes, caller-provided shift validation, and eval-time disabling of `exploration_eps`;
- formal evidence: four contiguous finite 300-epoch runs, 24/24 milestone audits, seven 548-image latency benchmarks, and five all-image/all-layer MoT routing matrices.

Related to #54.
