### PR TITLE
fix(vpeft): restore constraint and per-node variant semantics

### DIFF
--- a/tests/test_vpeft.py
+++ b/tests/test_vpeft.py
@@ -122,7 +122,7 @@ def test_vpeft_ao_budget_accounts_for_per_node_variants():
     graph = ComputationGraph(
         modules=[
             ModuleNode("backbone.linear", "Linear", 8, 8),
-            ModuleNode("backbone.linear2", "Linear", 64, 64),
+            ModuleNode("backbone.conv", "Conv2d", 8, 8, kernel_size=3),
         ]
     )
     decision = AlternatingOptimizationSolver(
@@ -130,6 +130,7 @@ def test_vpeft_ao_budget_accounts_for_per_node_variants():
     ).solve(graph, budget=10_000, variant="lora", constraints=ConstraintRegistry.default())
 
     assert len(decision.variants) == graph.n_nodes
+    assert decision.variants == ["ia3", "lora"]
     assert decision.budget_used == sum(
         graph.estimate_params(index, int(decision.ranks[index]), decision.variants[index])
         for index in range(graph.n_nodes)

--- a/ultralytics/vpeft/constraints.py
+++ b/ultralytics/vpeft/constraints.py
@@ -10,7 +10,7 @@ Soft constraints  → scalar penalties (≥ 0) weighted by Lagrange multipliers.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -624,17 +624,37 @@ class ConstraintRegistry:
         if hard_constraints or soft_constraints:
             self._build_from_legacy_names(hard_constraints or [], soft_constraints or [])
 
+    @staticmethod
+    def normalize_name(name: str) -> str:
+        """Return the canonical constraint id used by solver logs and duals."""
+        value = str(name).strip()
+        if not value:
+            return value
+        return value if value.startswith("C_") else f"C_{value}"
+
+    def hard_constraint_names(self) -> List[str]:
+        """Return canonical names of constraints participating in projection."""
+        return [constraint.name for constraint in self._hard_constraints]
+
+    def soft_constraint_names(self) -> List[str]:
+        """Return canonical names of constraints participating in dual penalties."""
+        return [constraint.name for constraint in self._soft_constraints]
+
     def _build_from_legacy_names(self, hard_names: List[str], soft_names: List[str]) -> None:
         """Build default constraint instances from legacy name lists."""
         name_map = self._default_name_map()
         for name in hard_names:
-            c = name_map.get(name)
+            c = name_map.get(self.normalize_name(name))
             if c is not None and c not in self._constraints:
                 self._register(c, as_hard=True)
+            elif c is not None:
+                self._add_classification(c, as_hard=True)
         for name in soft_names:
-            c = name_map.get(name)
+            c = name_map.get(self.normalize_name(name))
             if c is not None and c not in self._constraints:
                 self._register(c, as_hard=False)
+            elif c is not None:
+                self._add_classification(c, as_hard=False)
 
     @staticmethod
     def _default_name_map() -> Dict[str, Constraint]:
@@ -649,24 +669,26 @@ class ConstraintRegistry:
         }
 
     def _register(self, c: Constraint, as_hard: bool = True) -> None:
-        self._constraints.append(c)
-        if as_hard:
-            self._hard_constraints.append(c)
-        else:
-            self._soft_constraints.append(c)
+        if c not in self._constraints:
+            self._constraints.append(c)
+        self._add_classification(c, as_hard=as_hard)
         if isinstance(c, BudgetConstraint):
             self._budget_constraint = c
         if isinstance(c, MoEConsistencyConstraint):
             self._moe_constraint = c
 
+    def _add_classification(self, c: Constraint, *, as_hard: bool) -> None:
+        """Classify an existing constraint without duplicating its instance."""
+        target = self._hard_constraints if as_hard else self._soft_constraints
+        if c not in target:
+            target.append(c)
+
     def _register_list(self, constraints: List[Constraint]) -> None:
         for c in constraints:
