### PR TITLE
fix(lora): preserve alpha warmup across EMA lifecycle

### DIFF
--- a/tests/test_lora_selective_ema_lifecycle.py
+++ b/tests/test_lora_selective_ema_lifecycle.py
@@ -1,0 +1,159 @@
+import io
+import math
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from ultralytics.engine.extensions.adapters import AdapterRuntimeController
+from ultralytics.engine.extensions.recovery import TrainingRecoveryController
+from ultralytics.engine.trainer import BaseTrainer
+from ultralytics.utils.lora.fallback import FewShotLoRAConv, ManualLoRAConv
+from ultralytics.utils.torch_utils import ModelEMA
+
+
+class TinyFallbackGraph(nn.Module):
+    def __init__(
+        self,
+        *,
+        wrapper_type: type[nn.Module] = ManualLoRAConv,
+        use_rslora: bool = True,
+        backend: str = "fallback",
+    ):
+        super().__init__()
+        self.layer = wrapper_type(
+            nn.Conv2d(4, 4, 1),
+            r=8,
+            alpha=16,
+            dropout=0.05,
+            use_rslora=use_rslora,
+        )
+        self.lora_enabled = True
+        self.lora_backend = backend
+        self.lora_config = SimpleNamespace(r=8, alpha=16)
+        self.lora_runtime_metadata = {
+            "effective_backend": backend,
+            "requested_use_rslora": use_rslora,
+            "effective_use_rslora": use_rslora,
+        }
+        for name, parameter in self.named_parameters():
+            parameter.requires_grad = name.endswith((".lora_A", ".lora_B"))
+
+    def forward(self, x):
+        return self.layer(x)
+
+
+def _trainer(model: nn.Module, *, warmup: int) -> SimpleNamespace:
+    optimizer = torch.optim.SGD((parameter for parameter in model.parameters() if parameter.requires_grad), lr=0.1)
+    trainer = SimpleNamespace(
+        model=model,
+        optimizer=optimizer,
+        epochs=7,
+        resume=True,
+        ema=None,
+        lora_strategy=None,
+        args=SimpleNamespace(
+            model="tiny.pt",
+            close_mosaic=0,
+            lora_type="lora",
+            lora_alpha_warmup=warmup,
+            lora_layer_decay=0.0,
+            lora_ortho_weight=0.0,
+            lora_ortho_frequency=10,
+            lora_dropout=0.05,
+            lora_dropout_end=0.05,
+            lora_dropout_start_ratio=1.0,
+        ),
+    )
+    trainer._restore_lora_resume_model = lambda _checkpoint: None
+    trainer._load_checkpoint_state = lambda _checkpoint: None
+    return trainer
+
+
+def _controller(model: nn.Module, *, warmup: int):
+    trainer = _trainer(model, warmup=warmup)
+    controller = AdapterRuntimeController(trainer)
+    trainer.adapter_controller = controller
+    controller.configure_optimizer(trainer.optimizer)
+    trainer.ema = ModelEMA(model)
+    return trainer, controller
+
+
+@pytest.mark.parametrize("wrapper_type", (ManualLoRAConv, FewShotLoRAConv))
+@pytest.mark.parametrize("use_rslora", (False, True))
+def test_fallback_alpha_warmup_updates_online_and_ema_scaling(wrapper_type, use_rslora: bool):
+    model = TinyFallbackGraph(wrapper_type=wrapper_type, use_rslora=use_rslora)
+    trainer, controller = _controller(model, warmup=5)
+    full_scale = 16 / math.sqrt(8) if use_rslora else 16 / 8
+
+    assert model.layer.scaling == 0.0
+    assert trainer.ema.ema.layer.scaling == 0.0
+
+    for epoch in range(7):
+        controller.begin_epoch(epoch)
+        expected_factor = 0.5 * (1 - math.cos(math.pi * min(epoch / 5, 1.0)))
+        assert model.layer.scaling == pytest.approx(full_scale * expected_factor)
+        assert trainer.ema.ema.layer.scaling == pytest.approx(model.layer.scaling)
+
+
+@pytest.mark.parametrize("start_epoch", (2, 6))
+def test_resume_restores_scheduled_scaling_online_and_ema(start_epoch: int):
+    model = TinyFallbackGraph(use_rslora=True)
+    trainer, _ = _controller(model, warmup=5)
+
+    BaseTrainer.resume_training(trainer, {"epoch": start_epoch - 1})
+
+    expected_factor = 0.5 * (1 - math.cos(math.pi * min(start_epoch / 5, 1.0)))
+    expected = 16 / math.sqrt(8) * expected_factor
+    assert model.layer.scaling == pytest.approx(expected)
+    assert trainer.ema.ema.layer.scaling == pytest.approx(expected)
+
+
+def test_non_fallback_backend_does_not_rewrite_ema_treatment():
+    model = TinyFallbackGraph(backend="peft")
+    trainer, controller = _controller(model, warmup=0)
+    trainer.ema.ema.layer.scaling = 0.0
+
+    assert controller.sync_ema_treatment() == 0
+    assert trainer.ema.ema.layer.scaling == 0.0
+
+
+def test_validation_syncs_fallback_treatment_before_selecting_ema_model():
+    model = TinyFallbackGraph()
+    trainer, controller = _controller(model, warmup=0)
+    trainer.ema.ema.layer.scaling = 0.0
+    trainer._sync_ema_buffers_for_validation = lambda: None
+    trainer._state_is_finite = lambda _value: True
+    trainer.best_fitness = None
+    trainer.loss = torch.tensor(1.0)
+
+    def validator(runtime_trainer):
+        assert runtime_trainer.ema.ema.layer.scaling == model.layer.scaling
+        return {"fitness": 1.0}
+
+    trainer.validator = validator
+    metrics, fitness = BaseTrainer.validate(trainer)
+
+    assert metrics == {}
+    assert fitness == 1.0
+    assert controller.sync_ema_treatment() == 1
+
+
+def test_checkpoint_serialization_syncs_fallback_treatment():
+    model = TinyFallbackGraph()
+    trainer, _ = _controller(model, warmup=0)
+    trainer.ema.ema.layer.scaling = 0.0
+    trainer.scaler = SimpleNamespace(state_dict=lambda: {})
+    trainer.epoch = 0
+    trainer.start_epoch = 0
+    trainer.best_fitness = 0.0
+    trainer.metrics = {}
+    trainer.fitness = 0.0
+    trainer.read_results_csv = lambda: {}
+
+    serialized = TrainingRecoveryController(trainer).serialize_checkpoint(include_online_model=True)
+    checkpoint = torch.load(io.BytesIO(serialized), map_location="cpu", weights_only=False)
+
+    assert checkpoint["ema"].layer.scaling == model.layer.scaling
+    assert checkpoint["ema"].layer.use_rslora is True

