### PR TITLE
fix(moe): preserve DynamicRoutingLayer compatibility with released checkpoints

### DIFF
--- a/tests/test_moe_router_boundaries.py
+++ b/tests/test_moe_router_boundaries.py
@@ -224,6 +224,31 @@ class TestDynamicRoutingLayerBoundaries:
         with pytest.raises(ValueError, match="top_k"):
             DynamicRoutingLayer(IN_CHANNELS, NUM_EXPERTS, top_k=0)
 
+    def test_legacy_checkpoint_without_in_channels_preserves_output(self):
+        torch.manual_seed(0)
+        router = DynamicRoutingLayer(IN_CHANNELS, NUM_EXPERTS, top_k=TOP_K).eval()
+        x = _valid_input()
+
+        with torch.no_grad():
+            expected = router(x)
+        state_before = {name: tensor.clone() for name, tensor in router.state_dict().items()}
+
+        del router.in_channels
+        with torch.no_grad():
+            actual = router(x)
+
+        assert torch.equal(actual, expected)
+        assert state_before.keys() == router.state_dict().keys()
+        for name, tensor in router.state_dict().items():
+            assert torch.equal(tensor, state_before[name])
+
+    def test_legacy_checkpoint_without_in_channels_still_checks_channels(self):
+        router = DynamicRoutingLayer(IN_CHANNELS, NUM_EXPERTS, top_k=TOP_K)
+        del router.in_channels
+
+        with pytest.raises(ShapeMismatchError):
+            router(torch.randn(2, IN_CHANNELS // 2, 16, 16))
+
 
 def test_capacity_overflow_is_distributed_round_robin():
     from ultralytics.nn.modules.moe.routers import BaseRouter

--- a/ultralytics/nn/modules/moe/routers.py
+++ b/ultralytics/nn/modules/moe/routers.py
@@ -441,7 +441,8 @@ class DynamicRoutingLayer(nn.Module):
     def forward(self, x):
         exporting = torch.onnx.is_in_onnx_export() or torch.jit.is_tracing()
         if not exporting:
-            _validate_router_input(x, self.in_channels, "DynamicRoutingLayer")
+            expected_channels = getattr(self, "in_channels", _get_router_in_channels(self.routing_network))
+            _validate_router_input(x, expected_channels, "DynamicRoutingLayer")
         pooled = self.global_pool(x)
         routing_logits = self.routing_network(pooled)  # [B, num_experts, 1, 1]
         if not exporting:


### PR DESCRIPTION
### 说明

- 为旧版本反序列化得到的 `DynamicRoutingLayer` 增加兼容处理：当实例中没有 `in_channels` 属性时，从 `routing_network` 的第一个卷积层读取输入通道数；
- 新创建的 router 仍然优先使用已有的 `in_channels`，保持当前校验逻辑不变；
- 补充旧 checkpoint 对象的输出一致性、state 一致性和错误通道输入测试。

### 问题背景

官方 v26.02 `YOLO-Master-EsMoE-N.pt` 中包含四个较早版本序列化的 `DynamicRoutingLayer`。这些对象生成时还没有 `self.in_channels` 属性，而当前 `forward()` 会直接读取该属性。因此 checkpoint 本身可以加载，但第一次执行 forward 时会报错：

```text
AttributeError: 'DynamicRoutingLayer' object has no attribute 'in_channels'
```

所需的输入通道数实际上已经保存在 `routing_network` 的第一个 `Conv2d` 中；当前模块也已有 `_get_router_in_channels()`，可以安全读取这一结构信息。

### 修改方式

当 `in_channels` 存在时继续使用原值；只有旧对象缺少该属性时，才回退到 `_get_router_in_channels(self.routing_network)`。该修改不会增加或改变任何 parameter、buffer，也不会改变 checkpoint key。

### 验证结果

- 旧 checkpoint 兼容性定向测试：`2 passed`；
- `tests/test_moe_router_boundaries.py`：`36 passed`；
- `tests/test_mixture_fixes.py`：`10 passed`；
- 官方 v26.02 checkpoint SHA256：`29e1b93f09b16c8cf7c402f36dcaafc19d4812155631ed45b769e941e4c88c32`；
- 在官方 checkpoint 上复现了修复前的 `AttributeError`；
- 确认四个 legacy router 均缺少该实例属性，fallback 得到的输入通道数为 `64/128/128/256`；
- 与显式补齐 metadata 的对照实现比较，各层 routing logits、probabilities 以及完整 detector raw output 的 `max_abs_diff` 均为 `0.0`；
- 修复前后的 state-dict keys 和 tensors 完全一致。

### 影响范围

这是一个针对已发布 pickle 模型对象的向后兼容修复，不会改变 routing weights、Top-K 行为、训练逻辑、导出逻辑或 checkpoint schema。

Related to #52
