### PR TITLE
[tools/routing] feat: ES-MoE路由行为评估框架——从专家利用率到击中率的指标修正与对照实验验证 #52

### DIFF
--- a/scripts/reproduce/_reproduce_common.py
+++ b/scripts/reproduce/_reproduce_common.py
@@ -145,9 +145,11 @@ _WANDB_METRICS = {
     "train/box_loss": "train/box_loss",
     "train/cls_loss": "train/cls_loss",
     "train/moe_loss": "train/moe_loss",
+    "train/mixture_aux_loss": "train/mixture_aux_loss",
     "val/box_loss": "val/box_loss",
     "val/cls_loss": "val/cls_loss",
     "val/moe_loss": "val/moe_loss",
+    "val/mixture_aux_loss": "val/mixture_aux_loss",
 }
 
 

--- a/scripts/reproduce/reproduce_visdrone_sparse.py
+++ b/scripts/reproduce/reproduce_visdrone_sparse.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""按照论文 ES-MoE 设计训练 VisDrone baseline：soft Top-2 训练 + hard Top-2 验证。
+
+与 reproduce_visdrone.py 的区别：不使用 --no-sparse-eval，确保 top_k=2 < num_experts=4，
+实现论文设计的真正稀疏路由。每 N 个 epoch 输出路由诊断指标到 W&B。
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+import traceback
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _reproduce_common import (
+    DatasetSpec, ModelSpec, _read_last_metrics, _float_or_blank,
+    write_summary, _completed_epoch, _make_wandb_callbacks,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+SPARSE_MODEL = ModelSpec("EsMoE-N", "ultralytics/cfg/models/master/v0/det/yolo-master-n.yaml", uses_esmoe=True)
+DATASET = DatasetSpec("VisDrone", "VisDrone.yaml", "")  # project 由命令行指定
+
+
+def _make_sparse_topk_callback():
+    """确保 ES_MOE 使用 top_k=2 的稀疏路由（论文设计）。"""
+    from ultralytics.nn.modules.moe.modules import ES_MOE
+    from ultralytics.utils import LOGGER
+
+    state = {"applied": False}
+
+    def _apply(trainer):
+        if state["applied"]:
+            return
+        targets = [trainer.model]
+        ema = getattr(trainer, "ema", None)
+        if ema is not None and getattr(ema, "ema", None) is not None:
+            targets.append(ema.ema)
+
+        count = 0
+        for target in targets:
+            for m in target.modules():
+                if isinstance(m, ES_MOE):
+                    m.use_sparse_inference = True
+                    m.use_top_k = True
+                    m.top_k = 2
+                    count += 1
+        if count:
+            LOGGER.info(f"[reproduce:sparse] top_k=2 enabled on {count} ES_MOE module(s)")
+            state["applied"] = True
+
+    return _apply
+
+
+def _make_routing_diag_callback(every_n_epochs: int = 5):
+    """每 N 个 epoch 在验证后收集路由诊断指标，记录到 W&B 及训练日志。"""
+    from ultralytics.nn.modules.moe.modules import ES_MOE
+    from ultralytics.utils import LOGGER
+
+    def _on_val_end(trainer):
+        epoch = int(getattr(trainer, "epoch", 0)) + 1
+        if epoch % every_n_epochs != 0:
+            return
+
+        # 从 EMA 模型读取各层 ES_MOE 的 last_routing_snapshot
+        ema = getattr(trainer, "ema", None)
+        target = ema.ema if (ema is not None and getattr(ema, "ema", None) is not None) else trainer.model
+
+        layers_data = {}
+        for name, m in target.named_modules():
+            snap = getattr(m, "last_routing_snapshot", None)
+            if not isinstance(snap, dict) or not snap:
+                continue
+            usage = snap.get("expert_usage")
+            if usage is None:
+                continue
+            usage_list = [float(x) for x in usage.detach().cpu().reshape(-1)]
+            layers_data[name] = {
+                "num_experts": len(usage_list),
+                "usage": usage_list,
+            }
+
+        if not layers_data:
+            return
+
+        # 计算每层指标
+        for name, d in layers_data.items():
+            short = name.replace("model.", "L").replace(".routing", "")
+            usage = d["usage"]
+            gini = _compute_gini(usage)
+            dominant = max(usage) / (sum(usage) + 1e-12)
+
+            LOGGER.info(
+                f"[routing] epoch={epoch:>4d}  {short}: "
+                + "  ".join(f"E{i}:{u:.3f}" for i, u in enumerate(usage))
+                + f"  | Gini={gini:.3f}  Dominant={dominant:.3f}"
+            )
+
+            # 写入 W&B
+            try:
+                wandb_run = getattr(trainer, "wandb", None)
+                if wandb_run is not None:
+                    wandb_run.log({
+                        f"routing/{short}/gini": gini,
+                        f"routing/{short}/dominant": dominant,
+                        "routing/epoch": epoch,
+                    }, step=epoch)
+                    for i, u in enumerate(usage):
+                        wandb_run.log({f"routing/{short}/E{i}_usage": u}, step=epoch)
+            except Exception:
+                pass
+
+    return _on_val_end
+
+
+def _compute_gini(values):
+    import numpy as np
+    arr = np.array(values, dtype=np.float64)
+    total = arr.sum()
+    if total <= 0:
+        return 0.0
+    arr = arr / total
+    n = len(arr)
+    diff_sum = np.abs(arr[:, None] - arr[None, :]).sum()
+    return float(diff_sum / (2 * n))
+
+
+def train_sparse(args):
+    from ultralytics import YOLO
+
+    dataset = DatasetSpec("VisDrone", "VisDrone.yaml", args.project)
+    spec = SPARSE_MODEL
+    run_name = f"{dataset.name}_{spec.name}"
+    run_dir = Path(args.project) / run_name
+
+    last_pt = run_dir / "weights" / "last.pt"
+    best_pt = run_dir / "weights" / "best.pt"
+    done = _completed_epoch(run_dir)
+
+    if best_pt.exists() and done is not None and done + 1 >= args.epochs:
+        print(f"[skip] {run_name}: complete at epoch {done}", flush=True)
+        return {"model": spec.name, "status": "skipped"}
+
+    if last_pt.exists() and done is not None:
+        print(f"[resume] {run_name}: {last_pt} epoch={done} -> {args.epochs}", flush=True)
+        model = YOLO(str(last_pt))
+        resume = True
+    else:
+        print(f"[train:sparse] {run_name}: cfg={spec.cfg} data={dataset.data}  epochs={args.epochs}", flush=True)
+        model = YOLO(str(ROOT / spec.cfg))
+        resume = False
+
+    # 注入 top_k=2 回调
+    cb = _make_sparse_topk_callback()
+    model.add_callback("on_pretrain_routine_end", cb)
+
+    # W&B 回调
+    if args.wandb and args.wandb_mode != "disabled":
+        wandb_callbacks = _make_wandb_callbacks(run_name, dataset, spec, args, dense_val=False)
+        for event, fn in wandb_callbacks.items():
+            model.add_callback(event, fn)
+
+    # 路由诊断回调（每 N 个 epoch 在验证后记录路由指标）
+    diag_cb = _make_routing_diag_callback(every_n_epochs=args.routing_diag_interval)
+    model.add_callback("on_fit_epoch_end", diag_cb)
+
+    start = time.time()
+    model.train(
+        data=dataset.data,
+        epochs=args.epochs,
+        imgsz=args.imgsz,
+        batch=args.batch,
+        device=args.device,
+        workers=args.workers,
+        seed=args.seed,
+        deterministic=True,
+        project=str(args.project),
+        name=run_name,
+        exist_ok=True,
+        pretrained=False,
+        lora_r=0,
+        optimizer="auto",
+        val=True,
+        plots=True,
+        patience=args.patience,
+        amp=args.amp,
+        resume=resume,
+        verbose=args.verbose,
+        moe_balance_loss=args.moe_balance_loss,
+    )
+    return {"model": spec.name, "status": "resumed" if resume else "ok",
+            "duration_s": f"{time.time() - start:.1f}"}
+
+
+if __name__ == "__main__":
+    import argparse
+
+    p = argparse.ArgumentParser(description="Reproduce VisDrone EsMoE-N with sparse top-k=2 (paper design)")
+    p.add_argument("--epochs", type=int, default=500)
+    p.add_argument("--imgsz", type=int, default=640)
+    p.add_argument("--batch", type=int, default=32)
+    p.add_argument("--device", default="0")
+    p.add_argument("--workers", type=int, default=16)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--patience", type=int, default=0)
+    p.add_argument("--amp", action="store_true", default=True)
+    p.add_argument("--project", default="/root/workspace/YOLO-Master-docs/issue2/VisDrone/pahse0-baseline-train")
+    p.add_argument("--verbose", action="store_true")
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--check-build", action="store_true")
+    # W&B
+    p.add_argument("--wandb", action="store_true", default=True)
+    p.add_argument("--no-wandb", action="store_false", dest="wandb")
+    p.add_argument("--wandb-project", default="yolo-master-reproduce")
+    p.add_argument("--wandb-entity", default="")
+    p.add_argument("--wandb-mode", choices=["online", "offline", "disabled"], default="online")
+    p.add_argument("--moe-balance-loss", type=float, default=0.6)
+    p.add_argument("--routing-diag-interval", type=int, default=5, help="每 N 个 epoch 收集路由诊断")
+
+    args = p.parse_args()
+
+    if args.check_build:
+        from ultralytics.nn.tasks import DetectionModel
+        m = DetectionModel(str(ROOT / SPARSE_MODEL.cfg), ch=3, nc=80, verbose=False)
+        print(f"[build-ok] {SPARSE_MODEL.name}: {sum(p.numel() for p in m.parameters()) / 1e6:.3f}M")
+        sys.exit(0)
+
+    if args.dry_run:
+        print(f"[dry-run] Project: {args.project}  epochs={args.epochs}  batch={args.batch}  "
+              f"device={args.device}  wandb={args.wandb}")
+        sys.exit(0)
+
+    Path(args.project).mkdir(parents=True, exist_ok=True)
+    try:
+        status = train_sparse(args)
+        print(f"\n[train:sparse] DONE: {status}")
+    except Exception as exc:
+        print(f"[fail] {type(exc).__name__}: {exc}", flush=True)
+        traceback.print_exc()
+        sys.exit(1)
+
+    # 收集产物到项目目录
+    dataset = DatasetSpec("VisDrone", "VisDrone.yaml", args.project)
+    run_dir = Path(args.project) / f"{dataset.name}_{spec.name}"
+    out_dir = Path(args.project) / "baseline"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    best_src = run_dir / "weights" / "best.pt"
+    if best_src.exists():
+        import shutil
+        shutil.copy2(best_src, out_dir / "best.pt")
+        print(f"[collect] best.pt -> {out_dir / 'best.pt'}")
+
+    for f in ["args.yaml", "results.csv"]:
+        src = run_dir / f
+        if src.exists():
+            import shutil
+            shutil.copy2(src, out_dir / f)
+            print(f"[collect] {f} -> {out_dir / f}")
+
+    sys.exit(0)

--- a/tools/routing_interpreter.py
+++ b/tools/routing_interpreter.py
@@ -1,4 +1,16 @@
-"""Generate routing diagnostics and heatmaps from a YOLO-Master checkpoint."""
+"""Generate routing diagnostics and heatmaps from a YOLO-Master checkpoint.
+
+Two modes are supported:
+
+* **Single-image mode** (default) — pass a checkpoint and an image path.  Renders
+  router confidence / assignment maps and per-expert output-feature heatmaps,
+  and computes layer summaries and collapse checks.
+
+* **Dataset mode** — pass ``--dataset VisDrone.yaml`` instead of an image.  Runs
+  dataset-level sparse top‑k hit statistics, router differentiation metrics
+  (KL divergence, weight spread), and collapse reports.  Results are written as
+  ``dataset_routing_report.json``.
+"""
 
 from __future__ import annotations
 
@@ -7,7 +19,6 @@ import json
 import sys
 from pathlib import Path
 
-import numpy as np
 import torch
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -19,30 +30,72 @@ def build_parser() -> argparse.ArgumentParser:
     """Build the command-line interface."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("model", type=Path, help="YOLO checkpoint or model YAML")
-    parser.add_argument("image", type=Path, help="input image")
-    parser.add_argument("--layer", help="exact routed layer name; omit to capture all leaf routed layers")
-    parser.add_argument("--expert", type=int, help="also run a forced-expert counterfactual for --layer")
-    parser.add_argument("--imgsz", type=int, default=640, help="square inference size")
-    parser.add_argument("--device", default="cpu", help="torch device, for example cpu, mps, or cuda:0")
-    parser.add_argument("--half", action="store_true", help="use float16 inference (CUDA recommended)")
-    parser.add_argument("--output", type=Path, default=Path("runs/routing_interpreter"), help="output directory")
+    parser.add_argument(
+        "image", type=Path, nargs="?", default=None,
+        help="input image (required unless --dataset is used)",
+    )
+    parser.add_argument(
+        "--dataset",
+        help="dataset YAML path for batch analysis (replaces single-image mode)",
+    )
+    parser.add_argument(
+        "--layer",
+        help="exact routed layer name; omit to capture all leaf routed layers",
+    )
+    parser.add_argument(
+        "--expert", type=int,
+        help="also run a forced-expert counterfactual for --layer",
+    )
+    parser.add_argument(
+        "--imgsz", type=int, default=640, help="square inference size",
+    )
+    parser.add_argument(
+        "--device", default="cpu",
+        help="torch device, for example cpu, mps, or cuda:0",
+    )
+    parser.add_argument(
+        "--half", action="store_true",
+        help="use float16 inference (CUDA recommended)",
+    )
+    parser.add_argument(
+        "--output", type=Path, default=Path("runs/routing_interpreter"),
+        help="output directory",
+    )
+    parser.add_argument(
+        "--max-samples", type=int, default=None,
+        help="max images to process in dataset mode (default: all)",
+    )
+    parser.add_argument(
+        "--batch-size", type=int, default=16,
+        help="batch size for dataset mode dataloader",
+    )
     return parser
 
 
-def _load_batch(image_path: Path, imgsz: int, device: torch.device, dtype: torch.dtype) -> torch.Tensor:
+def _load_batch(
+    image_path: Path, imgsz: int, device: torch.device, dtype: torch.dtype,
+) -> torch.Tensor:
     """Load one image using the same letterbox and channel conventions as prediction."""
+    import numpy as np
+
     from ultralytics.data.augment import LetterBox
     from ultralytics.utils.patches import imread
 
     image = imread(str(image_path))
     if image is None:
         raise FileNotFoundError(f"could not read image: {image_path}")
-    resized = LetterBox(new_shape=(imgsz, imgsz), auto=False, stride=32)(image=image)
+    resized = LetterBox(new_shape=(imgsz, imgsz), auto=False, stride=32)(
+        image=image
+    )
     rgb = np.ascontiguousarray(resized[..., ::-1].transpose(2, 0, 1))
-    return torch.from_numpy(rgb).unsqueeze(0).to(device=device, dtype=dtype).div_(255.0)
+    return (
+        torch.from_numpy(rgb).unsqueeze(0).to(device=device, dtype=dtype).div_(255.0)
+    )
 
 
-def _load_model(model_path: Path, device: torch.device, half: bool) -> torch.nn.Module:
+def _load_model(
+    model_path: Path, device: torch.device, half: bool,
+) -> torch.nn.Module:
     """Load detection YAMLs and checkpoints without importing unrelated model families."""
     from ultralytics.nn.tasks import DetectionModel
     from ultralytics.utils.patches import torch_load
@@ -57,48 +110,50 @@ def _load_model(model_path: Path, device: torch.device, half: bool) -> torch.nn.
         else:
             model = checkpoint
         if not isinstance(model, torch.nn.Module):
-            raise TypeError(f"checkpoint does not contain an nn.Module under 'ema' or 'model': {model_path}")
+            raise TypeError(
+                f"checkpoint does not contain an nn.Module under 'ema' or "
+                f"'model': {model_path}"
+            )
     else:
-        raise ValueError(f"model must be a .pt, .pth, .yaml, or .yml file, got: {model_path}")
+        raise ValueError(
+            f"model must be a .pt, .pth, .yaml, or .yml file, got: {model_path}"
+        )
     model = model.to(device).eval()
     for module in model.modules():
         if hasattr(module, "inplace"):
             module.inplace = True
-        elif isinstance(module, torch.nn.Upsample) and not hasattr(module, "recompute_scale_factor"):
+        elif isinstance(module, torch.nn.Upsample) and not hasattr(
+            module, "recompute_scale_factor"
+        ):
             module.recompute_scale_factor = None
     return model.half() if half else model.float()
 
 
-def main(argv: list[str] | None = None) -> int:
-    """Run routing capture, collapse checks, rendering, and optional causal analysis."""
-    args = build_parser().parse_args(argv)
-    if args.expert is not None and not args.layer:
-        raise SystemExit("--expert requires --layer because counterfactual routing targets one exact layer")
-    if args.imgsz <= 0:
-        raise SystemExit("--imgsz must be positive")
-
+def _run_single_image(
+    args: argparse.Namespace,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> int:
+    """Single-image mode: expert feature heatmaps + collapse report."""
     from ultralytics.utils.routing_interpreter import RoutingInterpreter
 
-    device = torch.device(args.device)
-    dtype = torch.float16 if args.half else torch.float32
     network = _load_model(args.model, device, args.half)
     batch = _load_batch(args.image, args.imgsz, device, dtype)
 
     interpreter = RoutingInterpreter(network)
-    heatmaps = interpreter.visualize_routing(
-        batch,
-        layer_name=args.layer,
-        output_dir=None,
+    heatmaps, expert_features = interpreter.capture_routing_and_expert_features(
+        batch, layer_name=args.layer,
     )
     visualizations = interpreter.save_routing_visualizations(
-        heatmaps,
-        args.output,
-        input_image=batch,
+        heatmaps, args.output, input_image=batch,
+        expert_features=expert_features,
     )
     summaries = interpreter.collect_layer_summaries(heatmaps=heatmaps)
     collapse = interpreter.detect_routing_collapse(heatmaps=heatmaps)
     causal = (
-        interpreter.routing_causal_analysis(batch, args.layer, args.expert).to_dict()
+        interpreter.routing_causal_analysis(
+            batch, args.layer, args.expert,
+        ).to_dict()
         if args.expert is not None
         else None
     )
@@ -109,19 +164,137 @@ def main(argv: list[str] | None = None) -> int:
         "model": str(args.model),
         "image": str(args.image),
         "layer": args.layer,
-        "heatmaps": {name: heatmap.to_dict() for name, heatmap in heatmaps.items()},
+        "heatmaps": {name: h.to_dict() for name, h in heatmaps.items()},
+        "expert_features": {
+            name: feat.to_dict()
+            for name, feat in expert_features.items()
+        },
         "visualizations": {
             name: {artifact: str(path) for artifact, path in artifacts.items()}
             for name, artifacts in visualizations.items()
         },
-        "summaries": [summary.to_dict() for summary in summaries],
-        "collapse": {name: report.to_dict() for name, report in collapse.items()},
+        "summaries": [s.to_dict() for s in summaries],
+        "collapse": {n: r.to_dict() for n, r in collapse.items()},
         "causal": causal,
     }
-    report_path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+    report_path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8",
+    )
     print(f"Routing report: {report_path}")
     print(f"Heatmaps: {len(heatmaps)}")
     return 0
+
+
+def _run_dataset_analysis(
+    args: argparse.Namespace,
+    device: torch.device,
+) -> int:
+    """Dataset mode: sparse top-k stats + differentiation metrics."""
+    from ultralytics.data.build import build_dataloader, build_yolo_dataset
+    from ultralytics.data.utils import check_det_dataset
+    from ultralytics.utils.routing_interpreter import RoutingInterpreter
+
+    dtype = torch.float16 if args.half else torch.float32
+
+    network = _load_model(args.model, device, args.half)
+
+    # ── build dataset & dataloader ─────────────────────────────
+    data_dict = check_det_dataset(str(args.dataset))
+    from ultralytics.cfg import get_cfg
+    from ultralytics.utils import DEFAULT_CFG_DICT
+    cfg = get_cfg(DEFAULT_CFG_DICT)
+    cfg.imgsz = args.imgsz
+    cfg.rect = False
+    cfg.batch = args.batch_size
+    cfg.fraction = 1.0
+    dataset = build_yolo_dataset(
+        cfg,
+        str(data_dict["val"]),
+        batch=args.batch_size,
+        data=data_dict,
+        mode="val",
+        stride=32,
+    )
+    dataloader = build_dataloader(
+        dataset,
+        batch=args.batch_size,
+        workers=0,
+        shuffle=False,
+        rank=-1,
+    )
+
+    def _forward_tensor(_model, _batch):
+        """Pass the image tensor positionally, converting to float32."""
+        img = _batch["img"]
+        if img.dtype != torch.float32 and img.dtype != torch.float16:
+            img = img.float() / 255.0
+        return _model(img.to(next(_model.parameters()).device))
+
+    # ── run analysis ───────────────────────────────────────────
+    interpreter = RoutingInterpreter(network)
+
+    sparse_topk, differentiation, collapse = interpreter.run_dataset_analysis(
+        dataloader,
+        layer_name=args.layer,
+        max_samples=args.max_samples,
+        forward_fn=_forward_tensor,
+    )
+
+    # ── write JSON report ──────────────────────────────────────
+    args.output.mkdir(parents=True, exist_ok=True)
+    report_path = args.output / "dataset_routing_report.json"
+    num_samples = max(
+        (s.num_samples for s in sparse_topk.values()), default=0,
+    )
+    payload = {
+        "model": str(args.model),
+        "dataset": str(args.dataset),
+        "num_samples": num_samples,
+        "sparse_topk": {
+            name: s.to_dict() for name, s in sparse_topk.items()
+        },
+        "differentiation": {
+            name: m.to_dict() for name, m in differentiation.items()
+        },
+        "collapse": {
+            name: r.to_dict() for name, r in collapse.items()
+        },
+    }
+    report_path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8",
+    )
+    print(f"Dataset routing report: {report_path}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run routing capture, collapse checks, rendering, or dataset analysis."""
+    args = build_parser().parse_args(argv)
+
+    # ── validation ─────────────────────────────────────────────
+    if args.dataset and args.image:
+        raise SystemExit(
+            "Cannot specify both --dataset and a positional image argument"
+        )
+    if not args.dataset and not args.image:
+        raise SystemExit(
+            "Either an image path or --dataset is required"
+        )
+    if args.expert is not None and not args.layer:
+        raise SystemExit(
+            "--expert requires --layer because counterfactual routing targets "
+            "one exact layer"
+        )
+    if args.imgsz <= 0:
+        raise SystemExit("--imgsz must be positive")
+
+    device = torch.device(args.device)
+    dtype = torch.float16 if args.half else torch.float32
+
+    if args.dataset:
+        return _run_dataset_analysis(args, device)
+
+    return _run_single_image(args, device, dtype)
 
 
 if __name__ == "__main__":

--- a/ultralytics/nn/modules/moe/modules.py
+++ b/ultralytics/nn/modules/moe/modules.py
@@ -402,8 +402,8 @@ class AdaptiveCapacityMoE(UltraOptimizedMoE):
 class ES_MOE(nn.Module):
     """General MoE block with a routing network and multiple expert branches."""
 
-    def __init__(self, in_channels, out_channels=None, num_experts=3, reduction=8,
-                 top_k=None, use_sparse_inference=True, dynamic_threshold=0.4,
+    def __init__(self, in_channels, out_channels=None, num_experts=4, reduction=8,
+                 top_k=2, use_sparse_inference=True, dynamic_threshold=0.4,
                  max_kernel_size=15):
         """
         Args:

--- a/ultralytics/utils/routing_interpreter.py
+++ b/ultralytics/utils/routing_interpreter.py
@@ -106,6 +106,91 @@ class RoutingCausalReport:
         return asdict(self)
 
 
+@dataclass(frozen=True)
+class ExpertFeatureMap:
+    """Expert output feature maps reduced to spatial scalar maps via channel RMS.
+
+    Attributes:
+        layer_name: Name of the routed layer.
+        module_type: Class name of the routed module.
+        expert_maps: Tuple of [H, W] scalar tensors, one per expert, computed
+            as sqrt(mean(feature², dim=1)). An entry is None if the expert
+            was not executed during this forward pass.
+    """
+
+    layer_name: str
+    module_type: str
+    expert_maps: tuple[torch.Tensor | None, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "layer_name": self.layer_name,
+            "module_type": self.module_type,
+            "num_experts": len(self.expert_maps),
+            "spatial_shapes": [
+                list(m.shape) if m is not None else None for m in self.expert_maps
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class SparseTopKStats:
+    """Dataset-level sparse top-k selection statistics for one routed layer.
+
+    Attributes:
+        layer_name: Name of the routed layer.
+        module_type: Class name of the routed module.
+        num_experts: Total number of experts in the layer.
+        top_k: Number of active experts per sample.
+        num_samples: Number of samples analyzed.
+        expert_hit_counts: Per-expert count of samples where that expert was in
+            the top-k selection.
+        expert_hit_percentages: Per-expert percentage of samples where that
+            expert was in the top-k selection.
+        co_occurrence_matrix: E×E symmetric matrix of co-occurrence counts
+            (how many samples had both experts in top-k).
+    """
+
+    layer_name: str
+    module_type: str
+    num_experts: int
+    top_k: int
+    num_samples: int
+    expert_hit_counts: tuple[int, ...]
+    expert_hit_percentages: tuple[float, ...]
+    co_occurrence_matrix: tuple[tuple[int, ...], ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class RouterDifferentiationMetrics:
+    """Dataset-level router differentiation quality metrics for one routed layer.
+
+    Attributes:
+        layer_name: Name of the routed layer.
+        module_type: Class name of the routed module.
+        num_samples: Number of samples analyzed.
+        mean_kl_divergence: Mean KL(p||uniform) over all spatial positions and
+            samples.
+        std_kl_divergence: Standard deviation of per-pixel KL divergence.
+        mean_weight_spread: Mean of (max-min) of top-k weights, per sample.
+        std_weight_spread: Standard deviation of per-sample weight spread.
+    """
+
+    layer_name: str
+    module_type: str
+    num_samples: int
+    mean_kl_divergence: float
+    std_kl_divergence: float
+    mean_weight_spread: float
+    std_weight_spread: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
 class RoutingInterpreter:
     """Interpret routed models without changing their persistent runtime state."""
 
@@ -260,12 +345,118 @@ class RoutingInterpreter:
             self.save_routing_visualizations(heatmaps, output_dir, input_image=input_image)
         return heatmaps
 
+    def capture_routing_and_expert_features(
+        self,
+        batch: Any,
+        *,
+        layer_name: str | None = None,
+        forward_fn: Callable[[nn.Module, Any], Any] | None = None,
+    ) -> tuple[dict[str, RoutingHeatmap], dict[str, ExpertFeatureMap]]:
+        """Run one forward pass capturing both router probabilities and expert
+        output feature maps.
+
+        For each routed module that has an ``experts`` submodule, per-expert
+        forward hooks compute channel-RMS feature maps at the expert output.
+        Modules without experts only contribute router probabilities.
+
+        Returns:
+            ``(heatmaps, expert_features)`` where ``heatmaps`` is one
+            :class:`RoutingHeatmap` per layer and ``expert_features`` is one
+            :class:`ExpertFeatureMap` per layer that has experts.
+        """
+        modules = self._routed_modules(layer_name=layer_name, leaf_only=layer_name is None)
+        if not modules:
+            target = f" named {layer_name!r}" if layer_name else ""
+            raise ValueError(f"no routed modules{target} were found")
+
+        captured: dict[str, RoutingHeatmap] = {}
+        captured_features: dict[str, list[torch.Tensor | None]] = {}
+        handles = []
+
+        for name, module in modules.items():
+            router = self._router_for(module)
+            if router is None:
+                continue
+
+            def _capture_hook(
+                _router, _inputs, output, *, current_name=name, current_module=module
+            ):
+                probabilities = self._router_probabilities(
+                    output, int(getattr(current_module, "num_experts", 0))
+                )
+                if probabilities is None:
+                    return None
+                probabilities = probabilities.detach().float().cpu()
+                captured[current_name] = RoutingHeatmap(
+                    layer_name=current_name,
+                    module_type=type(current_module).__name__,
+                    probabilities=probabilities,
+                    assignments=probabilities.argmax(dim=1),
+                )
+                return None
+
+            handles.append(router.register_forward_hook(_capture_hook))
+
+            # --- expert feature capture ---
+            experts = getattr(module, "experts", None)
+            if isinstance(experts, nn.ModuleList) and len(experts) > 0:
+                storage: list[torch.Tensor | None] = [None] * len(experts)
+                captured_features[name] = storage
+                for idx, expert in enumerate(experts):
+                    def _make_expert_hook(slot_list, expert_idx):
+                        def _hook_fn(_mod, _inputs, output):
+                            feat = output.detach().float().cpu()
+                            rms = feat.square().mean(dim=1).sqrt()
+                            if rms.shape[0] == 1:
+                                rms = rms[0]
+                            slot_list[expert_idx] = rms
+                            return None
+
+                        return _hook_fn
+
+                    handles.append(
+                        expert.register_forward_hook(_make_expert_hook(storage, idx))
+                    )
+
+        if not handles:
+            raise ValueError(
+                "routed modules were found, but none expose a supported router "
+                "or routing submodule"
+            )
+
+        training_flags = self._training_flags()
+        try:
+            self.model.eval()
+            with torch.no_grad():
+                self._forward(batch, forward_fn)
+        finally:
+            for handle in handles:
+                handle.remove()
+            self._restore_training_flags(training_flags)
+
+        if layer_name is not None and layer_name not in captured:
+            raise RuntimeError(
+                f"router for layer {layer_name!r} did not produce a supported "
+                f"probability tensor"
+            )
+
+        expert_maps: dict[str, ExpertFeatureMap] = {}
+        for layer_name, storage in captured_features.items():
+            module_type = type(modules[layer_name]).__name__
+            expert_maps[layer_name] = ExpertFeatureMap(
+                layer_name=layer_name,
+                module_type=module_type,
+                expert_maps=tuple(storage),
+            )
+        return captured, expert_maps
+
     def save_routing_visualizations(
         self,
         heatmaps: Mapping[str, RoutingHeatmap],
         output_dir: str | Path,
         *,
         input_image: str | Path | torch.Tensor | None = None,
+        expert_features: Mapping[str, ExpertFeatureMap] | None = None,
     ) -> dict[str, dict[str, Path]]:
         """Write spatial heatmap overlays or global routing distributions."""
         import matplotlib
@@ -324,16 +515,36 @@ class RoutingInterpreter:
                 layer_written[artifact_name] = path
             for expert_idx in range(spatial.shape[0]):
                 artifact_name = f"expert_{expert_idx}_heatmap"
+                # Use expert feature map if available, otherwise fall back to
+                # router probability (backward-compatible).
+                _use_feat = (
+                    expert_features is not None and name in expert_features
+                )
+                feat_map = (
+                    expert_features[name].expert_maps[expert_idx]
+                    if _use_feat
+                    else None
+                )
+                if feat_map is not None:
+                    overlay_values = feat_map
+                    overlay_title = f"{name} - expert {expert_idx} feature (RMS)"
+                elif _use_feat:
+                    overlay_values = spatial[expert_idx]
+                    overlay_title = f"{name} - expert {expert_idx} (not selected)"
+                else:
+                    overlay_values = spatial[expert_idx]
+                    overlay_title = f"{name} - expert {expert_idx} activation"
                 path = output_path / f"{safe_name}_{artifact_name}.png"
+                vrange = self._display_range(overlay_values)
                 self._save_overlay(
-                    spatial[expert_idx],
+                    overlay_values,
                     background,
                     path,
-                    title=f"{name} - expert {expert_idx} activation",
+                    title=overlay_title,
                     categorical=False,
                     cmap="inferno",
-                    vmin=self._display_range(spatial[expert_idx])[0],
-                    vmax=self._display_range(spatial[expert_idx])[1],
+                    vmin=vrange[0] if math.isfinite(vrange[0]) else 0.0,
+                    vmax=vrange[1] if math.isfinite(vrange[1]) else 1.0,
                 )
                 layer_written[artifact_name] = path
 
@@ -342,7 +553,19 @@ class RoutingInterpreter:
             rows = math.ceil((spatial.shape[0] + 2) / columns)
             figure, axes = plt.subplots(rows, columns, figsize=(4.0 * columns, 3.8 * rows), squeeze=False)
             panels = [(confidence, "confidence", False, "magma"), (assignments.float(), "top-1 assignment", True, "tab20")]
-            panels.extend((spatial[idx], f"expert {idx}", False, "inferno") for idx in range(spatial.shape[0]))
+            for idx in range(spatial.shape[0]):
+                _use_feat = expert_features is not None and name in expert_features
+                feat_map = (
+                    expert_features[name].expert_maps[idx]
+                    if _use_feat
+                    else None
+                )
+                if feat_map is not None:
+                    panels.append((feat_map, f"expert {idx} feat", False, "inferno"))
+                elif _use_feat:
+                    panels.append((spatial[idx], f"expert {idx} (N/A)", False, "inferno"))
+                else:
+                    panels.append((spatial[idx], f"expert {idx}", False, "inferno"))
             for panel_idx, (values, title, categorical, cmap) in enumerate(panels):
                 low, high = (self._display_range(values) if not categorical else (None, None))
                 self._plot_map(
@@ -457,6 +680,197 @@ class RoutingInterpreter:
                 feature_signatures=tuple(signatures),
             )
         return reports
+
+    def run_dataset_analysis(
+        self,
+        dataloader: Iterable,
+        *,
+        layer_name: str | None = None,
+        forward_fn: Callable[[nn.Module, Any], Any] | None = None,
+        max_samples: int | None = None,
+    ) -> tuple[
+        dict[str, SparseTopKStats],
+        dict[str, RouterDifferentiationMetrics],
+        dict[str, RoutingCollapseReport],
+    ]:
+        """Compute sparse top-k selection stats, router differentiation metrics,
+        and routing collapse reports over a dataset.
+
+        Args:
+            dataloader: Iterable yielding batches (typically a YOLO dataloader
+                whose batch dict contains ``"img"``).
+            layer_name: Optional single layer to analyze (omit for all leaf
+                routed layers).
+            forward_fn: Optional custom forward callable.
+            max_samples: Maximum number of samples to process (``None`` means
+                iterate the entire dataloader).
+
+        Returns:
+            ``(sparse_topk_stats, differentiation_metrics, collapse_reports)``
+        """
+        accumulator_hit: dict[str, torch.Tensor] = {}
+        accumulator_cooc: dict[str, torch.Tensor] = {}
+        sample_counts: dict[str, int] = {}
+        module_types: dict[str, str] = {}
+        top_k_registry: dict[str, int] = {}
+        kl_lists: dict[str, list[float]] = {}
+        spread_lists: dict[str, list[float]] = {}
+        accumulated_probs: dict[str, torch.Tensor] = {}
+        processed = 0
+
+        device = next(self.model.parameters()).device
+
+        for batch in dataloader:
+            # Move images to model device
+            if isinstance(batch, Mapping) and "img" in batch:
+                batch = dict(batch)
+                batch["img"] = batch["img"].to(device)
+
+            heatmaps = self.capture_routing(
+                batch, layer_name=layer_name, forward_fn=forward_fn
+            )
+
+            for name, heatmap in heatmaps.items():
+                probs = heatmap.probabilities  # [B, E, ...]
+                B = probs.shape[0]
+                E = probs.shape[1]
+
+                # --- initialise accumulators on first encounter ---
+                if name not in accumulator_hit:
+                    accumulator_hit[name] = torch.zeros(E, dtype=torch.long)
+                    accumulator_cooc[name] = torch.zeros(E, E, dtype=torch.long)
+                    sample_counts[name] = 0
+                    module_types[name] = heatmap.module_type
+                    # Try to read top_k from the routed module itself
+                    routed_module = None
+                    for mod_name, mod in self.model.named_modules():
+                        if mod_name == name:
+                            routed_module = mod
+                            break
+                    top_k_registry[name] = int(
+                        getattr(routed_module, "top_k", min(E, 2))
+                    )
+                    kl_lists[name] = []
+                    spread_lists[name] = []
+                    accumulated_probs[name] = torch.zeros(E, dtype=torch.float64)
+
+                topk = min(top_k_registry[name], E)
+
+                # --- per-image importance (mean over spatial) ---
+                if probs.ndim > 2:
+                    spatial_mean = probs.flatten(2).mean(dim=2)  # [B, E]
+                else:
+                    spatial_mean = probs
+
+                _, topk_indices = torch.topk(spatial_mean.float(), topk, dim=1)
+
+                # --- sparse top-k hit counts ---
+                for e in range(E):
+                    accumulator_hit[name][e] += (
+                        (topk_indices == e).any(dim=1).sum().item()
+                    )
+
+                # --- co-occurrence ---
+                for b_idx in range(B):
+                    idx_set = topk_indices[b_idx].tolist()
+                    for i in idx_set:
+                        for j in idx_set:
+                            accumulator_cooc[name][i, j] += 1
+
+                sample_counts[name] += B
+
+                # --- kl divergence (per spatial position) ---
+                if probs.ndim > 2:
+                    kl = self._kl_divergence_uniform(probs.float())
+                else:
+                    kl = self._kl_divergence_uniform(
+                        probs.float().unsqueeze(-1).unsqueeze(-1)
+                    )
+                kl_lists[name].extend(kl.flatten().tolist())
+
+                # --- weight spread ---
+                gathered = torch.gather(
+                    spatial_mean.float(), 1, topk_indices
+                )  # [B, topk]
+                spread = gathered.max(dim=1).values - gathered.min(dim=1).values
+                spread_lists[name].extend(spread.tolist())
+
+                # --- accumulate probs for collapse report ---
+                if probs.ndim > 2:
+                    accumulated_probs[name] += probs.double().mean(
+                        dim=(0, 2, 3)
+                    )
+                else:
+                    accumulated_probs[name] += probs.double().mean(dim=0)
+
+            processed += B
+            if max_samples is not None and processed >= max_samples:
+                break
+
+        # --- build SparseTopKStats ---
+        sparse_topk: dict[str, SparseTopKStats] = {}
+        for name in accumulator_hit:
+            denom = max(sample_counts[name], 1)
+            sparse_topk[name] = SparseTopKStats(
+                layer_name=name,
+                module_type=module_types[name],
+                num_experts=int(accumulator_hit[name].shape[0]),
+                top_k=top_k_registry[name],
+                num_samples=sample_counts[name],
+                expert_hit_counts=tuple(accumulator_hit[name].tolist()),
+                expert_hit_percentages=tuple(
+                    (accumulator_hit[name].float() / denom * 100.0).tolist()
+                ),
+                co_occurrence_matrix=tuple(
+                    tuple(int(v) for v in row) for row in accumulator_cooc[name]
+                ),
+            )
+
+        # --- build RouterDifferentiationMetrics ---
+        diff_metrics: dict[str, RouterDifferentiationMetrics] = {}
+        for name in kl_lists:
+            kl_t = torch.tensor(kl_lists[name])
+            ws_t = torch.tensor(spread_lists[name])
+            diff_metrics[name] = RouterDifferentiationMetrics(
+                layer_name=name,
+                module_type=module_types[name],
+                num_samples=sample_counts[name],
+                mean_kl_divergence=float(kl_t.mean()),
+                std_kl_divergence=float(kl_t.std()),
+                mean_weight_spread=float(ws_t.mean()),
+                std_weight_spread=float(ws_t.std()),
+            )
+
+        # --- build collapse reports from accumulated usage ---
+        collapse_reports: dict[str, RoutingCollapseReport] = {}
+        for name, acc in accumulated_probs.items():
+            usage = acc / max(float(acc.sum()), 1e-12)
+            expert_usage = tuple(float(v) for v in usage.tolist())
+            dominant = max(expert_usage)
+            dominant_expert = expert_usage.index(dominant)
+            normalized_gini = self._normalized_gini(usage)
+            normalized_entropy = self._normalized_entropy(usage)
+            dead = tuple(
+                i for i, v in enumerate(expert_usage) if v <= 0.01
+            )
+            collapsed = bool(
+                dominant >= 0.8
+                or normalized_gini >= 0.8
+                or normalized_entropy <= 0.5
+                or dead
+            )
+            collapse_reports[name] = RoutingCollapseReport(
+                layer_name=name,
+                expert_usage=expert_usage,
+                dominant_expert=dominant_expert,
+                dominant_share=dominant,
+                normalized_gini=normalized_gini,
+                normalized_entropy=normalized_entropy,
+                dead_experts=dead,
+                collapsed=collapsed,
+            )
+
+        return sparse_topk, diff_metrics, collapse_reports
 
     def routing_causal_analysis(
         self,
@@ -582,6 +996,26 @@ class RoutingInterpreter:
         values = values / values.sum()
         entropy = -(values * values.clamp_min(1e-12).log()).sum()
         return float((entropy / math.log(count)).clamp(0.0, 1.0))
+
+    @staticmethod
+    def _kl_divergence_uniform(probabilities: torch.Tensor) -> torch.Tensor:
+        """Compute KL(p || uniform) per spatial position.
+
+        Args:
+            probabilities: ``[..., E, ...]`` routing probabilities that sum
+                to 1 along the expert dimension (dim=1).
+
+        Returns:
+            KL divergence map with the expert dimension reduced, clamped to
+            ``>= 0``.
+        """
+        E = probabilities.shape[1]
+        uniform = 1.0 / E
+        kl = (
+            probabilities
+            * (probabilities / uniform).log().clamp_min(-100)
+        ).sum(dim=1)
+        return kl.clamp_min(0.0)
 
     @classmethod
     def _router_probabilities(cls, output: Any, num_experts: int) -> torch.Tensor | None:
@@ -1003,10 +1437,13 @@ class RoutingInterpreter:
 
 
 __all__ = [
+    "ExpertFeatureMap",
     "ExpertSpecializationReport",
+    "RouterDifferentiationMetrics",
     "RoutingCausalReport",
     "RoutingCollapseReport",
     "RoutingHeatmap",
     "RoutingInterpreter",
     "RoutingLayerSummary",
+    "SparseTopKStats",
 ]


### PR DESCRIPTION
> [tools/routing] feat: ES-MoE routing behavior evaluation framework — metric correction from expert utilization to hit-rate, validated across controlled experiments

---
## TL ; DR

本工作是 issue #52 的阶段性工作，主要实现：

- 路由诊断工具基础设施扩展
- VisDrone ES-MoE 稀疏训练脚本 与 路由评估实验

本工作的重点主要在于路由行为的评估实验的工作，代码层面的改动并不大，主要是评估了一系列的路由行为的实验，优化了系统性的评估行为的基础设施脚本。并针对 issue #52 的后续工作制定了一系列的方针。

---
## 引言
该PR实际上是 issue #52 的一个阶段性的工作，我们在基于 PR #171 的baseline模型的基础上尝试去做模型的剪枝，发现专家的利用率都非常均衡，问题和 issue #111 非常类似，我们最开始尝试利用专家利用率对模型剪枝，发现几乎无法剪枝，在 3 个专家的配置下，专家利用率接近 33%，实际上利用 30% 进行剪枝，与其说是根据专家分化行为进行剪枝，更多是一种随机剪枝的情况，感觉较为不合理。做了一系列初步的评估，认为是我们**评估指标存在问题**。但我们不敢初步的定下结论，所以在本次工作中，我们设计了系统的路由诊断的工具基础设施，并且设计了路由分化行为评估的SOP，同时设计了一系列的实验来评估路由分化行为，为后续的工作寻找可行和合理的策略。

需要特此说明，本工作主要是以路由分化行为的实验驱动，尝试优化路由分化诊断工具的过程，实验并不严谨（只跑30epochs，只有一个趋势性分析），不过也是因为各个实验只是为了模型剪枝前路由行为诊断的前置性工作。

---
## 代码改动
- Commit 1：[VisDrone ES-MoE 稀疏训练脚本 + 专家参数修正](https://github.com/Tencent/YOLO-Master/commit/bd2a71ba4d98b410e7824c9a26390a725479e54d)
- Commit 2：[路由诊断工具基础设施扩展](https://github.com/Tencent/YOLO-Master/commit/a871c2bfdb60a626724d66c54d878b1399d0ec25)
---
## 实验设计 
正如引言所述，我们在baseline模型工作的基础上，设计了一系列的实验，主要是在专家数量和balance loss上做区分。我们希望看一下在不同的专家和balance loss下专家的路由会如何训练。

### 基础配置

| 参数            | 值                              |
| ------------- | ------------------------------ |
| 模型            | EsMoE-N (`yolo-master-n.yaml`) |
| 数据集           | VisDrone                       |
| imgsz         | 640                            |
| batch         | 32                             |
| device        | 0 (RTX 4090)                   |
| optimizer     | auto                           |
| seed          | 42                             |
| patience      | 0                              |
| amp           | true                           |

### 实验概述
本PR设计的实验主要是针对于模型的路由行为评估的相关指标，主要设计了几个参数变量：每层的专家数量 和 balance loss 值，具体设置和整体情况如下：

| 实验编号     | 专家数 | balance_loss | epochs | mAP50 |
| -------- | --- | ------------ | ------ | ----- |
| 1        | 4   | 0.3          | 30     | 0.176 |
| 2        | 4   | 1.0          | 30     | 0.176 |
| 3        | 4   | 1.5          | 30     | 0.159 |
| 4        | 3   | 0.3          | 30     | 0.151 |
| 5        | 3   | 1.0          | 30     | 0.155 |
| 6        | 3   | 1.5          | 30     | 0.148 |
| baseline | 3   | 1.0          | 200    | 0.314 |

## 实验结果与实验分析

### 1. Gini系数汇总与整体路由情况
我们统计了每个实验各层的一个gini系数以及死专家数量

| 实验       | 配置                | L3    | L6    | L9        | L12       | 均值    | 死专家总数 |
| -------- | ----------------- | ----- | ----- | --------- | --------- | ----- | ----- |
| exp1     | 4E, BL=0.3        | 0.704 | 0.701 | 0.672     | **0.375** | 0.613 | 6     |
| exp2     | 4E, BL=1.0        | 0.687 | 0.704 | 0.689     | **0.274** | 0.589 | 4     |
| exp3     | 4E, BL=1.5        | 0.681 | 0.696 | **0.134** | 0.287     | 0.449 | 4     |
| exp4     | 3E, BL=0.3        | 0.509 | 0.532 | 0.511     | **0.268** | 0.455 | 3     |
| exp5     | 3E, BL=1.0        | 0.523 | 0.531 | 0.505     | **0.104** | 0.416 | 3     |
| exp6     | 3E, BL=1.5        | 0.516 | 0.518 | 0.500     | **0.260** | 0.448 | 3     |
| baseline | 3E, BL=1.0, 200ep | **0.021** | **0.009** | **0.016**     | **0.010**     | **0.014** | 0     |

从上表，我们可以明显的看出这个gini系数会随着 balance loss 变大而减小，换句话说，就是强balance loss 会带来更强的负载均衡。同时我们也发现 balance loss 的传递应该会随着层数变深而难以回传，由于反向传播算法是从 L12 往 L3 传递，而由负载均衡带来的梯度可能会随着层数靠近输入层而更难以学习。
  
同时，我们和baseline模型比较可以发现，我们当前的死专家很大程度是源于训练轮数不够，而出现的专家饿死。而baseline模型看上去有着不错的一个专家均衡的效果。

### 2. 专家利用率明细
我们尝试更加深入的分析，统计了每层专家的一个具体的利用率，可以得到：

**4 专家组**

| 实验            | 层   | E0        | E1        | E2        | E3      | Gini  |
| ------------- | --- | --------- | --------- | --------- | ------- | ----- |
| exp1 (BL=0.3) | L3  | **0.556** | 0.444     | ❌ 0.000   | ❌ 0.000 | 0.704 |
|               | L6  | **0.552** | ❌ 0.000   | ❌ 0.000   | 0.448   | 0.701 |
|               | L9  | ❌ 0.000   | **0.508** | 0.492     | ❌ 0.000 | 0.672 |
|               | L12 | 0.370     | 0.096     | **0.394** | 0.139   | 0.375 |
| exp2 (BL=1.0) | L3  | **0.531** | 0.469     | ❌ 0.000   | ❌ 0.000 | 0.688 |
|               | L6  | **0.556** | ❌ 0.000   | 0.444     | ❌ 0.000 | 0.704 |
|               | L9  | ❌ 0.000   | **0.534** | 0.466     | ❌ 0.000 | 0.689 |
|               | L12 | **0.357** | 0.201     | 0.319     | 0.123   | 0.274 |
| exp3 (BL=1.5) | L3  | **0.522** | 0.478     | ❌ 0.000   | ❌ 0.000 | 0.681 |
|               | L6  | **0.544** | ❌ 0.000   | 0.456     | ❌ 0.000 | 0.696 |
|               | L9  | 0.217     | **0.345** | 0.214     | 0.224   | 0.134 |
|               | L12 | **0.373** | 0.191     | 0.311     | 0.126   | 0.287 |

**3 专家组**

| 实验            | 层   | E0        | E1        | E2        | Gini  |
| ------------- | --- | --------- | --------- | --------- | ----- |
| exp4 (BL=0.3) | L3  | ❌ 0.000   | 0.509     | 0.491     | 0.509 |
|               | L6  | ❌ 0.000   | **0.532** | 0.468     | 0.532 |
|               | L9  | ❌ 0.000   | 0.511     | 0.489     | 0.511 |
|               | L12 | 0.190     | 0.352     | **0.458** | 0.268 |
| exp5 (BL=1.0) | L3  | ❌ 0.000   | **0.523** | 0.477     | 0.523 |
|               | L6  | ❌ 0.000   | **0.531** | 0.469     | 0.531 |
|               | L9  | ❌ 0.000   | 0.505     | 0.495     | 0.505 |
|               | L12 | 0.270     | **0.374** | 0.355     | 0.104 |
| exp6 (BL=1.5) | L3  | ❌ 0.000   | **0.516** | 0.484     | 0.516 |
|               | L6  | ❌ 0.000   | **0.518** | 0.482     | 0.518 |
|               | L9  | ❌ 0.000   | 0.500     | **0.500** | 0.500 |
|               | L12 | **0.488** | 0.228     | 0.284     | 0.260 |
| baseline      | L3  | 0.321     | 0.337     | **0.342** | 0.021 |
|               | L6  | **0.338** | 0.329     | 0.332     | 0.009 |
|               | L9  | **0.342** | 0.332     | 0.326     | 0.016 |
|               | L12 | 0.335     | **0.337** | 0.328     | 0.010 |

从上表，我们可以更加清晰的看到我们前面的结论：
1. 靠近输出层的底层更加容易训练：负载均衡更加均衡；
2. 随着balance loss 增加，负载确实会更加均衡；
发现我们的baseline实际上是训练均衡的结果，并不是说训练过程存在问题，例如利用稠密模式训练导致专家利用率始终均衡，实际上并不是这样，我们这个训练是存在从无到有的一个学习过程的。同时我们也可以发现训练轮数少的时候专家塌缩，轮数多的时候又有可能专家退化，这或许就是未来动态调度所需要克服的问题。
### baseline 单图分析
我们上述的实验是针对一个整个数据集统计而来的，从上述的数据上是认为 baseline 模型有一个比较好的负载均衡的训练。但是当随机在测试集抽取了一张图，然后，根据不同专家输出的特征进行可视化得到：

<img width="3017" height="3495" alt="all_models_merged" src="https://github.com/user-attachments/assets/1a38c219-b8be-4010-8268-0ec91ac90b10" />

观察上图热力图，可以发现：
1. 首先可以发现的是确实有学到一个特征的趋势，可以通过不同层的一个专家特征热力图可以比较知道，不同层的专家学到的特征是存在差异性的。
2. 但是我们同时可以看到，在自然路由的条件下，这张图只有一个专家出现了热力图，这应该是由于路由只选择了其中一个专家。
这非常奇怪，所以我们删除了路由选择的这一步，让一张图强迫通过每一个专家，然后我们绘制特征热力图：

<img width="3044" height="880" alt="model_3_experts_merged" src="https://github.com/user-attachments/assets/8678c010-12ae-4f03-870a-d2d5ecc1caa6" />

注意图中央的横向车辆，特征热力图实际上是存在差异的，但是差异确实不明显，可能该层的专家存在退化现象，三个专家学到的东西比较一致。同样地，我们看 L6 L9 L12层：

<img width="3078" height="881" alt="model_6_experts_merged" src="https://github.com/user-attachments/assets/277d76ae-e719-498f-bec0-0287c2884093" />

<img width="3063" height="881" alt="model_9_experts_merged" src="https://github.com/user-attachments/assets/c1dc1dc5-116d-4ad8-b16a-237717f61f11" />

<img width="3087" height="879" alt="model_12_experts_merged" src="https://github.com/user-attachments/assets/199df5be-d31a-4ce7-831b-ed0fc475f423" />

后面的三层学到的特征差异还是蛮大的，这说明我们的专家的学习确实是学到了一定的分化效果的，但是如果我们希望去进行专家剪枝的，不同的专家重要性同等的话，难以进行专家剪枝。个人在实验过程中，实际上是希望专家学习不同的特征，但是在垂类数据集中，不同的专家存在分化，例如某些专家更适合学习汽车的特征，而某些专家更适合学习动物的特征之类的，而我们当前的baseline似乎趋向于学习了同一特征。这或许是我们不希望看到的。

### 4. 跨样本路由多样性
前文的实验是针对某张图进行分析的，但是正如我们前文所述，我们要去做剪枝实际上是希望模型在某个垂类数据集上存在分化性，所以我们在 VisDrone 数据集上统计了专家的击中率，而不是利用率。通过真实数据集，来反馈专家分化在某些垂类数据集上的表现：

**4 专家组 — 专家命中率 (%)**

| 实验   | 层   | E0   | E1   | E2   | E3   |
| ---- | --- | ---- | ---- | ---- | ---- |
| exp1 | L3  | 100  | 100  | 0    | 0    |
|      | L6  | 100  | 0    | 0    | 100  |
|      | L9  | 0    | 100  | 100  | 0    |
|      | L12 | 70.2 | 22.6 | 76.0 | 31.3 |
| exp2 | L3  | 100  | 100  | 0    | 0    |
|      | L6  | 100  | 0    | 100  | 0    |
|      | L9  | 43.4 | 68.2 | 43.1 | 45.3 |
|      | L12 | 73.9 | 36.1 | 63.5 | 26.5 |
| exp3 | L3  | 100  | 100  | 0    | 0    |
|      | L6  | 100  | 0    | 100  | 0    |
|      | L9  | 43.4 | 68.2 | 43.1 | 45.3 |
|      | L12 | 73.9 | 36.1 | 63.5 | 26.5 |

**3 专家组 — 专家命中率 (%)**

| 实验           | 层       | E0       | E1       | E2       |
| ------------ | ------- | -------- | -------- | -------- |
| exp4         | L3      | 0        | 100      | 100      |
|              | L6      | 0        | 100      | 100      |
|              | L9      | 0        | 100      | 100      |
|              | L12     | 44.2     | 68.4     | 87.4     |
| exp5         | L3      | 0        | 100      | 100      |
|              | L6      | 0        | 100      | 100      |
|              | L9      | 0        | 100      | 100      |
|              | L12     | 63.9     | 71.5     | 64.6     |
| exp6         | L3      | 0        | 100      | 100      |
|              | L6      | 0        | 100      | 100      |
|              | L9      | 0        | 100      | 100      |
|              | L12     | 91.4     | 47.4     | 61.1     |
| **baseline** | **L3**  | **10.6** | **90.7** | **98.7** |
|              | **L6**  | **94.5** | **29.6** | **75.9** |
|              | **L9**  | **97.8** | **95.4** | **6.8**  |
|              | **L12** | **66.8** | **97.1** | **36.1** |

我们非常惊喜的发现，我们的baseline模型在垂类数据集上存在明显的分化现象，我们之前利用平均利用率来进行剪枝的评估指标，存在指标选择上的错误。我们应该考虑用击中率而不是利用率来进行剪枝，应该用剪枝部署所需要数据集来评估一个击中率，然后通过击中率进行剪枝。

### 实验结论

我们首先从统计模型的整体指标出发，观察模型在不同训练指标下一个整体的变化趋势，发现负载均衡损失的趋势：
1. 靠近输出层的底层更加容易训练：负载均衡更加均衡；
2. 随着balance loss 增加，负载确实会更加均衡；
然后，我们发现epoch训练轮数较少的时候，专家实际上是存在塌缩的情况，就是尚未学到任何特征。然后也通过比较，我们发现我们的baseline实际上是训练均衡的结果，并不是说训练过程存在问题，例如利用稠密模式训练导致专家利用率始终均衡，实际上并不是这样，我们这个训练是存在从无到有的一个学习过程的。可以佐证baseline训练正常。

然后，我们深入地对于baseline进行分析，首先进行了单张热力图分析，发现baseline的专家特征学习存在明显的分化学习。这更加证明了baseline模型的一个合理学习的情况。然后这是针对单张的分析，基于此，我们就想到尝试利用数据集级别来进行分析，由此设计了击中率指标，通过这个击中率指标，可以更加清晰地佐证我们的baseline已经有分化行为了，并且路由分化也是正常的。基于此我们分析是我们的评估指标选择错误❌。

---
## 下一步计划

基于上述的实验与实验分析，我们分析到当前剪枝效果差的主要原因是来自于我们剪枝利用的评估指标（平均利用率）存在不合理之处，而是应该利用数据集统计的专家击中率。所以，我们下一步计划：
1. 重新训练baseline模型，希望在baseline模型训练过程中可以收集一个训练过程中的路由行为变化趋势曲线；
2. 尝试用不同阈值的专家击中率对于baseline模型进行剪枝，评估剪枝后的baseline模型效果和路由行为；
3. 对剪枝后的模型进行LoRA微调恢复，评估效果和路由行为；
4. 对于baseline模型的路由行为变化趋势进行分析，希望找到一个动态调度策略，来解决训练轮数少的时候专家塌缩，训练轮数多时专家退化的问题。
5. 尝试动态调度策略，剪枝，以及剪枝后的恢复工作。

## 讨论

在上述的实验过程中，我们针对路由分化行为做了大量的实验和分析，我们当前的想法是认为专家剪枝是一个从通用到分化的过程，所以在此我们或许有更进一步的想法：

**或许我们可以在通用数据集上去做强负载均衡约束的预训练，然后在垂类数据集上做微调以及弱负载均衡的分化训练。最后在部署端进行专家剪枝，得到强垂类数据的专家。**

## 相关命令

```bash
# 训练
python scripts/reproduce/reproduce_visdrone_sparse.py \
  --epochs 80 --moe-balance-loss 0.3 --moe-num-experts 4
  
# 利用数据集进行路由分析
python tools/routing_interpreter.py \
  <checkpoint.pt> \           # 权重
  --dataset VisDrone.yaml \   # 数据集
  --device cuda:0 \
  --output <output_dir> \     # 输出目录
  --batch-size 32
  
# 单图路由分析 所有层
python tools/routing_interpreter.py \
  <checkpoint.pt> \
  <image.jpg> \
  --device cuda:0 \
  --output <output_dir>

# 单图路由分析 仅指定层
python tools/routing_interpreter.py \
  <checkpoint.pt> \
  <image.jpg> \
  --layer model.12 \
  --device cuda:0 \
  --output <output_dir>

```

