### PR TITLE
feat(p2,uomoe): add P2 and UoMoE nano variants to the reproduction scripts

### DIFF
--- a/scripts/reproduce/README.md
+++ b/scripts/reproduce/README.md
@@ -23,9 +23,21 @@ Weights:
 
 Below is a comprehensive guide on how to reproduce the full training pipeline
 
-### 🚀 Update: New dataset: AI-TOD-v2
+---
 
-[AI-TOD-v2](https://github.com/Chasel-Tsui/AI-TOD-v2) is a much harder aerial **tiny-object** benchmark: 8 classes, ~800px crops, **mean object size ≈ 12px**, and a heavy class imbalance (one class dominates ~88% of the boxes). It pushes the two nano variants well past VisDrone/SKU-110K, and cleanly exposes a difference between their two MoE designs.
+### 🚀 Updates (Latest First)
+- **⭐️ 2026-07-19: Optimized P2 and UoMoE Models for Tiny Object Detection:** Four new nano variants (`v0.1-P2`, `EsMoE-P2`, `UoMoE`, `UoMoE-P2`) that attack the sub-8px floor from two orthogonal angles — a stride-4 **P2 head** (spatial resolution) and **UoMoE** routing (feature/compute allocation). `UoMoE-N`, `v0.1-P2-N` and `UoMoE-P2-N` are the only real-time N-tier detectors to break **≥20% AP on AI-TOD-v2**, outperforming YOLOv12-X by ~5 AP at ~10% of its FLOPs. See [this section](#6-p2--uomoe-variants-for-tiny-object-detection).
+- **⚡️ 2026-07-18: Multi-GPU DDP Training:** All baseline models and datasets now support DDP training with up to **8 GPUs**. See [this section](#new-ddp-training).
+- **🔎 2026-07-14: AI-TOD-v2 Dataset:** [AI-TOD-v2](https://github.com/Chasel-Tsui/AI-TOD-v2) is a much harder aerial **tiny-object** benchmark: 8 classes, ~800px crops, **mean object size ≈ 12px**, and a heavy class imbalance (one class dominates ~88% of the boxes). It pushes the two nano variants well past VisDrone/SKU-110K, and cleanly exposes a difference between their two MoE designs. See [this section](#new-ddp-training).
+
+## Table of Contents
+- [1. Setup](#1-setup)
+- [2. Dataset Download](#2-dataset-download)
+- [3. Training](#3-training)
+  - [⚡️ (NEW!) DDP Training](#new-ddp-training)
+- [4. Known issues + solutions/takeaways](#4-known-issues--solutionstakeaways)
+- [5. Directory for Run logs](#5-directory-for-run-logs)
+- [6. P2 & UoMoE Variants for Tiny Object Detection](#p2--uomoe-variants-for-tiny-object-detection)
 
 ## 1. Setup
 
@@ -124,16 +136,13 @@ A training of 100 epochs can already achieve a high mAP. **Only train for 300 or
 
 ---
 
-### ⚡️(NEW!) DDP Training
-The default scripts `reproduce_visdrone.py`, `reproduce_sku110k.py`, and `reproduce_aitodv2.py` only work with a single GPU. Here, we also provide a script dedicated to distributed training. It is compatible with both baseline models (`v0.1-N` and `EsMoE-N`) and the three datasets in the default scripts, and runs smoothly on NVIDIA's mainstream datacenter GPUs (we have tested A100, H100, H200, and B200).
+### (NEW!) DDP Training 
+The default scripts `reproduce_visdrone.py`, `reproduce_sku110k.py`, and `reproduce_aitodv2.py` only work with single GPU. Here, we also provide a script dedicated for distributed training. It's compatible with all of three models and the three datasets in the default scripts and runs smoothly on NVIDIA's mainstream datacenter GPUs (we have tested A100, H100, H200, and B200). 
 
-> **Note:** it runs **within a single node** only, and will not work across multiple physical servers even if they are joined by an InfiniBand switch.
+> Note: it can only run **within** the node and will not work accross multiple physical servers even if they joined by an IB switch. 
 
-#### Commands
-
-Multi-GPU DDP is triggered by a **comma-separated `--device`** with **≥ 2 GPUs**. `--batch` is the **total** batch, split evenly across the GPUs.
-
-```bash
+Commands
+```
 # VisDrone — EsMoE-N on 4 GPUs
 python scripts/reproduce/reproduce_ddp.py --dataset VisDrone --model EsMoE-N \
     --device 0,1,2,3 --batch 128 --epochs 300 --no-sparse-eval --workers 0
@@ -142,28 +151,28 @@ python scripts/reproduce/reproduce_ddp.py --dataset VisDrone --model EsMoE-N \
 python scripts/reproduce/reproduce_ddp.py --dataset SKU-110K --model v0.1-N \
     --device 0,1 --batch 64 --epochs 300 --workers 0
 
-# AI-TOD-v2 — v0.1-N on 8 GPUs (imgsz auto-set to 800)
-python scripts/reproduce/reproduce_ddp.py --dataset AI-TOD-v2 --model v0.1-N \
+# AI-TOD-v2 — UoMoE-N on 8 GPUs (imgsz auto-set to 800)
+python scripts/reproduce/reproduce_ddp.py --dataset AI-TOD-v2 --model UoMoE-N \
     --device 0,1,2,3,4,5,6,7 --batch 256 --epochs 300 --workers 0
 
-# Train both models on a dataset, sequentially
-python scripts/reproduce/reproduce_ddp.py --dataset VisDrone --model both --device 0,1,2,3 --batch 128 --workers 0
+# Train every model on a dataset, sequentially
+python scripts/reproduce/reproduce_ddp.py --dataset VisDrone --model all --device 0,1,2,3 --batch 128 --workers 0
 
-# Preview the plan without launching (or validate the model builds with --check-build)
-python scripts/reproduce/reproduce_ddp.py --dataset VisDrone --model EsMoE-N --device 0,1 --dry-run
+# Preview the plan without launching (also validates the model builds with --check-build)
+python scripts/reproduce/reproduce_ddp.py --dataset VisDrone --model UoMoE-N --device 0,1 --dry-run
 ```
 
 **Key flags**
-
+  
 | Flag | Meaning |
 | --- | --- |
 | `--dataset` | `VisDrone` / `SKU-110K` / `AI-TOD-v2` |
-| `--model` | `v0.1-N`, `EsMoE-N`, or `both` |
-| `--device` | comma-separated GPU ids, **≥ 2** (single GPU / CPU is refused) |
+| `--model` | `v0.1-N`, `EsMoE-N`, `UoMoE-N`, `UoMoE-P2-N`, `EsMoE-P2-N`, `v0.1-P2-N`, or `all` |
+| `--device` | comma-separated GPU ids, **≥ 2** (single GPU/CPU is refused) |
 | `--batch` | **total** batch across all GPUs (keep it divisible by the GPU count) |
-| `--no-sparse-eval` | corrected dense evaluation for `EsMoE-N` (no-op for `v0.1-N`) |
+| `--no-sparse-eval` | corrected dense evaluation for the ES_MOE models (no-op for the rest) |
 | `--lr0` / `--optimizer` | LR override for large-batch scaling (e.g. `--lr0 0.04` at large batch; forces SGD) |
-| `--cache ram \| disk` | cache decoded images in RAM or on disk; omit to read on the fly |
+ `--cache ram \| disk` | cache decoded images in RAM or on disk; omit to read on the fly |
 | `--workers` | dataloader workers **per GPU** (see note below) |
 
 > **Tip — `--workers 0`:** on the Python 3.14 stack, dataloader worker processes can stall DDP setup on some hosts. `--workers 0` loads data in the main process (a little slower per step) and is the reliable default; you can increase it once a run is confirmed stable.
@@ -202,7 +211,7 @@ python scripts/reproduce/reproduce_ddp.py --dataset VisDrone --model EsMoE-N --d
 
 ***Expected qualitative trend: `--no-sparse-eval` lifts `EsMoE-N` from collapsed (VisDrone) / far-below-baseline (SKU-110K) up to outperform the `v0.1-N` mAP, only with ~1/3 of its parameters. However, it may not help on AI-TOD-v2 since the rounting mechanism itself is incapable of handling it.***
 
-## 4. Known issues + solutions/takeaways ‼️Very important‼️
+## 4. Known issues + solutions/takeaways
 
 ### 1. **`EsMoE-N` validation mAP collapses on VisDrone & SKU-110k (ES_MOE sparse inference)**
 
@@ -291,5 +300,142 @@ runs/reproduce/<dataset>/summary.csv
 ```
 
 aggregates the final metrics for both models, including a `dense_eval` column that records whether `--no-sparse-eval` was applied.
+
+## 6. P2 & UoMoE Variants for Tiny Object Detection
+
+This formally integrates the improved models in issues [#98](https://github.com/Tencent/YOLO-Master/issues/98) & [#126](https://github.com/Tencent/YOLO-Master/issues/126). 
+
+Four additional nano models, `v0.1-P2`, `EsMoE-P2`, `UoMoE` and `UoMoE-P2` derived from the two baselines, now available on every dataset and every reproduce script. Same recipe as the baselines (`optimizer=auto` → SGD@0.01, `lora_r=0`, `deterministic`, `seed 42`, `patience 0`); just pass `--model <name>`.
+
+<img width="1821" height="1090" alt="model_evolution" src="https://github.com/user-attachments/assets/648ea44c-460a-4190-870b-d79c1ad47b28" />
+
+
+### How and Why they works?
+
+**Two independent levers on the tiny-object floor.** Both families attack the same failure mode — sub-8 px targets that a standard detector cannot recover — but from different angles. The **P2/stride-4 head** is a *spatial-resolution* fix (#98), and **UoMoE** (`UltraOptimizedMoE`) is a *feature/compute-allocation* fix (#126).
+
+#### Optimization 1: P2 — spatial resolution ([Issue #98](https://github.com/Tencent/YOLO-Master/issues/98))
+
+The stock head predicts on P3/P4/P5 (stride 8/16/32). Detection quality scales with an object's grid footprint, `footprint = object_px / stride`, so a 7 px object at 640 lands on ≈0.9 of a P3 cell and stays sub-grid — unlearnable no matter how good the features. Adding a stride-4 head halves the finest stride and doubles that footprint, moving tiny targets into the learnable regime. The P2 head is a pure neck/head extension (backbone untouched): the FPN top-down path is carried one level further to stride-4, the PAN bottom-up path is re-rooted at P2, and `Detect` becomes 4-level `(P2, P3, P4, P5)`.
+
+VisDrone, imgsz 640, 300 epochs, dense eval (`--no-sparse-eval`) for EsMoE models:
+
+| Model | Params | GFLOPs@640 | mAP50 | mAP50-95 | W&B Runs |
+|---|---|---|---|---|---|
+| EsMoE-N (baseline) | 2.69 M | 8.8 | 0.350 | 0.203 | [View](https://wandb.ai/yolo-master-reproduce/yolo-master-reproduce/runs/6rsdhsn9) |
+| **EsMoE-N-P2** | **2.81 M** (+4.4%) | **12.2** | **0.381 (+0.031)** | **0.225 (+0.022)** | [View](https://wandb.ai/yolo-master-reproduce/yolo-master-reproduce/runs/s44aqxgp) |
+| v0.1-N (baseline) | 7.52 M | 9.9 | 0.344 | 0.201 | [View](https://wandb.ai/yolo-master-reproduce/yolo-master-reproduce/runs/rbmyjy6b) | 
+| v0.1-N-P2 | 7.67 M | 14.7 | 0.369 (+0.025) | 0.218 (+0.017) | [View](https://wandb.ai/yolo-master-reproduce/yolo-master-reproduce/runs/qkf5d0je) |
+
+The per-class Δ is the textbook finer-head fingerprint — gains concentrate on the smallest classes and the largest class regresses slightly:
+
+| Class | Size | v0.1-N | v0.1-N-P2 | Δ | EsMoE-N | EsMoE-N-P2 | Δ |
+|---|---|---|---|---|---|---|---|
+| people | tiny |0.106 | 0.136 | +0.030 | 0.101 | 0.143 | **+0.042** |
+| pedestrian | tiny |0.160 | 0.198 | +0.038 | 0.165 | 0.203 | **+0.038** |
+| motor | tiny/small | 0.164 | 0.190 | +0.026 | 0.166 | 0.200 | **+0.034** |
+| car | small |0.533 | 0.566 | +0.033 | 0.538 | 0.572 | **+0.033** |
+| bus | medium |0.329 | 0.346 | +0.017 | 0.351 | 0.378 | **+0.027** |
+| bicycle | tiny/small |0.038 | 0.047 | +0.009 | 0.036 | 0.059 | **+0.022** |
+| awning-tricycle | tiny/small | 0.091 | 0.092 | +0.001 | 0.073 | 0.093 | **+0.021** |
+| van | small| 0.278 | 0.293 | +0.015 | 0.278 | 0.296 | **+0.018** |
+| tricycle | tiny/small |0.117 | 0.131 | +0.014 | 0.122 | 0.136 | **+0.014** |
+| truck | medium/large | 0.198 | 0.191 | −0.007 | 0.205 | 0.184 | **−0.021** |
+
+| Comparison | Visualization |
+| --- | --- |
+| Es-MoE-N-P2 vs EsMoE-N | <img width="2383" height="875" alt="Image" src="https://github.com/user-attachments/assets/d264c8f4-b2c2-4cb8-9bdc-c7881e77c940" /> |
+| v0.1-N-P2 vs v0.1-N | <img width="2383" height="875" alt="Image" src="https://github.com/user-attachments/assets/ce3aaf2c-a496-4296-9b33-3aba7beba27a" /> |
+
+Because imgsz and stride are *substitutes* (raising input resolution raises `object_px` proportionally), P2 is a low-resolution optimization: at 640 it clearly wins, but at 1280 the pixels already supply the footprint and the gain collapses to ~+0.8 mAP50. Evaluate and deploy at 640 (the real-time regime). Adding P2 also keeps the model firmly sub-S-tier — N→P2 costs +4.8 GFLOPs whereas N→S costs +24.8 GFLOPs (~1/5 of a scale-up), and it targets the tiny-object bottleneck that scaling up does not:
+
+| Model | Params | GFLOPs@640 | Stride-4 head? |
+|---|---|---|---|
+| **EsMoE-N-P2** | 2.8 M | **12.2** | ✅ |
+| v0.1-N-P2 | 7.7 M | 14.7 | ✅ |
+| YOLO11-S | 9.5 M | 21.7 | ✗ |
+| YOLO12-S | 9.3 M | 21.7 | ✗ |
+| YOLOv10-S | 8.1 M | 25.1 | ✗ |
+| YOLOv8-S | 11.2 M | 28.8 | ✗ |
+| YOLO-Master-S | 29.2 M | 34.7 | ✗ |
+
+#### Optimization2: UoMoE — feature/compute allocation ([Issue #126](https://github.com/Tencent/YOLO-Master/issues/126))
+
+Replacing v0.1-N's three `ModularRouterExpertMoE` blocks with `UltraOptimizedMoE` (backbone/head unchanged, identical `[out, num_experts, top_k]`) is a pure architecture win — neither more resolution nor more compute, just better routing of expert compute to densely-packed tiny-object regions, i.e. higher feature quality read out on the *same* grid.
+
+AI-TOD-v2 test split (14,018 imgs / 376,121 anns, 8 classes, mean object ~12 px; imgsz 800, 300 epochs):
+
+| model | params (M) | GFLOPs@800 | AP | AP50 | AP75 | AP_vt | AP_t | AP_s | AP_m | Weights | 
+|---|---|---|---|---|---|---|---|---|---|---|
+| v0.1-N | 7.52 | 14.65 | 11.0 | 27.0 | 6.7 | 3.6 | 10.9 | 14.6 | 19.1 | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/yolo-master-v01-n-aitodv2.pt) |
+| **UoMoE-N** | 7.42 | 14.61 | **20.6** | **47.0** | **14.5** | 5.9 | **18.9** | **28.0** | **35.1** | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.1/yolo-master-uomoe-n-aitodv2.pt) |
+| v0.1-P2-N | 7.60 | 20.95 | **21.4** | **48.6** | **15.0** | 7.8 | **21.1** | 27.2 | 32.7 | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.1/yolo-master-v01-p2-n-aitodv2.pt) |
+| UoMoE-P2-N | 7.50 | 20.91 | 21.1 | 47.8 | 14.7 | **8.6** | 20.4 | **27.6** | **33.8** | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.1/yolo-master-uomoe-p2-n-aitodv2.pt) |
+| YOLOv12-X | 59.3 | 185.4 | 16.1 | 33.5 | 13.4 | 5.4 | 17.0 | 21.4 | 28.5 | N/A |
+
+`UoMoE-N` jumps **+9.6 AP / +20.0 AP50** over `v0.1-N` at *fewer* params (7.42 vs 7.52 M) and iso-FLOPs (14.61 vs 14.65 GF).
+
+<img width="1300" height="845" alt="Image" src="https://github.com/user-attachments/assets/52991fcb-b5ae-4f9a-8560-23a556de4163" />
+
+**Based on the experiments above, v0.1-P2-N, UoMoE-N and UoMoE-P2-N are by far the only three real-time N-tier detectors which achieved ≥20% AP on the AI-TOD-v2 benchmark, outperforming YOLOv12-X by ~5 points AP with approx. 8~11% of its FLOPs.**
+
+#### How they interact - orthogonal on a weak base, substitutive on a strong one
+
+The two fixes target the *same* tiny-object bottleneck through different terms (P2 = sampling density, MoE = feature quality), so whether they compound depends on how much of that bottleneck the MoE has already closed:
+
+- **Weak base → they stack.** With ES-MoE (#98, VisDrone) P2 and MoE fix orthogonal gaps and add up: `EsMoE-N-P2` beats both the MoE-only and the P2-on-dense-backbone models (0.381 mAP50 at 2.8 M params / 12.2 GFLOPs).
+- **Strong base → P2 is largely redundant.** On AI-TOD-v2 (#126) P2 lifts the weak MoE (`v0.1-N`) by **+21.6 AP50** (27.0→48.6) but the strong `UoMoE-N` by only **+0.8** (47.0→47.8) — the stronger router has already resolved most of what the finer grid would have recovered. P2's residual value is confined entirely to the very-tiny (<8 px) bin (AP_vt 5.9→8.6, +2.7), making `UoMoE-P2-N` the best AP_vt of all four while flat elsewhere.
+
+**Practical takeaway.** `UoMoE-N` (no P2, 14.6 GF) lands within 1.6 AP50 of `v0.1-P2-N` (21.0 GF) — P2-variant-level accuracy at ~30% fewer FLOPs and no extra head. Pick `UoMoE-N` for the best accuracy/FLOPs trade-off; add P2 only when the <8 px bin is the priority.
+
+> **Reproducibility note:** `ultralytics.utils.torch_utils.get_flops` profiles an uninitialised `torch.empty` 32×32 input scaled ×625, which for input-dependent MoE triggers a different expert mix each call and makes identical runs report different GFLOPs (one UoMoE eval swung from 10.7 to 14.7). All FLOPs above are forced to a deterministic full-res measure.
+
+### Model Specs
+
+| Name | Derived from | Params | Notes |
+|---|---|---|---|
+| `v0.1-P2-N` | `v0.1-N` + P2/4 head | 7.60M | tiny-object variant |
+| `EsMoE-P2-N` | `EsMoE-N` + P2/4 head | 2.81M | tiny-object; **needs `--no-sparse-eval`** |
+| `UoMoE-N` | `v0.1-N`, MoE blocks → UltraOptimizedMoE | 7.42M | ~20–30% fewer GFLOPs at equal params |
+| `UoMoE-P2-N` | `UoMoE-N` + P2/4 head | 7.50M | UoMoE + tiny-object head |
+
+> **`--no-sparse-eval`** matters only for `EsMoE-P2-N` (an ES_MOE model): its default sparse eval
+> collapses mAP, so pass the flag for correct dense evaluation. It is a no-op for the v0.1/UoMoE variants.
+
+Sanity-check (instant, no training):
+
+```bash
+python scripts/reproduce/reproduce_visdrone.py --check-build --model UoMoE-P2-N
+```
+
+### Training Commands
+
+
+#### Single-GPU / per-dataset scripts
+
+```bash
+# P2 variants
+python scripts/reproduce/reproduce_aitodv2.py  --model v0.1-P2-N  --epochs 300 --batch 64
+python scripts/reproduce/reproduce_aitodv2.py  --model EsMoE-P2-N --epochs 300 --batch 64 --no-sparse-eval
+
+# UoMoE variants
+python scripts/reproduce/reproduce_visdrone.py --model UoMoE-N    --epochs 300 --batch 64
+python scripts/reproduce/reproduce_visdrone.py --model UoMoE-P2-N --epochs 300 --batch 64
+```
+
+#### Multi-GPU DDP (`reproduce_ddp.py`)
+
+`--device` must list ≥2 GPUs; `--batch` is the TOTAL across GPUs. Use `--workers 0` on the py-3.14 stack.
+
+```bash
+python scripts/reproduce/reproduce_ddp.py --dataset AI-TOD-v2 --model v0.1-P2-N  --device 0,1,2,3 --batch 128 --workers 0
+python scripts/reproduce/reproduce_ddp.py --dataset AI-TOD-v2 --model EsMoE-P2-N --device 0,1,2,3 --batch 128 --no-sparse-eval --workers 0
+python scripts/reproduce/reproduce_ddp.py --dataset VisDrone  --model UoMoE-N    --device 0,1,2,3 --batch 128 --workers 0
+python scripts/reproduce/reproduce_ddp.py --dataset VisDrone  --model UoMoE-P2-N --device 0,1     --batch 512 --lr0 0.04 --workers 0
+```
+
+> SKU-110K is *large-object-dense* dataset — the P2/UoMoE variants are provided for completeness there but are not tuned/tested on that dataset.
+
+---
 
 **Should you have any questions or doubts, feel free to make a comment or contact: rlici@connect.ust.hk**

--- a/scripts/reproduce/_reproduce_common.py
+++ b/scripts/reproduce/_reproduce_common.py
@@ -71,10 +71,27 @@ class DatasetSpec:
     project: str       # e.g. "runs/reproduce/visdrone"
 
 
-# Both datasets train the same two models. EsMoE-N gets dense validation.
+# The two shared nano baselines. EsMoE-N gets dense validation (--no-sparse-eval).
 MODELS = (
     ModelSpec("v0.1-N", "ultralytics/cfg/models/master/v0_1/det/yolo-master-n.yaml", uses_esmoe=False),
     ModelSpec("EsMoE-N", "ultralytics/cfg/models/master/v0/det/yolo-master-n.yaml", uses_esmoe=True),
+)
+
+# The four variants derived from the two baselines, shared across every dataset script so the
+# reproducible model set stays consistent (the cfgs are dataset-agnostic -- nc is bound at build
+# time from the dataset yaml):
+#   * P2/4 head          -> EsMoE-P2-N, v0.1-P2-N  (extra stride-4 head for tiny objects)
+#   * UltraOptimizedMoE  -> UoMoE-N   (v0.1 with its ModularRouterExpertMoE blocks swapped for
+#                                      UltraOptimizedMoE: shared expert + batched sparse compute +
+#                                      ultra-light router, ~20-30% fewer GFLOPs at equal params)
+#                          UoMoE-P2-N (that swap + the P2/4 head)
+# EsMoE-P2-N contains ES_MOE blocks, so --no-sparse-eval gives it the corrected dense eval too.
+# The UoMoE models are sparse train==eval, so uses_esmoe=False (--no-sparse-eval is a no-op).
+VARIANTS = (
+    ModelSpec("EsMoE-P2-N", "ultralytics/cfg/models/master/v0/det/yolo-master-n-p2.yaml", uses_esmoe=True),
+    ModelSpec("v0.1-P2-N", "ultralytics/cfg/models/master/v0_1/det/yolo-master-n-p2.yaml", uses_esmoe=False),
+    ModelSpec("UoMoE-N", "ultralytics/cfg/models/master/v0_1/det/yolo-master-n-uomoe.yaml", uses_esmoe=False),
+    ModelSpec("UoMoE-P2-N", "ultralytics/cfg/models/master/v0_1/det/yolo-master-n-uomoe-p2.yaml", uses_esmoe=False),
 )
 
 

--- a/scripts/reproduce/reproduce_aitodv2.py
+++ b/scripts/reproduce/reproduce_aitodv2.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from _reproduce_common import DatasetSpec, run_dataset  # noqa: E402
+from _reproduce_common import MODELS, VARIANTS, DatasetSpec, run_dataset  # noqa: E402
 
 DATASET = DatasetSpec(
     name="AI-TOD-v2",
@@ -33,4 +33,4 @@ DATASET = DatasetSpec(
 
 
 if __name__ == "__main__":
-    raise SystemExit(run_dataset(DATASET))
+    raise SystemExit(run_dataset(DATASET, models=MODELS + VARIANTS))

--- a/scripts/reproduce/reproduce_ddp.py
+++ b/scripts/reproduce/reproduce_ddp.py
@@ -28,7 +28,7 @@ Usage (≥ 2 GPUs; ``--workers 0`` recommended on the Python-3.14 stack — see 
     python scripts/reproduce/reproduce_ddp.py --dataset VisDrone  --model EsMoE-N --device 0,1,2,3 --batch 128 --no-sparse-eval --workers 0
     python scripts/reproduce/reproduce_ddp.py --dataset SKU-110K  --model v0.1-N  --device 0,1 --batch 64 --workers 0
     python scripts/reproduce/reproduce_ddp.py --dataset AI-TOD-v2 --model v0.1-N  --device 0,1,2,3 --batch 128 --workers 0
-    python scripts/reproduce/reproduce_ddp.py --dataset VisDrone  --model both    --device 0,1 --dry-run
+    python scripts/reproduce/reproduce_ddp.py --dataset VisDrone  --model all     --device 0,1 --dry-run
 
 Single-node convention (GPUs 0..N-1). To pin specific GPUs, set CUDA_VISIBLE_DEVICES and pass --device 0,1.
 """
@@ -54,8 +54,12 @@ DATASETS = {
 }
 # esmoe=True -> contains ES_MOE blocks (sparse eval collapses mAP; --no-sparse-eval corrects it).
 MODELS = {
-    "v0.1-N":  {"cfg": "ultralytics/cfg/models/master/v0_1/det/yolo-master-n.yaml", "esmoe": False},
-    "EsMoE-N": {"cfg": "ultralytics/cfg/models/master/v0/det/yolo-master-n.yaml",   "esmoe": True},
+    "v0.1-N":     {"cfg": "ultralytics/cfg/models/master/v0_1/det/yolo-master-n.yaml",         "esmoe": False},
+    "EsMoE-N":    {"cfg": "ultralytics/cfg/models/master/v0/det/yolo-master-n.yaml",            "esmoe": True},
+    "EsMoE-P2-N": {"cfg": "ultralytics/cfg/models/master/v0/det/yolo-master-n-p2.yaml",         "esmoe": True},
+    "v0.1-P2-N":  {"cfg": "ultralytics/cfg/models/master/v0_1/det/yolo-master-n-p2.yaml",       "esmoe": False},
+    "UoMoE-N":    {"cfg": "ultralytics/cfg/models/master/v0_1/det/yolo-master-n-uomoe.yaml",    "esmoe": False},
+    "UoMoE-P2-N": {"cfg": "ultralytics/cfg/models/master/v0_1/det/yolo-master-n-uomoe-p2.yaml", "esmoe": False},
 }
 
 # --------------------------------------------------------------------------- #
@@ -162,7 +166,7 @@ def _reexec_under_torchrun(args: argparse.Namespace, data: str, n: int) -> None:
 
 
 def _teardown_ddp() -> None:
-    """Destroy the process group between models (--model both) so the next model can re-init it."""
+    """Destroy the process group between models (--model all) so the next model can re-init it."""
     try:
         import torch.distributed as dist
 
@@ -287,8 +291,8 @@ def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__.split("\n")[0],
                                 formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--dataset", required=True, choices=list(DATASETS))
-    p.add_argument("--model", required=True, choices=list(MODELS) + ["both"],
-                   help="A model, or 'both' for v0.1-N and EsMoE-N.")
+    p.add_argument("--model", required=True, choices=list(MODELS) + ["all"],
+                   help="A model name, or 'all' to train every model in sequence.")
     p.add_argument("--device", required=True,
                    help="Comma-separated GPU ids, >=2 (e.g. '0,1'). REQUIRED: this script is DDP-only.")
     p.add_argument("--epochs", type=int, default=300)
@@ -321,7 +325,7 @@ def build_parser() -> argparse.ArgumentParser:
 def main() -> int:
     args = build_parser().parse_args()
     ds = DATASETS[args.dataset]
-    models = list(MODELS) if args.model == "both" else [args.model]
+    models = list(MODELS) if args.model == "all" else [args.model]
     project = Path(args.project) if args.project else (ROOT / ds["project"])
     os.environ["WANDB_MODE"] = args.wandb_mode  # inherited by torchrun ranks
 

--- a/scripts/reproduce/reproduce_sku110k.py
+++ b/scripts/reproduce/reproduce_sku110k.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from _reproduce_common import DatasetSpec, run_dataset  # noqa: E402
+from _reproduce_common import MODELS, VARIANTS, DatasetSpec, run_dataset  # noqa: E402
 
 DATASET = DatasetSpec(
     name="SKU-110K",
@@ -30,4 +30,4 @@ DATASET = DatasetSpec(
 
 
 if __name__ == "__main__":
-    raise SystemExit(run_dataset(DATASET))
+    raise SystemExit(run_dataset(DATASET, models=MODELS + VARIANTS))

--- a/scripts/reproduce/reproduce_visdrone.py
+++ b/scripts/reproduce/reproduce_visdrone.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from _reproduce_common import DatasetSpec, run_dataset  # noqa: E402
+from _reproduce_common import MODELS, VARIANTS, DatasetSpec, run_dataset  # noqa: E402
 
 DATASET = DatasetSpec(
     name="VisDrone",
@@ -30,4 +30,4 @@ DATASET = DatasetSpec(
 
 
 if __name__ == "__main__":
-    raise SystemExit(run_dataset(DATASET))
+    raise SystemExit(run_dataset(DATASET, models=MODELS + VARIANTS))

--- a/ultralytics/cfg/models/master/v0/det/yolo-master-n-p2.yaml
+++ b/ultralytics/cfg/models/master/v0/det/yolo-master-n-p2.yaml
@@ -1,0 +1,42 @@
+# EsMoE-N-P2 (dense): EsMoE-N MoE backbone + high-res P2/4 detection head (TPH-style).
+# Reconstructed from the trained EsMoE-N-TPH checkpoint's model.yaml (the /tmp cfg was lost).
+# 4-scale Detect [P2,P3,P4,P5] strides [4,8,16,32]. nc is overridden by the dataset yaml.
+
+nc: 10
+scales:
+  n: [0.5, 0.25, 1024]
+
+backbone:
+  - [-1, 1, Conv, [64, 3, 2]]
+  - [-1, 1, Conv, [128, 3, 2]]
+  - [-1, 2, C3k2, [256, False, 0.25]]
+  - [-1, 1, ES_MOE, [256]]
+  - [-1, 1, Conv, [256, 3, 2]]
+  - [-1, 2, C3k2, [512, False, 0.25]]
+  - [-1, 1, ES_MOE, [512]]
+  - [-1, 1, Conv, [512, 3, 2]]
+  - [-1, 4, A2C2f, [512, True, 4]]
+  - [-1, 1, ES_MOE, [512]]
+  - [-1, 1, Conv, [1024, 3, 2]]
+  - [-1, 4, A2C2f, [1024, True, 1]]
+  - [-1, 1, ES_MOE, [1024]]
+head:
+  - [-1, 1, nn.Upsample, [None, 2, nearest]]
+  - [[-1, 9], 1, Concat, [1]]
+  - [-1, 2, C3k2, [512, True]]
+  - [-1, 1, nn.Upsample, [None, 2, nearest]]
+  - [[-1, 6], 1, Concat, [1]]
+  - [-1, 2, C3k2, [256, True]]
+  - [-1, 1, nn.Upsample, [None, 2, nearest]]
+  - [[-1, 3], 1, Concat, [1]]
+  - [-1, 2, C3k2, [128, True]]
+  - [-1, 1, Conv, [128, 3, 2]]
+  - [[-1, 18], 1, Concat, [1]]
+  - [-1, 2, C3k2, [256, True]]
+  - [-1, 1, Conv, [256, 3, 2]]
+  - [[-1, 15], 1, Concat, [1]]
+  - [-1, 2, C3k2, [512, True]]
+  - [-1, 1, Conv, [512, 3, 2]]
+  - [[-1, 12], 1, Concat, [1]]
+  - [-1, 2, C3k2, [512, True]]
+  - [[21, 24, 27, 30], 1, Detect, [nc]]

--- a/ultralytics/cfg/models/master/v0_1/det/yolo-master-n-p2.yaml
+++ b/ultralytics/cfg/models/master/v0_1/det/yolo-master-n-p2.yaml
@@ -1,0 +1,70 @@
+# YOLO-Master-v0.1-N-P2 🚀 AGPL-3.0 License - https://ultralytics.com/license
+#
+# P2-head variant of YOLO-Master-v0.1-N for tiny / densely-packed objects
+# (VisDrone-style imagery). Adds an extra high-resolution P2/4 detection head
+# on top of the stock P3/P4/P5 heads, following the TPH-YOLOv5 recipe of a
+# dedicated tiny-object prediction head (its single largest ablation gain).
+#
+# The backbone is UNCHANGED from v0.1-N (same ModularRouterExpertMoE / A2C2f
+# stack). Only the neck/head is extended: the FPN top-down path is carried one
+# level further down to stride-4, and the PAN bottom-up path is re-rooted at P2.
+# Heads: P2/4, P3/8, P4/16, P5/32  ->  Detect x4.
+#
+# Note: no transformer blocks are inserted at the new stride-4 head on purpose.
+# Global attention at 160x160 (640 input) is prohibitively expensive for a Nano
+# real-time model, and YOLO-Master already carries area-attention (A2C2f) plus
+# MoE gating in the backbone; the portable P2 win here is the extra head.
+
+# Parameters
+nc: 80 # number of classes
+scales: # model compound scaling constants
+  n: [0.50, 0.25, 1024]
+
+backbone:
+  - [-1, 1, Conv, [64, 3, 2]]                       # 0-P1/2
+  - [-1, 1, Conv, [128, 3, 2]]                      # 1-P2/4
+  - [-1, 2, C3k2, [256, False, 0.25]]               # 2-P2/4  (P2 feature source)
+
+  - [-1, 1, Conv, [256, 3, 2]]                      # 3-P3/8
+  - [-1, 2, C3k2, [512, False, 0.25]]               # 4
+
+  - [-1, 1, ModularRouterExpertMoE, [512, 4, 2]]    # 5-P3/8  (P3 feature source)
+
+  - [-1, 1, Conv, [512, 3, 2]]                      # 6-P4/16
+  - [-1, 4, A2C2f, [512, True, 4]]                  # 7
+
+  - [-1, 1, ModularRouterExpertMoE, [512, 8, 2]]    # 8-P4/16 (P4 feature source)
+
+  - [-1, 1, Conv, [1024, 3, 2]]                     # 9-P5/32
+  - [-1, 4, A2C2f, [1024, True, 1]]                 # 10
+
+  - [-1, 1, ModularRouterExpertMoE, [1024, 16, 2]]  # 11-P5/32 (P5 feature source)
+
+head:
+  # --- top-down (FPN) ---
+  - [-1, 1, nn.Upsample, [None, 2, "nearest"]]      # 12
+  - [[-1, 8], 1, Concat, [1]]                        # 13 cat backbone P4
+  - [-1, 2, C3k2, [512, True]]                       # 14 (P4 td)
+
+  - [-1, 1, nn.Upsample, [None, 2, "nearest"]]      # 15
+  - [[-1, 5], 1, Concat, [1]]                         # 16 cat backbone P3
+  - [-1, 2, C3k2, [256, True]]                        # 17 (P3 td)
+
+  - [-1, 1, nn.Upsample, [None, 2, "nearest"]]      # 18
+  - [[-1, 2], 1, Concat, [1]]                         # 19 cat backbone P2
+  - [-1, 2, C3k2, [128, True]]                        # 20 (P2/4-tiny)   <- Detect P2
+
+  # --- bottom-up (PAN) ---
+  - [-1, 1, Conv, [128, 3, 2]]                       # 21
+  - [[-1, 17], 1, Concat, [1]]                        # 22 cat head P3
+  - [-1, 2, C3k2, [256, True]]                        # 23 (P3/8-small)  <- Detect P3
+
+  - [-1, 1, Conv, [256, 3, 2]]                       # 24
+  - [[-1, 14], 1, Concat, [1]]                        # 25 cat head P4
+  - [-1, 2, C3k2, [512, True]]                        # 26 (P4/16-medium)<- Detect P4
+
+  - [-1, 1, Conv, [512, 3, 2]]                       # 27
+  - [[-1, 11], 1, Concat, [1]]                        # 28 cat backbone P5
+  - [-1, 2, C3k2, [512, True]]                        # 29 (P5/32-large) <- Detect P5
+
+  - [[20, 23, 26, 29], 1, Detect, [nc]]              # Detect(P2, P3, P4, P5)

--- a/ultralytics/cfg/models/master/v0_1/det/yolo-master-n-uomoe-p2.yaml
+++ b/ultralytics/cfg/models/master/v0_1/det/yolo-master-n-uomoe-p2.yaml
@@ -1,0 +1,64 @@
+# YOLO-Master-v0.1-N-P2-UoMoE 🚀 AGPL-3.0 License - https://ultralytics.com/license
+#
+# UltraOptimizedMoE variant of our tiny-object winner yolo-master-n-p2.yaml.
+# Identical P2/4-head backbone+neck; the three ModularRouterExpertMoE blocks are
+# swapped for UltraOptimizedMoE (same [out, num_experts, top_k] args). Combines
+# the two independent wins: the extra stride-4 (P2) detection head for tiny
+# objects, and the deployment-optimized MoE (shared expert = stable like v0.1,
+# batched sparse expert compute + ultra-light router = faster inference). Sparse
+# train==eval with the shared path always on -> no --no-sparse-eval mismatch.
+# Heads: P2/4, P3/8, P4/16, P5/32 -> Detect x4.
+
+# Parameters
+nc: 80 # number of classes
+scales: # model compound scaling constants
+  n: [0.50, 0.25, 1024]
+
+backbone:
+  - [-1, 1, Conv, [64, 3, 2]]                       # 0-P1/2
+  - [-1, 1, Conv, [128, 3, 2]]                      # 1-P2/4
+  - [-1, 2, C3k2, [256, False, 0.25]]               # 2-P2/4  (P2 feature source)
+
+  - [-1, 1, Conv, [256, 3, 2]]                      # 3-P3/8
+  - [-1, 2, C3k2, [512, False, 0.25]]               # 4
+
+  - [-1, 1, UltraOptimizedMoE, [512, 4, 2]]         # 5-P3/8  (P3 feature source)
+
+  - [-1, 1, Conv, [512, 3, 2]]                      # 6-P4/16
+  - [-1, 4, A2C2f, [512, True, 4]]                  # 7
+
+  - [-1, 1, UltraOptimizedMoE, [512, 8, 2]]         # 8-P4/16 (P4 feature source)
+
+  - [-1, 1, Conv, [1024, 3, 2]]                     # 9-P5/32
+  - [-1, 4, A2C2f, [1024, True, 1]]                 # 10
+
+  - [-1, 1, UltraOptimizedMoE, [1024, 16, 2]]       # 11-P5/32 (P5 feature source)
+
+head:
+  # --- top-down (FPN) ---
+  - [-1, 1, nn.Upsample, [None, 2, "nearest"]]      # 12
+  - [[-1, 8], 1, Concat, [1]]                        # 13 cat backbone P4
+  - [-1, 2, C3k2, [512, True]]                       # 14 (P4 td)
+
+  - [-1, 1, nn.Upsample, [None, 2, "nearest"]]      # 15
+  - [[-1, 5], 1, Concat, [1]]                         # 16 cat backbone P3
+  - [-1, 2, C3k2, [256, True]]                        # 17 (P3 td)
+
+  - [-1, 1, nn.Upsample, [None, 2, "nearest"]]      # 18
+  - [[-1, 2], 1, Concat, [1]]                         # 19 cat backbone P2
+  - [-1, 2, C3k2, [128, True]]                        # 20 (P2/4-tiny)   <- Detect P2
+
+  # --- bottom-up (PAN) ---
+  - [-1, 1, Conv, [128, 3, 2]]                       # 21
+  - [[-1, 17], 1, Concat, [1]]                        # 22 cat head P3
+  - [-1, 2, C3k2, [256, True]]                        # 23 (P3/8-small)  <- Detect P3
+
+  - [-1, 1, Conv, [256, 3, 2]]                       # 24
+  - [[-1, 14], 1, Concat, [1]]                        # 25 cat head P4
+  - [-1, 2, C3k2, [512, True]]                        # 26 (P4/16-medium)<- Detect P4
+
+  - [-1, 1, Conv, [512, 3, 2]]                       # 27
+  - [[-1, 11], 1, Concat, [1]]                        # 28 cat backbone P5
+  - [-1, 2, C3k2, [512, True]]                        # 29 (P5/32-large) <- Detect P5
+
+  - [[20, 23, 26, 29], 1, Detect, [nc]]              # Detect(P2, P3, P4, P5)

--- a/ultralytics/cfg/models/master/v0_1/det/yolo-master-n-uomoe.yaml
+++ b/ultralytics/cfg/models/master/v0_1/det/yolo-master-n-uomoe.yaml
@@ -1,0 +1,54 @@
+# YOLO-Master-v0.1-N-UoMoE 🚀 AGPL-3.0 License - https://ultralytics.com/license
+#
+# UltraOptimizedMoE variant of YOLO-Master-v0.1-N. Identical backbone/head to
+# yolo-master-n.yaml, with the three ModularRouterExpertMoE blocks swapped for
+# UltraOptimizedMoE (same [out, num_experts, top_k] args). UltraOptimizedMoE is
+# the deployment-optimized MoE generation: always-on shared expert (stable, like
+# v0.1 — not ES_MOE), z-loss + differentiable balance loss, an ultra-light
+# depthwise router (~95% fewer routing FLOPs), and batched sparse expert compute
+# (no per-expert Python loop) for faster inference. Sparse at train AND eval with
+# the shared path always on -> train==eval consistent (no --no-sparse-eval needed).
+
+# Parameters
+nc: 80 # number of classes
+scales: # model compound scaling constants
+  n: [0.50, 0.25, 1024]
+
+backbone:
+  - [-1, 1, Conv, [64, 3, 2]]
+  - [-1, 1, Conv, [128, 3, 2]]
+  - [-1, 2, C3k2, [256, False, 0.25]]
+
+  - [-1, 1, Conv, [256, 3, 2]]
+  - [-1, 2, C3k2, [512, False, 0.25]]
+
+  - [-1, 1, UltraOptimizedMoE, [512, 4, 2]]
+
+  - [-1, 1, Conv, [512, 3, 2]]
+  - [-1, 4, A2C2f, [512, True, 4]]
+
+  - [-1, 1, UltraOptimizedMoE, [512, 8, 2]]
+
+  - [-1, 1, Conv, [1024, 3, 2]]
+  - [-1, 4, A2C2f, [1024, True, 1]]
+
+  - [-1, 1, UltraOptimizedMoE, [1024, 16, 2]]
+
+head:
+  - [-1, 1, nn.Upsample, [None, 2, "nearest"]]
+  - [[-1, 8], 1, Concat, [1]]
+  - [-1, 2, C3k2, [512, True]]
+
+  - [-1, 1, nn.Upsample, [None, 2, "nearest"]]
+  - [[-1, 5], 1, Concat, [1]]
+  - [-1, 2, C3k2, [256, True]]
+
+  - [-1, 1, Conv, [256, 3, 2]]
+  - [[-1, 14], 1, Concat, [1]]
+  - [-1, 2, C3k2, [512, True]]
+
+  - [-1, 1, Conv, [512, 3, 2]]
+  - [[-1, 11], 1, Concat, [1]]
+  - [-1, 2, C3k2, [512, True]]
+
+  - [[17, 20, 23], 1, Detect, [nc]]


### PR DESCRIPTION
- Integration of #98, #126.
- Extends #81, #117, #140 to cover **6 models** and 3 datasets. 
 
<img width="1821" height="1090" alt="model_evolution" src="https://github.com/user-attachments/assets/d0f8628b-3e88-42aa-9ea1-1304452641bf" />

## 🔗 What's added

Extends the reproduction suite from the two baselines (`v0.1-N`, `EsMoE-N`) to **six models** by adding four variants:

- From Issue #98:
  - `v0.1-P2-N` featuring P2/4 head for tiny object detection (best on AI-TOD-v2)
  - `EsMoE-P2-N` featuring P2/4 head for **efficient** tiny object detection (best on VisDrone)
- From Issue #117:
  - `UoMoE-N` adopting `UltraOptimizedMoE` to **raise mAP while lowering FLOPs**
  - `UoMoE-P2-N` combining `UltraOptimizedMoE` and P2/4 head

available on every dataset (VisDrone / SKU-110K / AI-TOD-v2) and every reproduce script (per-dataset single-GPU, native multi-GPU, and `reproduce_ddp.py`):

| Variant | Derived from | Design |
|---|---|---|
| `v0.1-P2-N` | `v0.1-N` + P2/4 head | extra stride-4 head for tiny objects |
| `EsMoE-P2-N` | `EsMoE-N` + P2/4 head | same, on the ES_MOE base |
| `UoMoE-N` | `v0.1-N`, MoE blocks → `UltraOptimizedMoE` | shared expert + batched sparse compute + ultra-light router (~20–30% fewer GFLOPs at equal params) |
| `UoMoE-P2-N` | `UoMoE-N` + P2/4 head | UoMoE + tiny-object head |

## It's purely additive (no library changes)

`UltraOptimizedMoE` already ships in `ultralytics/nn/modules/moe/` and is registered in `tasks.py`, and P2 is just an extra head on the existing `yolo-master-n.yaml` bases. So this PR only adds **model configs + script wiring** — nothing in `ultralytics/` changes.

New configs:
- `ultralytics/cfg/models/master/v0/det/yolo-master-n-p2.yaml`
- `ultralytics/cfg/models/master/v0_1/det/yolo-master-n-p2.yaml`
- `ultralytics/cfg/models/master/v0_1/det/yolo-master-n-uomoe.yaml`
- `ultralytics/cfg/models/master/v0_1/det/yolo-master-n-uomoe-p2.yaml`

## How it works

- The four variants are defined once in a shared `_reproduce_common.VARIANTS` tuple; the three dataset scripts each expose an identical set via `run_dataset(DATASET, models=MODELS + VARIANTS)`, and `reproduce_ddp.py` gains the same four entries. One source of truth, so the model set can't drift between scripts.
- `EsMoE-P2-N` contains ES_MOE blocks, so it reuses the **existing** `--no-sparse-eval` dense-eval callback — no new mechanism. The v0.1/UoMoE variants are sparse train==eval (flag is a no-op).
- The variant cfgs are dataset-agnostic; `nc` is bound at build time from the dataset yaml.
- Renames `reproduce_ddp.py`'s `--model` catch-all from `both` → **`all`** (accurate now that there are six models, and matches the README).

> Note: SKU-110K is a large-object dataset, so the P2/UoMoE variants there are provided for a consistent
> model set but are not expected to help / are untuned on that dataset (documented in the script + README).

## 📁 Files

`scripts/reproduce/{_reproduce_common,reproduce_visdrone,reproduce_aitodv2,reproduce_sku110k,reproduce_ddp}.py`,
4 new model cfgs, and `scripts/reproduce/README.md` (documents the variants + updated model table). 10 files, +433 / −36.

## ✅ Validation

All six models build on a **clean checkout** (no local library edits) on all four scripts:

```
[build-ok] v0.1-N 7.55M · EsMoE-N 2.69M · EsMoE-P2-N 2.81M · v0.1-P2-N 7.67M · UoMoE-N 7.45M · UoMoE-P2-N 7.57M
```

`--model all` enumerates all six now instead of two.

---

Please refer to the section 6 in `README.md` for more information.