--- a/ultralytics/engine/extensions/adapters.py
+++ b/ultralytics/engine/extensions/adapters.py
@@ -27,6 +27,8 @@ def update_args_with_lora_runtime_metadata(args, model) -> None:
         "peft_type": "effective_lora_type",
         "requested_init_lora_weights": "requested_lora_init_lora_weights",
         "effective_init_lora_weights": "effective_lora_init_lora_weights",
+        "requested_use_rslora": "requested_lora_use_rslora",
+        "effective_use_rslora": "effective_lora_use_rslora",
         "safety_profile": "lora_safety_profile",
         "safety_overrides": "lora_safety_overrides",
         "target_audit": "lora_target_audit",
@@ -219,16 +221,58 @@ class AdapterRuntimeController:
         self.trainer.lora_ortho_frequency = self.ortho_frequency
         self.trainer.lora_ortho_batch_counter = 0
 
+    def sync_ema_treatment(self) -> int:
+        """Copy scheduled fallback scaling from online wrappers to matching EMA wrappers."""
+        metadata = getattr(self.model, "lora_runtime_metadata", {}) or {}
+        effective_backend = metadata.get("effective_backend", getattr(self.model, "lora_backend", None))
+        if effective_backend != "fallback":
+            return 0
+        ema = getattr(getattr(self.trainer, "ema", None), "ema", None)
+        if ema is None:
+            return 0
+        from ultralytics.utils.lora.fallback import FewShotLoRAConv, ManualLoRAConv
+
+        online_modules = dict(self.model.named_modules())
+        ema_modules = dict(unwrap_model(ema).named_modules())
+        synced = 0
+        for name, online in online_modules.items():
+            if not isinstance(online, (ManualLoRAConv, FewShotLoRAConv)):
+                continue
+            averaged = ema_modules.get(name)
+            if not isinstance(averaged, type(online)):
+                raise ValueError(f"EMA fallback adapter layout differs at '{name}'.")
+            online_identity = (online.use_rslora, online.r, online.alpha)
+            ema_identity = (averaged.use_rslora, averaged.r, averaged.alpha)
+            if ema_identity != online_identity:
+                raise ValueError(f"EMA fallback adapter identity differs at '{name}'.")
+            averaged.scaling = online.scaling
+            synced += 1
+        return synced
+
+    def _set_alpha_for_epoch(self, epoch: int) -> None:
+        """Set the effective alpha schedule, including resume after the warmup endpoint."""
+        if self.strategy is None:
+            return
+        alpha_warmup = int(getattr(self.trainer.args, "lora_alpha_warmup", 0) or 0)
+        if alpha_warmup <= 0:
+            return
+        if epoch < alpha_warmup:
+            self.strategy.step_alpha_warmup(epoch, warmup_epochs=alpha_warmup)
+        elif getattr(self.strategy, "_strategy_active", False):
+            self.strategy.finalize_alpha_warmup()
+
+    def restore_after_resume(self, start_epoch: int) -> None:
+        """Restore the scheduled treatment after checkpoint reconstruction."""
+        self._set_alpha_for_epoch(start_epoch)
+        self.sync_ema_treatment()
+
     def begin_epoch(self, epoch: int) -> None:
         """Advance alpha warmup and adapter dropout schedules."""
         if self.strategy is None:
             return
         args = self.trainer.args
