### PR TITLE
fix(yoloe): preserve released checkpoint execution semantics

### DIFF
--- a/tests/test_yoloe_released_checkpoint_compat.py
+++ b/tests/test_yoloe_released_checkpoint_compat.py
@@ -1,0 +1,74 @@
+"""Regression coverage for released YOLOE segmentation checkpoint reconstruction."""
+
+import os
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+
+from ultralytics.nn.tasks import YOLOEModel, YOLOESegModel
+
+
+ROOT = Path(os.environ.get("YOLO_MASTER_SOURCE_ROOT", Path(__file__).resolve().parents[1]))
+DETECT_CFG = ROOT / "ultralytics/cfg/models/11/yoloe-11.yaml"
+SEGMENT_CFG = ROOT / "ultralytics/cfg/models/11/yoloe-11-seg.yaml"
+SPPF_INDEX = 9
+
+
+def _checkpoint_like_segmentation_source_and_detection_target():
+    """Build the legacy execution metadata pattern without downloading checkpoint assets."""
+    source = YOLOESegModel(str(SEGMENT_CFG), verbose=False).eval()
+    target = YOLOEModel(str(DETECT_CFG), verbose=False).eval()
+    source.model[SPPF_INDEX].cv1.act = nn.SiLU(inplace=True)
+    return source, target
+
+
+def _assert_target_state_was_fully_shared(source, target):
+    source_state, target_state = source.state_dict(), target.state_dict()
+    assert all(name in source_state and torch.equal(value, source_state[name]) for name, value in target_state.items())
+
+
+def test_released_segmentation_load_restores_shared_sppf_execution_semantics():
+    """A released segmentation source must preserve SiLU when reconstructing the shared detection path."""
+    torch.manual_seed(0)
+    source, target = _checkpoint_like_segmentation_source_and_detection_target()
+    source_sppf, target_sppf = source.model[SPPF_INDEX], target.model[SPPF_INDEX]
+    x = torch.randn(1, source_sppf.cv1.conv.in_channels, 8, 8)
+
+    assert isinstance(source_sppf.cv1.act, nn.SiLU)
+    assert isinstance(target_sppf.cv1.act, nn.Identity)
+    with torch.inference_mode():
+        target.load({"model": source}, verbose=False)
+
+        _assert_target_state_was_fully_shared(source, target)
+        assert isinstance(target_sppf.cv1.act, nn.SiLU)
+        assert torch.equal(source_sppf(x), target_sppf(x))
+
+
+def test_detection_constructor_and_detection_source_keep_current_sppf_identity_semantics():
+    """The migration is not a global SPPF default change and does not apply to detection sources."""
+    source = YOLOEModel(str(DETECT_CFG), verbose=False).eval()
+    target = YOLOEModel(str(DETECT_CFG), verbose=False).eval()
+    source.model[SPPF_INDEX].cv1.act = nn.SiLU(inplace=True)
+
+    target.load({"model": source}, verbose=False)
+
+    assert isinstance(YOLOEModel(str(DETECT_CFG), verbose=False).model[SPPF_INDEX].cv1.act, nn.Identity)
+    assert isinstance(target.model[SPPF_INDEX].cv1.act, nn.Identity)
+
+
+def test_released_segmentation_activation_migration_fails_closed_on_sppf_state_layout_mismatch():
+    """A source with a different SPPF state layout must not transfer non-state execution metadata."""
+    source, target = _checkpoint_like_segmentation_source_and_detection_target()
+    source_sppf = source.model[SPPF_INDEX]
+    source_sppf.cv1.conv = nn.Conv2d(
+        source_sppf.cv1.conv.in_channels,
+        source_sppf.cv1.conv.out_channels + 1,
+        kernel_size=1,
+        bias=False,
+    )
+
+    migrated = target._migrate_released_segmentation_execution_semantics(source)
+
+    assert migrated == ()
+    assert isinstance(target.model[SPPF_INDEX].cv1.act, nn.Identity)

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1235,6 +1235,37 @@ class YOLOEModel(DetectionModel):
         super().__init__(cfg=cfg, ch=ch, nc=nc, verbose=verbose)
         self.text_model = self.yaml.get("text_model", "mobileclip:blt")
 
