### PR TITLE
[scripts/reproduce] feat: Add baseline reproduction for construction-ppe and brain-tumor datasets #49

### DIFF
--- a/scripts/reproduce/README.md
+++ b/scripts/reproduce/README.md
@@ -1,4 +1,4 @@
-# Reproduction Methodology for Training the Baseline YOLO-Master-v0.1-N & YOLO-Master-EsMoE-N on VisDrone, SKU-110K, and AI-TOD-v2
+# Reproduction Methodology for Training the Baseline YOLO-Master-v0.1-N & YOLO-Master-EsMoE-N on VisDrone, SKU-110K, AI-TOD-v2, construction-ppe, and brain-tumor
  
 
 Reproducible training strategy for the two YOLO-Master nano variants on three vertical scenes, with per-epoch logging of the required metrics (mAP50, mAP50-95, box_loss, cls_loss, moe_loss)
@@ -26,6 +26,7 @@ Below is a comprehensive guide on how to reproduce the full training pipeline
 ---
 
 ### 🚀 Updates (Latest First)
+- **🦺 2026-07-24: construction-ppe & brain-tumor Datasets:** Added two new vertical datasets — **construction-ppe** (industrial safety PPE detection, 11 classes, 1,132 images) and **brain-tumor** (medical imaging, 2 classes, 893 images) — with reproduce scripts and baseline results. See [this section](#3-training).
 - **⭐️ 2026-07-19: Optimized P2 and UoMoE Models for Tiny Object Detection:** Four new nano variants (`v0.1-P2`, `EsMoE-P2`, `UoMoE`, `UoMoE-P2`) that attack the sub-8px floor from two orthogonal angles — a stride-4 **P2 head** (spatial resolution) and **UoMoE** routing (feature/compute allocation). `UoMoE-N`, `v0.1-P2-N` and `UoMoE-P2-N` are the only real-time N-tier detectors to break **≥20% AP on AI-TOD-v2**, outperforming YOLOv12-X by ~5 AP at ~10% of its FLOPs. See [this section](#6-p2--uomoe-variants-for-tiny-object-detection).
 - **⚡️ 2026-07-18: Multi-GPU DDP Training:** All baseline models and datasets now support DDP training with up to **8 GPUs**. See [this section](#new-ddp-training).
 - **🔎 2026-07-14: AI-TOD-v2 Dataset:** [AI-TOD-v2](https://github.com/Chasel-Tsui/AI-TOD-v2) is a much harder aerial **tiny-object** benchmark: 8 classes, ~800px crops, **mean object size ≈ 12px**, and a heavy class imbalance (one class dominates ~88% of the boxes). It pushes the two nano variants well past VisDrone/SKU-110K, and cleanly exposes a difference between their two MoE designs. See [this section](#new-ddp-training).
@@ -89,7 +90,14 @@ python -c "from ultralytics.data.utils import check_det_dataset; check_det_datas
 
 Since this dataset is constructed upon the [xVIEW](https://xviewdataset.org) dataset, please refer to the offical [AI-TOD repo](https://github.com/jwwangchn/AI-TOD) for raw image downloads and generation scripts. 
 
-The dataset should be stored under the default Ultralytics `datasets_dir` , usually under `../datasets`. VisDrone is ~2.3GB, SKU-110K ~13.6GB and AI-TOD-v2 is ~27GB
+The dataset should be stored under the default Ultralytics `datasets_dir` , usually under `../datasets`. VisDrone is ~2.3GB, SKU-110K ~13.6GB, AI-TOD-v2 is ~27GB, construction-ppe is ~170MB, and brain-tumor is ~6MB.
+
+### construction-ppe & brain-tumor:
+
+```bash
+python -c "from ultralytics.data.utils import check_det_dataset; check_det_dataset('construction-ppe.yaml', autodownload=True)"
+python -c "from ultralytics.data.utils import check_det_dataset; check_det_dataset('brain-tumor.yaml', autodownload=True)"
+```
 
 ## 3. Training
 
@@ -117,6 +125,18 @@ python scripts/reproduce/reproduce_sku110k.py  --model EsMoE-N --epochs <epoch> 
 python scripts/reproduce/reproduce_aitodv2.py --model v0.1-N  --imgsz 800 --batch 64 --epochs 300
 # YOLO-Master-EsMoE-N
 python scripts/reproduce/reproduce_aitodv2.py --model EsMoE-N --imgsz 800 --batch 64 --epochs 300 --no-sparse-eval
+
+# ------ construction-ppe ------
+# YOLO-Master-v0.1-N
+python scripts/reproduce/reproduce_ppe.py --model v0.1-N  --epochs <epoch> --batch <batch-size>
+# YOLO-Master-EsMoE-N
+python scripts/reproduce/reproduce_ppe.py --model EsMoE-N --epochs <epoch> --batch <batch-size> --no-sparse-eval
+
+# ------ brain-tumor ------
+# YOLO-Master-v0.1-N
+python scripts/reproduce/reproduce_brain_tumor.py --model v0.1-N  --epochs <epoch> --batch <batch-size>
+# YOLO-Master-EsMoE-N
+python scripts/reproduce/reproduce_brain_tumor.py --model EsMoE-N --epochs <epoch> --batch <batch-size> --no-sparse-eval
 ```
 
 ### Key flags
@@ -198,6 +218,10 @@ python scripts/reproduce/reproduce_ddp.py --dataset VisDrone --model UoMoE-N --d
 | EsMoE-N | SKU-110K | `--no-sparse-eval` | 0.904 | 0.583 | [View](https://wandb.ai/yolo-master-reproduce/yolo-master-reproduce/runs/yiz22jp3) | [Download](https://github.com/skywalker-lt/YOLO-Master/releases/download/v0.1.0/result-esmoen-sku110k.zip) |
 | v0.1-N | AI-TOD-v2 | default | 0.282 | 0.120 | [View](https://wandb.ai/yolo-master-reproduce/yolo-master-reproduce/runs/x8447xku) | N/A |
 | EsMoE-N | AI-TOD-v2 | `--no-sparse-eval` | ≈0 (collapsed) | ≈0 | [View](https://wandb.ai/yolo-master-reproduce/yolo-master-reproduce/runs/x8447xku) | N/A | 
+| v0.1-N | construction-ppe | default | 0.527 | 0.253 | [View](https://wandb.ai/delei-kong-szu/yolo-master-reproduce/runs/3z8vcfuy) | N/A |
+| EsMoE-N | construction-ppe | `--no-sparse-eval` | 0.535 | 0.267 | [View](https://wandb.ai/delei-kong-szu/yolo-master-reproduce/runs/cvsslgdu) | N/A |
+| v0.1-N | brain-tumor | default | 0.531 | 0.364 | [View](https://wandb.ai/delei-kong-szu/yolo-master-reproduce/runs/n1qozc3y) | N/A |
+| EsMoE-N | brain-tumor | `--no-sparse-eval` | 0.552 | 0.381 | [View](https://wandb.ai/delei-kong-szu/yolo-master-reproduce/runs/hpi4dvhj) | N/A | 
 
 *The raw results of the AI-TOD-v2 training runs are unavailable. Please check the W&B runs instead.
 

--- a/scripts/reproduce/reproduce_brain_tumor.py
+++ b/scripts/reproduce/reproduce_brain_tumor.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Reproduce YOLO-Master-v0.1-N and YOLO-Master-EsMoE-N baselines on brain-tumor.
+
+brain-tumor (medical imaging: negative/positive tumor detection, 2 classes),
+built-in config brain-tumor.yaml. Add --no-sparse-eval to opt into the
+corrected dense evaluation for EsMoE-N (train==eval); v0.1-N is unaffected.
+
+Examples:
+    python scripts/reproduce/reproduce_brain_tumor.py --check-build
+    python scripts/reproduce/reproduce_brain_tumor.py --epochs 200 --batch 32
+    python scripts/reproduce/reproduce_brain_tumor.py --model EsMoE-N --no-sparse-eval
+    python scripts/reproduce/reproduce_brain_tumor.py --model v0.1-N --no-wandb
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _reproduce_common import DatasetSpec, run_dataset  # noqa: E402
+
+DATASET = DatasetSpec(
+    name="brain-tumor",
+    data="brain-tumor.yaml",
+    project="runs/reproduce/brain-tumor",
+)
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_dataset(DATASET))

--- a/scripts/reproduce/reproduce_construction_ppe.py
+++ b/scripts/reproduce/reproduce_construction_ppe.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Reproduce YOLO-Master-v0.1-N and YOLO-Master-EsMoE-N baselines on construction-ppe.
+
+construction-ppe (industrial safety: helmet/vest/mask/goggles, 4 classes),
+built-in config construction-ppe.yaml. Add --no-sparse-eval to opt into the
+corrected dense evaluation for EsMoE-N (train==eval); v0.1-N is unaffected.
+
+Examples:
+    python scripts/reproduce/reproduce_construction_ppe.py --check-build
+    python scripts/reproduce/reproduce_construction_ppe.py --epochs 100 --batch 32
+    python scripts/reproduce/reproduce_construction_ppe.py --model EsMoE-N --no-sparse-eval
+    python scripts/reproduce/reproduce_construction_ppe.py --model v0.1-N --no-wandb
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _reproduce_common import DatasetSpec, run_dataset  # noqa: E402
+
+DATASET = DatasetSpec(
+    name="construction-ppe",
+    data="construction-ppe.yaml",
+    project="runs/reproduce/ppe",
+)
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_dataset(DATASET))


### PR DESCRIPTION
## TL;DR
本 PR 是针对 issue #49 的提交，工作在 VisDrone（航拍密集小目标）、construction-ppe（工业安全 PPE 检测）和 brain-tumor（脑肿瘤医学影像）三个差异显著的垂类场景上，分别使用 YOLO-Master-v0.1-N 和 YOLO-Master-EsMoE-N 完成基线训练与对比分析。三个数据集覆盖了从高空航拍到近距离监控再到灰度医学影像的不同领域，验证了 YOLO-Master 框架在跨场景下的基线表现。
本次实验记录：
- 三个数据集在 v0.1-N 和 EsMoE-N 下的训练结果、曲线和日志；
- 三个数据集不同模型下的对比实验、推理速度对比、实验分析等；
## 环境

| 项目          | 配置                             |
| ----------- | ------------------------------ |
| GPU         | NVIDIA GeForce RTX 4090 (24GB) |
| CUDA        | 12.4                           |
| PyTorch     | 2.5.1                          |
| ultralytics | 8.3.240                        |
| Python      | 3.11.15                        |
| OS          | Ubuntu 22.04                   |

## 数据集概况

| 数据集                  | 场景      | 类别数 | 训练/验证图      | 特点               |
| -------------------- | ------- | --- | ----------- | ---------------- |
| **VisDrone**         | 航拍密集小目标 | 10  | 6,471 / 548 | 极小目标（~20px）、密集场景 |
| **construction-ppe** | 工业安全    | 11  | 1,132 / 143 | 小样本、多相似类别        |
| **brain-tumor**      | 医学影像    | 2   | 893 / 223   | 极小型（<1K 张）、二分类   |

## 模型

| 模型          | 配置文件                          | 参数量   | MoE 模块                 | 备注                    |
| ----------- | ----------------------------- | ----- | ---------------------- | --------------------- |
| **v0.1-N**  | `v0_1/det/yolo-master-n.yaml` | 7.55M | ModularRouterExpertMoE | 含 shared expert       |
| **EsMoE-N** | `v0/det/yolo-master-n.yaml`   | 2.69M | ES_MOE                 | 必须 `--no-sparse-eval` |

## 结果总览  

| 数据集              | 模型      | mAP50      | mAP50-95   | 最佳 epoch | 参数量   | 耗时        | W&B                                                                       |
| ---------------- | ------- | ---------- | ---------- | -------- | ----- | --------- | ------------------------------------------------------------------------- |
| VisDrone         | v0.1-N  | 0.3369     | 0.1951     | 173      | 7.55M | ~63 min   | [🔗](https://wandb.ai/delei-kong-szu/yolo-master-reproduce/runs/wk2xet1b) |
| VisDrone         | EsMoE-N | **0.3396** | **0.1969** | 185      | 2.69M | 207.5 min | [🔗](https://wandb.ai/delei-kong-szu/yolo-master-reproduce/runs/q6xq2dbk) |
| construction-ppe | v0.1-N  | 0.5269     | 0.2529     | 142      | 7.55M | 41.0 min  | [🔗](https://wandb.ai/delei-kong-szu/yolo-master-reproduce/runs/3z8vcfuy) |
| construction-ppe | EsMoE-N | **0.5348** | **0.2669** | 171      | 2.69M | 41.8 min  | [🔗](https://wandb.ai/delei-kong-szu/yolo-master-reproduce/runs/cvsslgdu) |
| brain-tumor      | v0.1-N  | 0.5305     | 0.3639     | 40       | 7.55M | 47.0 min  | [🔗](https://wandb.ai/delei-kong-szu/yolo-master-reproduce/runs/n1qozc3y) |
| brain-tumor      | EsMoE-N | **0.5515** | **0.3809** | 38       | 2.69M | 31.8 min  | [🔗](https://wandb.ai/delei-kong-szu/yolo-master-reproduce/runs/hpi4dvhj) |

## W&B 训练曲线

| 数据集              | 模型      | W&B Run 训练日志链接                                                      |
| ---------------- | ------- | ------------------------------------------------------------------- |
| VisDrone         | v0.1-N  | https://wandb.ai/delei-kong-szu/yolo-master-reproduce/runs/wk2xet1b |
| VisDrone         | EsMoE-N | https://wandb.ai/delei-kong-szu/yolo-master-reproduce/runs/q6xq2dbk |
| construction-ppe | v0.1-N  | https://wandb.ai/delei-kong-szu/yolo-master-reproduce/runs/3z8vcfuy |
| construction-ppe | EsMoE-N | https://wandb.ai/delei-kong-szu/yolo-master-reproduce/runs/cvsslgdu |
| brain-tumor      | v0.1-N  | https://wandb.ai/delei-kong-szu/yolo-master-reproduce/runs/n1qozc3y |
| brain-tumor      | EsMoE-N | https://wandb.ai/delei-kong-szu/yolo-master-reproduce/runs/hpi4dvhj |

## 实验分析

### 复现性评估
我们下载了作者在 v0.1.0 Release 中发布的 VisDrone 微调权重，在相同验证集上重新评估，与我们训练的模型进行指标对比：

| 指标           | 作者 EsMoE-N | 我们 EsMoE-N |
| ------------ | ---------- | ---------- |
| **mAP50**    | **0.3504** | 0.3393     |
| **mAP50-95** | **0.2036** | 0.1969     |
| **mAP75**    | **0.2030** | 0.1940     |
| 推理耗时 (ms)    | **0.87**   | 0.93       |
| 总耗时 (ms)     | **1.73**   | 1.81       |
| 参数量          | 2.69M      | 2.69M      |

可以看到论文中 EsMoE-N 与我们训练的 EsMoE-N 差距很小（mAP50 相差 0.011 / 3.2%），可以在一定程度上说明我们复现了论文当中的训练结果。

### 推理速度对比
由于论文当中重要创新点在于 Es-MoE 的应用，该应用在很大程度上减少了模型的参数量，降低了模型的推理成本。为此我们设计了相关的推理速度的对比实验，下表为验证集整体推理速度（ultralytics `results.speed`，per-image 平均）：

| 模型 | 数据集 | 推理(ms) | 预处理(ms) | 后处理(ms) | 总耗时(ms) | GFLOPs |
|------|--------|----------|-----------|-----------|-----------|--------|
| v0.1-N | VisDrone | 1.43 | 0.24 | 0.69 | 2.37 | 9.2 |
| EsMoE-N | VisDrone | **0.93** | 0.26 | 0.61 | **1.81** | 8.5 |
| v0.1-N | construction-ppe | 2.92 | 0.42 | 0.43 | 3.77 | 9.6 |
| EsMoE-N | construction-ppe | **1.62** | 0.48 | 0.43 | **2.53** | 8.5 |
| v0.1-N | brain-tumor | 1.97 | 0.40 | 0.31 | 2.68 | — |
| EsMoE-N | brain-tumor | **1.57** | 0.43 | 0.32 | **2.32** | 8.5 |

EsMoE-N 在三个数据集上的推理速度均快于 v0.1-N：VisDrone 快 35%、construction-ppe 快 45%、brain-tumor 快 20%。核心原因是 EsMoE-N 参数量仅 2.69M（v0.1-N 的 36%），GFLOPs 更低（8.5 vs 9.2），GPU kernel 耗时更短。

### corner case 分析
除了上述的实验，我们还希望分析一下不同的模型在更细致的分类指标上，或者一些corner case上有没有显著差异，分析专家架构在不同特征和纹理上会不会出现显著的学习差异，为此我们分析了不同数据集下的 per-class 指标以及corner case：

#### VisDrone per-class mAP50-95 对比：

| 类别              | v0.1-N | EsMoE-N | 差异         |
| --------------- | ------ | ------- | ---------- |
| car             | 0.5269 | 0.5317  | +0.005     |
| bus             | 0.3321 | 0.3465  | **+0.014** |
| van             | 0.2697 | 0.2732  | +0.004     |
| truck           | 0.1871 | 0.1780  | -0.009     |
| motor           | 0.1568 | 0.1579  | +0.001     |
| pedestrian      | 0.1512 | 0.1584  | +0.007     |
| tricycle        | 0.1245 | 0.1117  | -0.013     |
| people          | 0.1001 | 0.1013  | +0.001     |
| awning-tricycle | 0.0733 | 0.0787  | +0.005     |
| bicycle         | 0.0303 | 0.0315  | +0.001     |

**construction-ppe per-class mAP50-95 对比**：

| 类别        | v0.1-N | EsMoE-N | 差异         |
| --------- | ------ | ------- | ---------- |
| vest      | 0.4915 | 0.5152  | **+0.024** |
| Person    | 0.4374 | 0.4617  | **+0.024** |
| boots     | 0.4129 | 0.4217  | +0.009     |
| helmet    | 0.4124 | 0.4145  | +0.002     |
| goggles   | 0.3590 | 0.3952  | **+0.036** |
| gloves    | 0.3512 | 0.3471  | -0.004     |
| no_helmet | 0.1327 | 0.1432  | +0.010     |
| none      | 0.1364 | 0.1402  | +0.004     |
| no_gloves | 0.0392 | 0.0548  | +0.016     |
| no_goggle | 0.0300 | 0.0423  | +0.012     |
| no_boots  | 0.0008 | 0.0042  | +0.003     |

**brain-tumor per-class mAP50-95 对比**：

| 类别 | v0.1-N | EsMoE-N | 差异 |
|------|--------|---------|------|
| negative | 0.4282 | 0.4890 | **+0.061** |
| positive | 0.2981 | 0.2733 | -0.025 |

根据上述三个数据集的对比，可以发现不同的模型在不同类别上的学习并没有一个显著的差异性，说明 EsMoE-N 并没有因为参数量的减少而专注于某个类别的学习，依旧是学习到了各个类别的一个特征。部分类别的效果不好更多是整体 YOLO 架构或者数据集部分类别难度导致的。例如小目标识别困难、遮挡场景检测困难、数据集过小导致过拟合现象等。

除此之外，我们分析了几个corner case：
**VisDrone case 1 密集人群**
<img width="5760" height="1080" alt="Pasted image 20260724232230" src="https://github.com/user-attachments/assets/c717da42-5c1f-408f-8ae4-cd3ad7050422" />
可以看到 Es-MoE 相较于 v0.1-N在这个路口的密集人群上有更高的检出率，但是依旧存在显著的不足，特别是在暗处的密集人群，两者都没有很好的检出。

**VisDrone case 2 小数据类别**
<img width="2880" height="540" alt="Pasted image 20260724232718" src="https://github.com/user-attachments/assets/5eef25f1-dde6-402a-913f-6ae31d6b3e60" />
在这个case中，我们可以看到无论是 v0.1-N 还是 Es-MoE，对于二轮车的检出都比较偏弱，猜测可能是二轮车自身数据较小导致的，通过 per-class mAP50-95 中 bicycle 极差也可以看出；

### 结论
整体上我们通过上述几个实验，可以在一定程度上分析不同模型在模型复现下的一个效果，可以佐证我们在模型训练上实现了正确的多垂类数据集复现实验工作。不过我们针对实验做了一定的简单分析，其实很难评估不同模型在推理效果上的一个差异，特别是根据 pre-class 评估和corner case分析上实际上更多是表现出目标检测问题的共性：小目标、密集目标、遮挡目标检出难问题。

## 复现命令
### 下载数据集
```bash
# VisDrone（2.3GB）
wget -P <datasets_dir>/VisDrone \
  "https://gh-proxy.org/https://github.com/ultralytics/yolov5/releases/download/v1.0/VisDrone2019-DET-train.zip" \
<img width="2880" height="540" alt="Pasted image 20260724232718" src="https://github.com/user-attachments/assets/c3e7050e-01b2-4e9c-a4d0-0ae0af0c085f" />

  "https://gh-proxy.org/https://github.com/ultralytics/yolov5/releases/download/v1.0/VisDrone2019-DET-val.zip"

python -c "from ultralytics.data.utils import check_det_dataset; check_det_dataset('VisDrone.yaml', autodownload=True)"

# construction-ppe（~170MB）
wget -P <datasets_dir> \
  "https://gh-proxy.org/https://github.com/ultralytics/assets/releases/download/v0.0.0/construction-ppe.zip"

python -c "from ultralytics.data.utils import check_det_dataset; check_det_dataset('construction-ppe.yaml', autodownload=True)"

# brain-tumor（~6MB）
wget -P <datasets_dir> \
  "https://gh-proxy.org/https://github.com/ultralytics/assets/releases/download/v0.0.0/brain-tumor.zip"

python -c "from ultralytics.data.utils import check_det_dataset; check_det_dataset('brain-tumor.yaml', autodownload=True)"
```

### 训练

```bash
# VisDrone
python scripts/reproduce/reproduce_visdrone.py --model v0.1-N --epochs 200 --batch 32 --device 0

python scripts/reproduce/reproduce_visdrone.py --model EsMoE-N --epochs 200 --batch 32 --device 0 --no-sparse-eval

# construction-ppe
python scripts/reproduce/reproduce_ppe.py --model v0.1-N --epochs 200 --batch 32 --device 0

python scripts/reproduce/reproduce_ppe.py --model EsMoE-N --epochs 200 --batch 32 --device 0 --no-sparse-eval

# brain-tumor

python scripts/reproduce/reproduce_brain_tumor.py --model v0.1-N --epochs 200 --batch 32 --device 0

python scripts/reproduce/reproduce_brain_tumor.py --model EsMoE-N --epochs 200 --batch 32 --device 0 --no-sparse-eval
```
---

I have read the CLA Document and I sign the CLA