-            # Default: all constraints are hard except Budget which can be soft
-            is_hard = not isinstance(c, BudgetConstraint)
-            self._register(c, as_hard=is_hard)
-            # Also register Budget as soft if not already
-            if isinstance(c, BudgetConstraint) and c not in self._soft_constraints:
-                self._soft_constraints.append(c)
+            # A flat legacy list still enforces every supplied constraint.
+            self._register(c, as_hard=True)
+            if isinstance(c, BudgetConstraint):
+                self._add_classification(c, as_hard=False)
 
     @property
     def constraints(self) -> List[Constraint]:
@@ -677,24 +699,39 @@ class ConstraintRegistry:
 
     @classmethod
     def default(cls, config: Optional[Dict[str, Any]] = None) -> "ConstraintRegistry":
-        """Build a default registry with all 7 constraints."""
+        """Build a registry with explicit hard and soft constraint semantics."""
         cfg = config or {}
         registry = cls()
-        registry._register(OperatorCompatibilityConstraint(
-            allow_depthwise=cfg.get("allow_depthwise", False)), as_hard=True)
-        registry._register(SemanticProtectionConstraint(
-            include_head=cfg.get("include_head", False),
-            only_backbone=cfg.get("only_backbone", False),
-            exclude_modules=cfg.get("exclude_modules", None)), as_hard=True)
-        registry._register(BudgetConstraint(
-            max_params=cfg.get("max_params", 2_100_000)), as_hard=True)
-        registry._register(DeploymentCompatibilityConstraint(
-            platform=cfg.get("platform", "pytorch")), as_hard=True)
-        registry._register(VariantModuleCompatibilityConstraint(
-            block_size=cfg.get("block_size", None)), as_hard=True)
-        registry._register(MoEConsistencyConstraint(
-            epsilon=cfg.get("moe_epsilon", 4)), as_hard=True)
-        registry._register(DivisibilityConstraint(), as_hard=True)
+        all_constraints = [
+            OperatorCompatibilityConstraint(allow_depthwise=cfg.get("allow_depthwise", False)),
+            SemanticProtectionConstraint(
+                include_head=cfg.get("include_head", False),
+                only_backbone=cfg.get("only_backbone", False),
+                exclude_modules=cfg.get("exclude_modules", None),
+            ),
+            BudgetConstraint(max_params=cfg.get("max_params", 2_100_000)),
+            DeploymentCompatibilityConstraint(platform=cfg.get("platform", "pytorch")),
+            VariantModuleCompatibilityConstraint(block_size=cfg.get("block_size", None)),
+            MoEConsistencyConstraint(epsilon=cfg.get("moe_epsilon", 4)),
+            DivisibilityConstraint(),
+        ]
+        by_name = {constraint.name: constraint for constraint in all_constraints}
+        default_hard = ["C_op", "C_sem", "C_budget", "C_deploy", "C_compat", "C_moe", "C_div"]
+        default_soft = ["C_budget", "C_deploy"]
+        hard_names = [cls.normalize_name(name) for name in cfg.get("hard_constraints", default_hard)]
+        soft_names = [cls.normalize_name(name) for name in cfg.get("soft_constraints", default_soft)]
+        for constraint in all_constraints:
+            if constraint.name in hard_names:
+                registry._register(constraint, as_hard=True)
+            elif constraint.name in soft_names:
+                registry._register(constraint, as_hard=False)
+        for name in soft_names:
+            if name in by_name:
+                constraint = by_name[name]
+                if constraint not in registry._constraints:
+                    registry._register(constraint, as_hard=False)
+                else:
+                    registry._add_classification(constraint, as_hard=False)
         candidates = cfg.get("candidate_targets")
         if candidates:
             registry._register(CandidateTargetConstraint(candidates), as_hard=True)