-        alpha_warmup = int(getattr(args, "lora_alpha_warmup", 0) or 0)
-        if 0 <= epoch < alpha_warmup:
-            self.strategy.step_alpha_warmup(epoch, warmup_epochs=alpha_warmup)
-        elif alpha_warmup > 0 and epoch == alpha_warmup:
-            self.strategy.finalize_alpha_warmup()
+        self._set_alpha_for_epoch(epoch)
+        self.sync_ema_treatment()
         self.strategy.update_dropout_schedule(
             self.trainer.model,
             epoch=epoch,

--- a/ultralytics/engine/extensions/recovery.py
+++ b/ultralytics/engine/extensions/recovery.py
@@ -155,6 +155,9 @@ class TrainingRecoveryController:
         trainer = self.trainer
         from ultralytics.utils.checkpoint_compat import checkpoint_runtime_metadata
 
+        adapter_controller = getattr(trainer, "adapter_controller", None)
+        if adapter_controller is not None:
+            adapter_controller.sync_ema_treatment()
         buffer = io.BytesIO()
         source_model = unwrap_model(trainer.model)
         model = deepcopy(source_model) if include_online_model else None

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -995,6 +995,9 @@ class BaseTrainer:
                 - metrics (dict | None): Dictionary of validation metrics, or None if validation was skipped.
                 - fitness (float | None): Fitness score for the validation, or None if validation was skipped.
         """
+        adapter_controller = getattr(self, "adapter_controller", None)
+        if adapter_controller is not None:
+            adapter_controller.sync_ema_treatment()
         self._sync_ema_buffers_for_validation()
         ema_model = getattr(getattr(self, "ema", None), "ema", None)
         if ema_model is not None and not self._state_is_finite(unwrap_model(ema_model)):
@@ -1420,6 +1423,9 @@ class BaseTrainer:
             unwrap_model(self.model).criterion.updates = start_epoch - 1
             unwrap_model(self.model).criterion.update()
         self.start_epoch = start_epoch
+        adapter_controller = getattr(self, "adapter_controller", None)
+        if adapter_controller is not None:
+            adapter_controller.restore_after_resume(start_epoch)
         if start_epoch > (self.epochs - self.args.close_mosaic):
             self._close_dataloader_mosaic()
 

--- a/ultralytics/utils/lora/training.py
+++ b/ultralytics/utils/lora/training.py
@@ -251,7 +251,9 @@ class LoraTrainingStrategy:
             # PEFT >= 0.18 uses nn.ModuleDict for lora_A (e.g. {'default': Conv2d}).
             # Older PEFT stores lora_A as a single Parameter or Module with .weight.
             is_lora_layer = False
-            if isinstance(lora_a, nn.ModuleDict):
+            if isinstance(lora_a, nn.Parameter):
+                is_lora_layer = True
+            elif isinstance(lora_a, nn.ModuleDict):
                 # Check that at least one adapter entry has a weight attribute
                 is_lora_layer = any(hasattr(child, 'weight') for child in lora_a.values())
             elif hasattr(lora_a, 'weight'):


### PR DESCRIPTION
## 背景

这个改动接着 #170 往下做。#170 处理了 fallback RS-LoRA 的 scaling 和保存加载；alpha warmup 还涉及 EMA、验证和断点恢复，所以当时单独拆了出来。

目前 fallback LoRA wrapper 的 `lora_A` 是 bare `nn.Parameter`，现有 warmup 发现逻辑不会识别它。配置 `lora_alpha_warmup` 后，fallback adapter 实际上仍会直接使用完整 scaling。

同时，fallback wrapper 的 `scaling` 是普通 Python 属性，不在 `state_dict` 中。online model 更新 scaling 后，EMA model 不会自动同步，验证、保存 checkpoint 和恢复训练时可能使用不同的 scaling。

## 修改内容

- 让 alpha warmup 能识别 bare-Parameter fallback wrapper；
- 每个 epoch 更新 warmup 后，同步 online model 和 EMA model 的 scaling；
- 在验证、保存 checkpoint 和恢复训练时再次同步；
- 同步时检查 wrapper 类型、`use_rslora`、rank 和 alpha 是否一致；
- 在运行参数中记录 requested/effective RS-LoRA mode。

这里只同步 fallback wrapper 的 `scaling`，EMA 原有的参数和 buffer 更新方式保持不变。

## 测试

新增 9 个测试，覆盖：

- `ManualLoRAConv` 和 `FewShotLoRAConv`；
- 普通 LoRA 与 RS-LoRA；
- 各个 epoch 的 warmup scaling；
- 验证和 checkpoint 中的 EMA scaling；
- 从 warmup 中途或结束后恢复训练；
- 非 fallback backend。

同一组测试在未修改的 `main` 上为 `8 failed, 1 passed`，应用修复后为 `9 passed`。

相关 LoRA、adapter、EMA、recovery 和 planner 测试为 `159 passed, 1 deselected`。Ruff、`py_compile` 和 `git diff --check` 也已通过。

## 说明

这次没有改 fallback adapter 的 merge 逻辑，也没有调整 EMA 对参数和 buffer 的正常更新方式。