+    def load(self, weights, verbose=True):
+        """Load weights and preserve released segmentation checkpoint execution semantics when fully shared."""
+        source = weights["model"] if isinstance(weights, dict) else weights
+        super().load(weights, verbose=verbose)
+        migrated = self._migrate_released_segmentation_execution_semantics(source)
+        if verbose and migrated:
+            LOGGER.info(f"Migrated released YOLOE segmentation execution semantics: {', '.join(migrated)}")
+
+    def _migrate_released_segmentation_execution_semantics(self, source):
+        """Migrate non-state SPPF activation metadata for fully shared released segmentation sources only."""
+        if isinstance(self, YOLOESegModel) or not isinstance(source, YOLOESegModel):
+            return ()
+
+        migrated = []
+        for index, (source_layer, target_layer) in enumerate(zip(source.model, self.model)):
+            if type(source_layer) is not SPPF or type(target_layer) is not SPPF:
+                continue
+            if type(source_layer.cv1) is not type(target_layer.cv1):
+                continue
+            source_state, target_state = source_layer.state_dict(), target_layer.state_dict()
+            if source_state.keys() != target_state.keys() or any(
+                source_value.shape != target_state[name].shape or not torch.equal(source_value, target_state[name])
+                for name, source_value in source_state.items()
+            ):
+                continue
+            if not isinstance(source_layer.cv1.act, nn.SiLU) or not isinstance(target_layer.cv1.act, nn.Identity):
+                continue
+            target_layer.cv1.act = deepcopy(source_layer.cv1.act)
+            migrated.append(f"model.{index}.cv1.act")
+        return tuple(migrated)
+
     @smart_inference_mode()
     def get_text_pe(self, text, batch=80, cache_clip_model=False, without_reprta=False):
         """Get text positional embeddings using the CLIP model.


### PR DESCRIPTION
## 背景

当前 `SPPF` 构造会把 `cv1.act` 设为 `Identity`，而已发布的 YOLOE segmentation checkpoint 中该位置保留的是 `SiLU`。当使用 released segmentation checkpoint 为官方 detection YAML 重建共享检测路径时，权重虽然能够完整迁移，但 activation 这类不属于 state dict 的执行元数据不会被 `BaseModel.load()` 恢复，因而会造成共享检测输出不一致。

## 修改内容

- 在 `YOLOEModel.load()` 完成常规权重加载后，增加一个严格受限的 execution-metadata compatibility migration。
- 迁移仅在以下条件全部满足时触发：target 为 detection `YOLOEModel`、source 为 `YOLOESegModel`、对应层均为同型 `SPPF`、完整 SPPF state layout 和已加载数值一致，并且 source/target activation 恰好为 `SiLU`/`Identity`。
- 只深拷贝匹配层的 `cv1.act`，不改变全局 SPPF 默认值。
- detection-to-detection、fresh detection constructor 和 state-layout mismatch 均保持现有行为并 fail closed。

## 验证

- 新增 3 项离线回归测试：
  - released segmentation source 能恢复共享 SPPF 执行语义；
  - detection constructor 与 detection source 不触发迁移；
  - SPPF state layout 不匹配时拒绝迁移。
- test-first fixture 在未修代码上按预期失败，修复后 3 项全部通过。
- 使用 released `yoloe-11s-seg.pt`、同一次 prompt embedding、FP32 eval 对固定 1 张和固定 10 张图进行真实验证：共享层、pre-DFL、decoded bbox 与 class score 均完全一致，记录的最大绝对误差均为 `0.0`。
- `py_compile`、`git diff --check` 和提交前隐私检查通过。

## 说明

这次修改只处理 checkpoint 加载后的行为一致性。精度、速度、显存、训练稳定性和 PEFT 效果没有做额外对比，后续如果需要可以单独验证。