### PR TITLE
fix(routing): weight dataset statistics by sample

### DIFF
--- a/tests/test_routing_interpreter.py
+++ b/tests/test_routing_interpreter.py
@@ -259,6 +259,27 @@ def test_causal_analysis_forces_expert_and_restores_router():
     assert torch.allclose(natural, restored)
 
 
+def test_dataset_collapse_usage_is_weighted_by_samples_not_batches():
+    batches = [torch.ones(2, 1, 3, 4), -torch.ones(1, 1, 3, 4)]
+
+    _, _, collapse = RoutingInterpreter(ToyModel()).run_dataset_analysis(batches)
+
+    positive = torch.softmax(torch.tensor([1.0, -1.0]), dim=0)
+    negative = positive.flip(0)
+    expected = (2 * positive + negative) / 3
+    assert collapse["routed"].expert_usage == pytest.approx(expected.tolist())
+
+
+def test_single_sample_dataset_metrics_have_finite_zero_spread():
+    _, differentiation, _ = RoutingInterpreter(ToyModel()).run_dataset_analysis(
+        [torch.ones(1, 1, 3, 4)]
+    )
+
+    metrics = differentiation["routed"]
+    assert metrics.std_kl_divergence == pytest.approx(0.0)
+    assert metrics.std_weight_spread == pytest.approx(0.0)
+
+
 @pytest.mark.parametrize(
     ("module", "batch", "expected_shape"),
     [

--- a/ultralytics/utils/routing_interpreter.py
+++ b/ultralytics/utils/routing_interpreter.py
@@ -796,12 +796,7 @@ class RoutingInterpreter:
                 spread_lists[name].extend(spread.tolist())
 
                 # --- accumulate probs for collapse report ---
-                if probs.ndim > 2:
-                    accumulated_probs[name] += probs.double().mean(
-                        dim=(0, 2, 3)
-                    )
-                else:
-                    accumulated_probs[name] += probs.double().mean(dim=0)
+                accumulated_probs[name] += spatial_mean.double().sum(dim=0)
 
             processed += B
             if max_samples is not None and processed >= max_samples:
@@ -836,9 +831,9 @@ class RoutingInterpreter:
                 module_type=module_types[name],
                 num_samples=sample_counts[name],
                 mean_kl_divergence=float(kl_t.mean()),
-                std_kl_divergence=float(kl_t.std()),
+                std_kl_divergence=float(kl_t.std(unbiased=False)),
                 mean_weight_spread=float(ws_t.mean()),
-                std_weight_spread=float(ws_t.std()),
+                std_weight_spread=float(ws_t.std(unbiased=False)),
             )
 
         # --- build collapse reports from accumulated usage ---


### PR DESCRIPTION
## 问题

VisDrone 验证集有 548 张图，`batch=16` 时末批只有 4 张。旧实现先对每个 batch 求均值再累加，导致末批 4 张图与完整 batch 的 16 张图权重相同，进而影响专家利用率和 routing collapse 的验收统计。

此外，数据集只有一个样本时，PyTorch 默认的无偏标准差会返回 `NaN`。

## 修改

- collapse usage 改为先计算逐样本空间均值，再按样本求和，最终归一化。
- KL divergence 和 weight spread 的标准差改为 `unbiased=False`，单样本时返回有限的零离散度。

## 验证

采用 test-first：

- 修复前：两个新增回归测试均失败（2 failed）。
- 修复后：focused 回归测试 2 passed。
- 修复后：`tests/test_routing_interpreter.py` 完整测试 22 passed。