@@ -754,57 +791,112 @@ class ConstraintRegistry:
         return mask
 
     def enforce_moe_consistency(
-        self, graph: ComputationGraph, placement: torch.Tensor, ranks: torch.Tensor,
-        variant: str, candidate_ranks: Iterable[int],
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Project placed graph-discovered expert groups onto one common rank."""
+        self,
+        graph: ComputationGraph,
+        placement: torch.Tensor,
+        ranks: torch.Tensor,
+        variant: Union[str, Sequence[str]],
+        candidate_ranks: Iterable[int],
+    ) -> Tuple[torch.Tensor, torch.Tensor, List[str]]:
+        """Project placed graph-discovered expert groups onto one feasible variant and rank."""
+        variants = [variant] * graph.n_nodes if isinstance(variant, str) else list(variant)
+        if len(variants) != graph.n_nodes:
+            raise ValueError("variant list must have one entry per graph node")
         if self._moe_constraint is None:
-            return placement, ranks
+            return placement, ranks, variants
+        rank_candidates = sorted({int(rank) for rank in candidate_ranks if int(rank) > 0})
         groups: Dict[str, List[int]] = {}
-        for i in range(graph.n_nodes):
-            info = self._node_info_from_graph(graph, i)
-            if placement[i] > 0.5 and info.semantic_role == "MoE_expert" and info.moe_group:
-                groups.setdefault(info.moe_group, []).append(i)
+        for index in range(graph.n_nodes):
+            info = self._node_info_from_graph(graph, index)
+            if placement[index] > 0.5 and info.semantic_role == "MoE_expert" and info.moe_group:
+                groups.setdefault(info.moe_group, []).append(index)
         for indices in groups.values():
             if len(indices) < 2:
                 continue
-            common = []
-            for rank in sorted({int(x) for x in candidate_ranks if int(x) > 0}):
+            candidate_variants = list(dict.fromkeys(variants[index] for index in indices))
+            compatible_variants = [
+                candidate
+                for candidate in candidate_variants
                 if all(
-                    all(c.is_feasible(self._node_info_from_graph(graph, i), variant, rank)
-                        for c in self._hard_constraints if c is not self._moe_constraint)
-                    for i in indices
-                ):
-                    common.append(rank)
-            if not common:
-                for i in indices:
-                    placement[i] = 0.0
-                    ranks[i] = 0
+                    any(
+                        all(
+                            constraint.is_feasible(self._node_info_from_graph(graph, index), candidate, rank)
+                            for constraint in self._hard_constraints
+                            if constraint is not self._moe_constraint
+                        )
+                        for rank in rank_candidates
+                    )
+                    for index in indices
+                )
+            ]
+            if not compatible_variants:
+                for index in indices:
+                    placement[index] = 0.0
+                    ranks[index] = 0
                 continue
-            chosen = min(common, key=lambda rank: (sum(abs(int(ranks[i].item()) - rank) for i in indices), rank))
-            for i in indices:
-                ranks[i] = chosen
-        return placement, ranks
+            chosen_variant = compatible_variants[0]
+            for index in indices:
+                variants[index] = chosen_variant
+            common_ranks = [
+                rank
+                for rank in rank_candidates
+                if all(
+                    all(
+                        constraint.is_feasible(self._node_info_from_graph(graph, index), chosen_variant, rank)
+                        for constraint in self._hard_constraints
+                        if constraint is not self._moe_constraint
+                    )
+                    for index in indices
+                )
+            ]
+            if not common_ranks:
+                for index in indices:
+                    placement[index] = 0.0
+                    ranks[index] = 0
+                continue
+            chosen_rank = min(
+                common_ranks,
+                key=lambda rank: (sum(abs(int(ranks[index].item()) - rank) for index in indices), rank),
+            )
+            for index in indices:
+                ranks[index] = chosen_rank
+        return placement, ranks, variants
 
     def evaluate_soft(
         self,
         graph: ComputationGraph,
         placement: torch.Tensor,
         ranks: torch.Tensor,
-        variant: str,
-    ) -> Dict[str, float]:
+        variant: Union[str, Sequence[str]],
+    ) -> Dict[str, Union[float, torch.Tensor]]:
         """Evaluate soft constraints and return a dict of violation scalars.
         Positive values indicate violation; zero means satisfied.
         """
-        # Aggregate per-node penalties for placed modules
-        total_penalties: Dict[str, float] = {}
+        variants = [variant] * graph.n_nodes if isinstance(variant, str) else list(variant)
+        if len(variants) != graph.n_nodes:
+            raise ValueError("variant list must have one entry per graph node")
+        differentiable = bool(placement.requires_grad or ranks.requires_grad)
+        total_penalties: Dict[str, Union[float, torch.Tensor]] = {}
         for c in self._soft_constraints:
+            if differentiable and isinstance(c, BudgetConstraint):
+                costs = []
+                for index in range(graph.n_nodes):
+                    cost = graph.estimate_params(index, ranks[index], variants[index])
+                    if not isinstance(cost, torch.Tensor):
+                        cost = torch.as_tensor(cost, dtype=placement.dtype, device=placement.device)
+                    costs.append(cost)
+                used = torch.sum(placement * torch.stack(costs))
+                total_penalties[c.name] = torch.relu(used - c.max_params) / max(float(c.max_params), 1.0)
+                continue
             total = 0.0
-            for i in range(graph.n_nodes):
-                if placement[i] > 0.5:
-                    node_info = self._node_info_from_graph(graph, i)
-                    rank = int(ranks[i].item()) if isinstance(ranks[i], torch.Tensor) else int(ranks[i])
-                    total += c.penalty(node_info, variant, rank)
+            for index in range(graph.n_nodes):
+                node_info = self._node_info_from_graph(graph, index)
+                rank = int(ranks[index].item()) if isinstance(ranks[index], torch.Tensor) else int(ranks[index])
+                penalty = c.penalty(node_info, variants[index], rank)
+                if differentiable:
+                    total = total + placement[index] * penalty
+                elif placement[index] > 0.5:
+                    total += penalty
             total_penalties[c.name] = total * c.weight
         return total_penalties
 
@@ -813,13 +905,16 @@ class ConstraintRegistry:
         graph: ComputationGraph,
         placement: torch.Tensor,
         ranks: torch.Tensor,
-        variant: str,
+        variant: Union[str, Sequence[str]],
     ) -> int:
         """Sum of adapter parameters for all placed modules."""
+        variants = [variant] * graph.n_nodes if isinstance(variant, str) else list(variant)
+        if len(variants) != graph.n_nodes:
+            raise ValueError("variant list must have one entry per graph node")
         total = 0
-        for i in range(graph.n_nodes):
-            if placement[i] > 0.5:
-                total += int(graph.estimate_params(i, int(ranks[i].item()), variant))
+        for index in range(graph.n_nodes):
+            if placement[index] > 0.5:
+                total += int(graph.estimate_params(index, int(ranks[index].item()), variants[index]))
         return total
 
     # -- new per-node interface --

--- a/ultralytics/vpeft/solver.py
+++ b/ultralytics/vpeft/solver.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import math
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -51,20 +51,23 @@ def _project_discrete_solution(
     graph: ComputationGraph,
     placement: torch.Tensor,
     ranks: torch.Tensor,
-    variant: str,
+    variant: Union[str, Sequence[str]],
     constraints: ConstraintRegistry,
     candidate_ranks: List[int],
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Project a discrete solution onto concrete per-node rank constraints."""
     projected_placement = placement.clone()
     projected_ranks = ranks.clone()
+    variants = [variant] * graph.n_nodes if isinstance(variant, str) else list(variant)
+    if len(variants) != graph.n_nodes:
+        raise ValueError("variant list must have one entry per graph node")
     rank_set = sorted({int(rank) for rank in candidate_ranks if int(rank) > 0})
 
     for i in range(graph.n_nodes):
         if projected_placement[i] <= 0.5:
             projected_ranks[i] = 0
             continue
-        feasible = [rank for rank in rank_set if constraints.is_rank_feasible(graph, i, variant, rank)]
+        feasible = [rank for rank in rank_set if constraints.is_rank_feasible(graph, i, variants[i], rank)]
         if not feasible:
             projected_placement[i] = 0.0
             projected_ranks[i] = 0
@@ -81,32 +84,35 @@ def _project_budget(
     placement: torch.Tensor,
     ranks: torch.Tensor,
     budget: int,
-    variant: str,
+    variant: Union[str, Sequence[str]],
     utilities: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Drop lowest utility-density nodes until the hard budget is restored."""
+    """Drop the lowest utility-density nodes until the hard budget is restored."""
     placement = placement.clone()
     ranks = ranks.clone()
+    variants = [variant] * graph.n_nodes if isinstance(variant, str) else list(variant)
+    if len(variants) != graph.n_nodes:
+        raise ValueError("variant list must have one entry per graph node")
     while True:
         used = sum(
-            graph.estimate_params(i, int(ranks[i].item()), variant)
-            for i in range(graph.n_nodes)
-            if placement[i] > 0.5 and ranks[i] > 0
+            graph.estimate_params(index, int(ranks[index].item()), variants[index])
+            for index in range(graph.n_nodes)
+            if placement[index] > 0.5 and ranks[index] > 0
         )
         if used <= budget:
             return placement, ranks
         placed = [
-            i for i in range(graph.n_nodes)
-            if placement[i] > 0.5 and ranks[i] > 0
+            index for index in range(graph.n_nodes) if placement[index] > 0.5 and ranks[index] > 0
         ]
         if not placed:
             return placement, ranks
         drop = min(
             placed,
-            key=lambda i: (
-                utilities[i].item() / max(graph.estimate_params(i, int(ranks[i].item()), variant), 1),
-                utilities[i].item(),
-                i,
+            key=lambda index: (
+                utilities[index].item()
+                / max(graph.estimate_params(index, int(ranks[index].item()), variants[index]), 1),
+                utilities[index].item(),
+                index,
             ),
         )
         placement[drop] = 0.0
@@ -147,6 +153,9 @@ class PlacementDecision:
 
     utility: float
     """Total objective value U(π, r, ξ)."""
+
+    variants: Optional[List[str]] = None
+    """Effective per-node PEFT variants; absent entries default to ``variant``."""
 
 
 # ---------------------------------------------------------------------------
@@ -297,7 +306,7 @@ class AlternatingOptimizationSolver(ConstraintSolver):
         """Local enumeration of a small candidate variant set per module."""
         n = graph.n_nodes
         # Small candidate set: current + two common variants
-        candidates = list(set([current_xi[0]] + ["lora", "ia3"]))
+        candidates = sorted(set(current_xi + ["lora", "ia3"]))
 
         xi_new = list(current_xi)
         for i in range(n):
@@ -344,18 +353,18 @@ class AlternatingOptimizationSolver(ConstraintSolver):
             r[i] = self.rank_min
 
         # Project to budget (greedy drop if over)
-        used = constraints.get_budget_usage(graph, pi, r, variant)
+        used = constraints.get_budget_usage(graph, pi, r, xi)
         if used > budget:
             sorted_idx = feasible_idx[torch.argsort(utilities[feasible_idx])]
             for i in sorted_idx:
                 if used <= budget:
                     break
-                used -= graph.estimate_params(i.item(), r[i].item(), variant)
+                used -= graph.estimate_params(i.item(), r[i].item(), xi[i.item()])
                 pi[i] = 0.0
                 r[i] = 0
 
-        # Dual variables for budget / latency / memory / deploy
-        soft_keys = ["budget", "latency", "memory", "deploy"]
+        # Dual variables are keyed by the registry's canonical constraint ids.
+        soft_keys = constraints.soft_constraint_names()
         lambda_dual: Dict[str, float] = {k: 0.0 for k in soft_keys}
 
         # --- alternating optimisation loop ---------------------------------
@@ -370,19 +379,21 @@ class AlternatingOptimizationSolver(ConstraintSolver):
             )
 
             # Step 2: fix (π, ξ) → optimise r
-            r = self._rank_allocator.allocate(graph, pi, budget, variant, constraints=constraints)
+            r = self._rank_allocator.allocate(graph, pi, budget, xi, constraints=constraints)
 
             # Step 3: fix (π, r) → optimise ξ (local enumeration)
             xi = self._optimize_xi(graph, pi, r, utilities, constraints, xi)
 
             # Step 4: dual ascent on soft constraints
-            soft_violations = constraints.evaluate_soft(graph, pi, r, variant)
+            soft_violations = constraints.evaluate_soft(graph, pi, r, xi)
             for key in soft_keys:
                 violation = soft_violations.get(key, 0.0)
-                if key == "budget":
-                    used_now = constraints.get_budget_usage(graph, pi, r, variant)
+                if key == "C_budget":
+                    used_now = constraints.get_budget_usage(graph, pi, r, xi)
                     violation = max(0.0, used_now - budget)
-                lambda_dual[key] = max(0.0, lambda_dual[key] + self.dual_lr * violation)
+                if isinstance(violation, torch.Tensor):
+                    violation = float(violation.detach().item())
+                lambda_dual[key] = max(0.0, lambda_dual[key] + self.dual_lr * float(violation))
 
             # Convergence check: L1(π) + L2(r) + Hamming(ξ)
             delta_pi = torch.sum(torch.abs(pi - pi_prev)).item()
@@ -392,10 +403,10 @@ class AlternatingOptimizationSolver(ConstraintSolver):
                 break
 
         # --- post-processing -----------------------------------------------
-        pi, r = _project_discrete_solution(graph, pi, r, variant, constraints, self.rank_set)
-        pi, r = constraints.enforce_moe_consistency(graph, pi, r, variant, self.rank_set)
-        pi, r = _project_budget(graph, pi, r, budget, variant, utilities)
-        budget_used = int(constraints.get_budget_usage(graph, pi, r, variant))
+        pi, r = _project_discrete_solution(graph, pi, r, xi, constraints, self.rank_set)
+        pi, r, xi = constraints.enforce_moe_consistency(graph, pi, r, xi, self.rank_set)
+        pi, r = _project_budget(graph, pi, r, budget, xi, utilities)
+        budget_used = int(constraints.get_budget_usage(graph, pi, r, xi))
         budget_remaining = max(0, budget - budget_used)
         target_modules = [
             graph.get_module_names()[i] for i in range(n) if pi[i] > 0.5
@@ -425,6 +436,7 @@ class AlternatingOptimizationSolver(ConstraintSolver):
             target_modules=target_modules,
             reason=reason,
             utility=utility,
+            variants=list(xi),
         )
 
 
@@ -538,10 +550,11 @@ class DifferentiableOptimizationSolver(ConstraintSolver):
         # Feature vector: normalised utility per node (kept 1-D for the stub MLPs)
         feat = utilities.view(-1, 1)  # [N, 1]
 
-        soft_keys = ["budget", "latency", "memory", "deploy"]
-        lambda_dual = {k: 0.0 for k in soft_keys}
-        epsilon = {k: 0.0 for k in soft_keys}  # slack thresholds
-        epsilon["budget"] = budget
+        soft_keys = constraints.soft_constraint_names()
+        lambda_dual = {key: 1.0 for key in soft_keys}
+        epsilon = {key: 0.0 for key in soft_keys}
+        epsilon_budget = budget
+        epsilon["C_budget"] = epsilon_budget
 
         if self.optimize_variant:
             params = (
@@ -603,20 +616,27 @@ class DifferentiableOptimizationSolver(ConstraintSolver):
             budget_used = torch.sum(pi_hat * costs)
 
             penalty = _softplus_penalty(
-                budget_used - epsilon["budget"], self.beta_softplus
+                budget_used - epsilon_budget, self.beta_softplus
             )
 
             # Other soft constraints (via registry)
-            soft_violations = constraints.evaluate_soft(graph, pi_hat, r_cont, variant)
+            if self.optimize_variant and xi_soft is not None:
+                xi_for_constraints = [
+                    self.variant_candidates[index] for index in torch.argmax(xi_soft, dim=-1).tolist()
+                ]
+            else:
+                xi_for_constraints = [variant] * n
+            soft_violations = constraints.evaluate_soft(graph, pi_hat, r_cont, xi_for_constraints)
             total_penalty = penalty
             for key in soft_keys:
-                if key == "budget":
+                if key == "C_budget":
                     continue
                 val = soft_violations.get(key, 0.0)
-                if isinstance(val, (int, float)):
-                    total_penalty = total_penalty + _softplus_penalty(
-                        torch.tensor(float(val)) - epsilon[key], self.beta_softplus
-                    )
+                if not isinstance(val, torch.Tensor):
+                    val = torch.as_tensor(float(val), device=feat.device)
+                total_penalty = total_penalty + _softplus_penalty(
+                    val - epsilon[key], self.beta_softplus
+                )
 
             # Hard-constraint projection loss (penalise placement on forbidden nodes)
             L_hard = torch.sum(pi_hat * (1.0 - hard_mask.float()))
@@ -631,10 +651,11 @@ class DifferentiableOptimizationSolver(ConstraintSolver):
             # Dual ascent every 10 steps
             if iteration % 10 == 0 and iteration > 0:
                 for key in soft_keys:
-                    if key == "budget":
+                    if key == "C_budget":
                         violation = max(0.0, budget_used.item() - budget)
                     else:
-                        violation = max(0.0, soft_violations.get(key, 0.0))
+                        raw = soft_violations.get(key, 0.0)
+                        violation = max(0.0, float(raw.detach().item() if isinstance(raw, torch.Tensor) else raw))
                     lambda_dual[key] = max(
                         0.0, lambda_dual[key] + self.dual_lr * violation
                     )
@@ -671,28 +692,28 @@ class DifferentiableOptimizationSolver(ConstraintSolver):
             variant_global = variant
 
         pi_discrete, r_discrete = _project_discrete_solution(
-            graph, pi_discrete, r_discrete, variant_global, constraints, self.rank_set
+            graph, pi_discrete, r_discrete, xi_selected, constraints, self.rank_set
         )
-        pi_discrete, r_discrete = constraints.enforce_moe_consistency(
-            graph, pi_discrete, r_discrete, variant_global, self.rank_set
+        pi_discrete, r_discrete, xi_selected = constraints.enforce_moe_consistency(
+            graph, pi_discrete, r_discrete, xi_selected, self.rank_set
         )
         pi_discrete, r_discrete = _project_budget(
-            graph, pi_discrete, r_discrete, budget, variant_global, utilities
+            graph, pi_discrete, r_discrete, budget, xi_selected, utilities
         )
 
         # Post-process: ensure budget is respected by dropping lowest-utility placed modules
-        used = int(constraints.get_budget_usage(graph, pi_discrete, r_discrete, variant_global))
+        used = int(constraints.get_budget_usage(graph, pi_discrete, r_discrete, xi_selected))
         if used > budget:
             placed = (pi_discrete > 0.5).nonzero(as_tuple=True)[0]
             sorted_by_util = placed[torch.argsort(utilities[placed])]
             for i in sorted_by_util:
                 if used <= budget:
                     break
-                used -= graph.estimate_params(i.item(), r_discrete[i].item(), variant_global)
+                used -= graph.estimate_params(i.item(), r_discrete[i].item(), xi_selected[i.item()])
                 pi_discrete[i] = 0.0
                 r_discrete[i] = 0
 
-        budget_used = int(constraints.get_budget_usage(graph, pi_discrete, r_discrete, variant_global))
+        budget_used = int(constraints.get_budget_usage(graph, pi_discrete, r_discrete, xi_selected))
         budget_remaining = max(0, budget - budget_used)
         target_modules = [
             graph.get_module_names()[i] for i in range(n) if pi_discrete[i] > 0.5
@@ -719,6 +740,7 @@ class DifferentiableOptimizationSolver(ConstraintSolver):
             target_modules=target_modules,
             reason=reason,
             utility=utility,
+            variants=list(xi_selected),
         )
 
 
@@ -823,10 +845,10 @@ class MIPRelaxationSolver(ConstraintSolver):
         )
         r = allocator.allocate(graph, pi, budget, variant, constraints=constraints)
         pi, r = _project_discrete_solution(graph, pi, r, variant, constraints, self.rank_set)
-        pi, r = constraints.enforce_moe_consistency(graph, pi, r, variant, self.rank_set)
-        pi, r = _project_budget(graph, pi, r, budget, variant, utilities)
+        pi, r, variants = constraints.enforce_moe_consistency(graph, pi, r, variant, self.rank_set)
+        pi, r = _project_budget(graph, pi, r, budget, variants, utilities)
 
-        budget_used = int(constraints.get_budget_usage(graph, pi, r, variant))
+        budget_used = int(constraints.get_budget_usage(graph, pi, r, variants))
         budget_remaining = max(0, budget - budget_used)
         target_modules = [
             graph.get_module_names()[i] for i in range(n) if pi[i] > 0.5
@@ -857,6 +879,7 @@ class MIPRelaxationSolver(ConstraintSolver):
             target_modules=target_modules,
             reason=reason,
             utility=utility,
+            variants=variants,
         )
 
     # ------------------------------------------------------------------
@@ -945,12 +968,12 @@ class MIPRelaxationSolver(ConstraintSolver):
         pi_vals, ranks = _project_discrete_solution(
             graph, pi_vals, ranks, variant, constraints, self.rank_set
         )
-        pi_vals, ranks = constraints.enforce_moe_consistency(
+        pi_vals, ranks, variants = constraints.enforce_moe_consistency(
             graph, pi_vals, ranks, variant, self.rank_set
         )
-        pi_vals, ranks = _project_budget(graph, pi_vals, ranks, budget, variant, torch.tensor(utilities))
+        pi_vals, ranks = _project_budget(graph, pi_vals, ranks, budget, variants, torch.tensor(utilities))
 
-        budget_used = int(constraints.get_budget_usage(graph, pi_vals, ranks, variant))
+        budget_used = int(constraints.get_budget_usage(graph, pi_vals, ranks, variants))
         budget_remaining = max(0, budget - budget_used)
         target_modules = [
             graph.get_module_names()[i] for i in range(n) if pi_vals[i] > 0.5
@@ -981,4 +1004,5 @@ class MIPRelaxationSolver(ConstraintSolver):
             target_modules=target_modules,
             reason=reason,
             utility=utility,
+            variants=variants,
         )


### PR DESCRIPTION
## 背景

Tencent/YOLO-Master `main@fae93a7` 的 CI 在 Ubuntu x64/ARM、macOS 和 Windows 上稳定失败，直接表现为：

- `ConstraintRegistry` 缺少 `hard_constraint_names()`
- `PlacementDecision` 缺少 `variants`

该失败在合并 PR #161 之前的 `main@287db2a` 已存在，因此不是 #161 引入。根因是 `287db2a` 的合并保留了相关回归测试，但覆盖了 `6dd7294` / `3c5da5a` 中已经配套存在的 canonical constraint 与 per-node variant 实现。

主线 CI 证据：

- latest main: https://github.com/Tencent/YOLO-Master/actions/runs/29975362709
- pre-#161 main: https://github.com/Tencent/YOLO-Master/actions/runs/29939615114

## 修复内容

本 PR 恢复了下面这些配套语义：

- constraint 名称 canonical 化，以及 hard/soft constraint 的显式分类与配置覆盖
- 保留合并后的 `CandidateTargetConstraint`、MoE graph annotation 与现有 policy/RL 功能
- constraint 的 soft evaluation、budget accounting 与 MoE projection 接受真实 per-node variants
- AO 的 rank allocation、soft dual penalty、离散投影、budget projection 和最终 `budget_used` 全程使用每个节点实际选择的 variant
- DCO 离散结果与 MIP/global-variant 路径返回并按有效 per-node variants 核算
- 保持原有 single-global-variant 调用兼容

回归测试进一步改为真实异构图：Linear 节点选择 `ia3`，Conv2d 节点保留 `lora`，并验证 `decision.variants` 与 `budget_used` 的逐节点重算一致，避免出现字段已经返回、预算仍按全局 variant 计算的情况。

## Test-first 证据

在未修改的 `main@fae93a7` 上先运行现有两个回归测试：

- `test_vpeft_registry_uses_canonical_soft_constraint_names`
- `test_vpeft_ao_budget_accounts_for_per_node_variants`

Red：`2 failed`，分别复现缺少 `hard_constraint_names` 和 `PlacementDecision.variants`。

修复后：

- focused regression: `2 passed`
- `tests/test_vpeft.py`: `22 passed`
- `tests/test_vpeft_rl_rank_allocator.py`: `6 passed`
- `py_compile`: passed
- `git diff --check`: passed

测试在 R3 的隔离 `/tmp` 源码快照中以 CPU、离线方式运行，未修改共享 Python 环境或共享 checkout。

## 范围与风险

本 PR 只修改 VPEFT constraint/solver 语义及其回归测试，不包含 YOLOE 实验文件、私有 artifacts 或实验结论。OR-Tools 的 MIP exact backend 未在本地单独执行；其 single-global-variant 路径保留，跨平台结果以 Draft PR 初始 CI 为准。