### PR TITLE
fix(numeric): support legacy PyTorch autocast fallback

### DIFF
--- a/tests/test_torch_legacy_compat.py
+++ b/tests/test_torch_legacy_compat.py
@@ -1,8 +1,68 @@
-"""Regression tests for the minimum supported PyTorch loader API."""
+"""Regression tests for the minimum supported PyTorch APIs."""
 
+from contextlib import nullcontext
 from unittest.mock import Mock
 
+import pytest
+import torch
+
+from ultralytics.nn.modules._numeric import disabled_autocast
 from ultralytics.utils import patches, torch_utils
+
+
+@pytest.mark.parametrize("device_type", ["cpu", "cuda", "mps"])
+def test_disabled_autocast_uses_modern_api(monkeypatch, device_type):
+    context = nullcontext()
+    modern_autocast = Mock(return_value=context)
+    legacy_autocast = Mock(return_value=nullcontext())
+    monkeypatch.setattr(torch, "autocast", modern_autocast)
+    monkeypatch.setattr(torch.cuda.amp, "autocast", legacy_autocast)
+
+    assert disabled_autocast(device_type) is context
+    modern_autocast.assert_called_once_with(device_type=device_type, enabled=False)
+    legacy_autocast.assert_not_called()
+
+
+def test_disabled_autocast_uses_legacy_cuda_api(monkeypatch):
+    context = nullcontext()
+    legacy_autocast = Mock(return_value=context)
+    monkeypatch.delattr(torch, "autocast", raising=False)
+    monkeypatch.setattr(torch.cuda.amp, "autocast", legacy_autocast)
+
+    assert disabled_autocast("cuda") is context
+    legacy_autocast.assert_called_once_with(enabled=False)
+
+
+def test_disabled_autocast_legacy_cpu_is_noop(monkeypatch):
+    legacy_autocast = Mock(return_value=nullcontext())
+    monkeypatch.delattr(torch, "autocast", raising=False)
+    monkeypatch.setattr(torch.cuda.amp, "autocast", legacy_autocast)
+
+    with disabled_autocast("cpu") as value:
+        assert value is None
+    legacy_autocast.assert_not_called()
+
+
+def test_disabled_autocast_legacy_mps_is_noop(monkeypatch):
+    legacy_autocast = Mock(return_value=nullcontext())
+    monkeypatch.delattr(torch, "autocast", raising=False)
+    monkeypatch.setattr(torch.cuda.amp, "autocast", legacy_autocast)
+
+    with disabled_autocast("mps") as value:
+        assert value is None
+    legacy_autocast.assert_not_called()
+
+
+def test_disabled_autocast_unknown_device_is_noop(monkeypatch):
+    modern_autocast = Mock(return_value=nullcontext())
+    legacy_autocast = Mock(return_value=nullcontext())
+    monkeypatch.setattr(torch, "autocast", modern_autocast)
+    monkeypatch.setattr(torch.cuda.amp, "autocast", legacy_autocast)
+
+    with disabled_autocast("unknown") as value:
+        assert value is None
+    modern_autocast.assert_not_called()
+    legacy_autocast.assert_not_called()
 
 
 def test_torch_load_drops_unsupported_weights_only(monkeypatch):

--- a/tests/test_torch_legacy_compat.py
+++ b/tests/test_torch_legacy_compat.py
@@ -15,7 +15,7 @@ def test_disabled_autocast_uses_modern_api(monkeypatch, device_type):
     context = nullcontext()
     modern_autocast = Mock(return_value=context)
     legacy_autocast = Mock(return_value=nullcontext())
-    monkeypatch.setattr(torch, "autocast", modern_autocast)
+    monkeypatch.setattr(torch, "autocast", modern_autocast, raising=False)
     monkeypatch.setattr(torch.cuda.amp, "autocast", legacy_autocast)
 
     assert disabled_autocast(device_type) is context
@@ -56,7 +56,7 @@ def test_disabled_autocast_legacy_mps_is_noop(monkeypatch):
 def test_disabled_autocast_unknown_device_is_noop(monkeypatch):
     modern_autocast = Mock(return_value=nullcontext())
     legacy_autocast = Mock(return_value=nullcontext())
-    monkeypatch.setattr(torch, "autocast", modern_autocast)
+    monkeypatch.setattr(torch, "autocast", modern_autocast, raising=False)
     monkeypatch.setattr(torch.cuda.amp, "autocast", legacy_autocast)
 
     with disabled_autocast("unknown") as value:

--- a/ultralytics/nn/modules/_numeric.py
+++ b/ultralytics/nn/modules/_numeric.py
@@ -11,8 +11,18 @@ import torch.nn as nn
 
 def disabled_autocast(device_type: str):
     """Return an autocast-disabled context for router-critical numerical work."""
-    if device_type in {"cpu", "cuda", "mps"}:
-        return torch.autocast(device_type=device_type, enabled=False)
+    if device_type not in {"cpu", "cuda", "mps"}:
+        return nullcontext()
+
+    autocast = getattr(torch, "autocast", None)
+    if autocast is not None:
+        return autocast(device_type=device_type, enabled=False)
+
+    if device_type == "cuda":
+        cuda_amp = getattr(getattr(torch, "cuda", None), "amp", None)
+        legacy_autocast = getattr(cuda_amp, "autocast", None)
+        if legacy_autocast is not None:
+            return legacy_autocast(enabled=False)
     return nullcontext()
 
 


### PR DESCRIPTION
## Summary

Adds a backward-compatible autocast-disabled context for legacy PyTorch versions that do not provide the top-level `torch.autocast` API.

The issue was observed in the repository's Python 3.8 / PyTorch 1.8 CI environment, where existing Mixture, MoA, and MoT tests failed with `AttributeError: module 'torch' has no attribute 'autocast'`.

## Changes

- Preserve the existing `torch.autocast(device_type=..., enabled=False)` path on modern PyTorch.
- Fall back to `torch.cuda.amp.autocast(enabled=False)` for legacy CUDA environments.
- Use `nullcontext()` for legacy CPU, MPS, and unsupported device types.
- Keep compatibility handling centralized in `disabled_autocast()` rather than patching individual Mixture modules.
- Add regression tests for modern CPU/CUDA/MPS paths, legacy CUDA, legacy CPU/MPS, and unknown devices.

## Scope

This PR does not change:

- routing behavior;
- model outputs;
- optimizer logic;
- training configuration;
- LoRA behavior;
- CI workflow definitions.

It only provides a compatibility fallback for the shared numerical helper.

## Validation

- `8 passed` in `tests/test_torch_legacy_compat.py`
- `13 passed` in the previously affected Mixture test files
- Ruff passed
- Python compilation passed
- `git diff --check` passed

No GPU is required for the regression tests; the legacy CUDA path is validated with mocks.