### PR TITLE
perf(edge): add fair CPU thread controls for ONNX, NCNN and MNN

### DIFF
--- a/examples/YOLO-Master-Edge-Deployment/README.md
+++ b/examples/YOLO-Master-Edge-Deployment/README.md
@@ -77,6 +77,7 @@ examples/YOLO-Master-Edge-Deployment/build-ort/yolo_master_edge_benchmark \
   --images /path/to/VisDrone/images/val \
   --profile visdrone \
   --imgsz 960 \
+  --threads 4 \
   --limit 500 \
   --output benchmark_onnx.csv
 ```
@@ -107,6 +108,7 @@ examples/YOLO-Master-Edge-Deployment/build-ncnn/yolo_master_edge_benchmark \
   --images /path/to/VisDrone/images/val \
   --profile visdrone \
   --imgsz 960 \
+  --threads 4 \
   --limit 500 \
   --output benchmark_ncnn.csv
 ```
@@ -137,11 +139,17 @@ examples/YOLO-Master-Edge-Deployment/build-mnn/yolo_master_edge_benchmark \
   --images /path/to/VisDrone/images/val \
   --profile visdrone \
   --imgsz 960 \
+  --threads 4 \
   --limit 500 \
   --output benchmark_mnn.csv
 ```
 
 `--images` accepts either a directory of images or a text file with one image path per line.
+`--threads` configures the CPU worker count for ONNX Runtime, NCNN, and MNN. Keep it identical across backends for a
+fair CPU comparison. Thread configuration is applied before each runtime loads its model.
+
+For MNN, the input session is resized only when the input tensor shape changes. Fixed-shape benchmark loops therefore
+exclude repeated session-resize overhead.
 
 ## Benchmark CSV Output
 

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/backend.h
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/backend.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -11,6 +12,7 @@ struct Tensor {
 class Backend {
 public:
     virtual ~Backend() = default;
+    virtual void set_num_threads(int threads) = 0;
     virtual void load(const std::string& model_path) = 0;
     virtual Tensor infer(const Tensor& input) = 0;
     virtual std::string name() const = 0;

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/mnn_backend.cpp
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/mnn_backend.cpp
@@ -37,6 +37,13 @@ void validate_input(const Tensor& input) {
 
 MnnBackend::MnnBackend() = default;
 
+void MnnBackend::set_num_threads(int threads) {
+    if (threads <= 0) {
+        throw std::invalid_argument("MNN thread count must be positive");
+    }
+    num_threads_ = threads;
+}
+
 MnnBackend::~MnnBackend() {
 #ifdef WITH_MNN
     if (interpreter_) {
@@ -60,7 +67,7 @@ void MnnBackend::load(const std::string& model_path) {
 
     MNN::ScheduleConfig config;
     config.type = MNN_FORWARD_CPU;
-    config.numThread = 1;
+    config.numThread = num_threads_;
     session_ = interpreter_->createSession(config);
     if (!session_) {
         throw std::runtime_error("failed to create MNN session: " + model_path_);
@@ -87,8 +94,11 @@ Tensor MnnBackend::infer(const Tensor& input) {
     }
 
     std::vector<int> dims(input.shape.begin(), input.shape.end());
-    interpreter_->resizeTensor(input_tensor_, dims);
-    interpreter_->resizeSession(session_);
+    if (input_shape_ != input.shape) {
+        interpreter_->resizeTensor(input_tensor_, dims);
+        interpreter_->resizeSession(session_);
+        input_shape_ = input.shape;
+    }
 
     auto* tmp_input = MNN::Tensor::create(
         dims,

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/mnn_backend.h
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/mnn_backend.h
@@ -10,12 +10,15 @@ class MnnBackend final : public Backend {
 public:
     MnnBackend();
     ~MnnBackend() override;
+    void set_num_threads(int threads) override;
     void load(const std::string& model_path) override;
     Tensor infer(const Tensor& input) override;
     std::string name() const override;
 
 private:
     std::string model_path_;
+    int num_threads_ = 4;
+    std::vector<int64_t> input_shape_;
 #ifdef WITH_MNN
     MNN::Interpreter* interpreter_ = nullptr;
     MNN::Session* session_ = nullptr;

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/ncnn_backend.cpp
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/ncnn_backend.cpp
@@ -163,6 +163,13 @@ NcnnBackend::NcnnBackend() = default;
 
 NcnnBackend::~NcnnBackend() = default;
 
+void NcnnBackend::set_num_threads(int threads) {
+    if (threads <= 0) {
+        throw std::invalid_argument("NCNN thread count must be positive");
+    }
+    num_threads_ = threads;
+}
+
 void NcnnBackend::load(const std::string& model_path) {
     if (model_path.empty()) {
         throw std::invalid_argument("NCNN model path is empty");
@@ -176,7 +183,7 @@ void NcnnBackend::load(const std::string& model_path) {
 
     net_.reset(new ncnn::Net());
     net_->opt.use_vulkan_compute = false;
-    net_->opt.num_threads = 1;
+    net_->opt.num_threads = num_threads_;
 
     if (net_->load_param(param_path_.c_str()) != 0) {
         throw std::runtime_error("failed to load NCNN param file: " + param_path_);

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/ncnn_backend.h
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/ncnn_backend.h
@@ -11,12 +11,14 @@ class NcnnBackend final : public Backend {
 public:
     NcnnBackend();
     ~NcnnBackend() override;
+    void set_num_threads(int threads) override;
     void load(const std::string& model_path) override;
     Tensor infer(const Tensor& input) override;
     std::string name() const override;
 
 private:
     std::string model_path_;
+    int num_threads_ = 4;
 #ifdef WITH_NCNN
     std::string param_path_;
     std::string bin_path_;

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/onnx_backend.cpp
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/onnx_backend.cpp
@@ -11,6 +11,13 @@ OnnxBackend::OnnxBackend()
 {
 }
 
+void OnnxBackend::set_num_threads(int threads) {
+    if (threads <= 0) {
+        throw std::invalid_argument("ONNX Runtime thread count must be positive");
+    }
+    num_threads_ = threads;
+}
+
 void OnnxBackend::load(const std::string& model_path) {
     if (model_path.empty()) {
         throw std::invalid_argument("ONNX model path is empty");
@@ -18,7 +25,9 @@ void OnnxBackend::load(const std::string& model_path) {
     model_path_ = model_path;
 
 #ifdef WITH_ONNXRUNTIME
-    session_options_.SetIntraOpNumThreads(1);
+    session_options_.SetIntraOpNumThreads(num_threads_);
+    session_options_.SetInterOpNumThreads(1);
+    session_options_.SetExecutionMode(ExecutionMode::ORT_SEQUENTIAL);
     session_options_.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
     session_.reset(new Ort::Session(env_, model_path.c_str(), session_options_));
 

--- a/examples/YOLO-Master-Edge-Deployment/cpp/backends/onnx_backend.h
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/backends/onnx_backend.h
@@ -10,12 +10,14 @@
 class OnnxBackend final : public Backend {
 public:
     OnnxBackend();
+    void set_num_threads(int threads) override;
     void load(const std::string& model_path) override;
     Tensor infer(const Tensor& input) override;
     std::string name() const override;
 
 private:
     std::string model_path_;
+    int num_threads_ = 4;
 #ifdef WITH_ONNXRUNTIME
     Ort::Env env_;
     Ort::SessionOptions session_options_;

--- a/examples/YOLO-Master-Edge-Deployment/cpp/edge_benchmark.cpp
+++ b/examples/YOLO-Master-Edge-Deployment/cpp/edge_benchmark.cpp
@@ -28,6 +28,7 @@ struct Args {
     int warmup = 5;
     int runs = 1;
     int limit = 0;
+    int threads = 4;
 };
 
 struct TimingRow {
@@ -52,6 +53,7 @@ static void print_usage(const char* program) {
         << "[--warmup 5] "
         << "[--runs 1] "
         << "[--limit 500] "
+        << "[--threads 4] "
         << "[--output benchmark.csv]\n";
 }
 
@@ -100,6 +102,8 @@ static Args parse_args(int argc, char** argv) {
             args.runs = std::stoi(value);
         } else if (key == "--limit") {
             args.limit = std::stoi(value);
+        } else if (key == "--threads") {
+            args.threads = std::stoi(value);
         } else {
             std::cerr << "Unknown argument: " << key << "\n";
             print_usage(argv[0]);
@@ -120,7 +124,8 @@ static Args parse_args(int argc, char** argv) {
         std::cerr << "Invalid --profile: " << args.profile << "\n";
         std::exit(2);
     }
-    if (args.imgsz <= 0 || args.warmup < 0 || args.runs <= 0 || args.limit < 0) {
+    if (args.imgsz <= 0 || args.warmup < 0 || args.runs <= 0 || args.limit < 0 ||
+        args.threads <= 0) {
         std::cerr << "Invalid numeric argument\n";
         std::exit(2);
     }
@@ -251,6 +256,7 @@ int main(int argc, char** argv) {
         const Args args = parse_args(argc, argv);
         const auto images = collect_images(args.images, args.limit);
         auto backend = create_backend(args.backend);
+        backend->set_num_threads(args.threads);
         backend->load(args.model);
 
         const Tensor warmup_input = preprocess_image(images.front(), args.imgsz, args.imgsz).input;
@@ -295,6 +301,7 @@ int main(int argc, char** argv) {
                   << " model=" << args.model
                   << " profile=" << args.profile
                   << " imgsz=" << args.imgsz
+                  << " threads=" << args.threads
                   << " conf=" << args.conf
                   << " iou=" << args.iou
                   << " output=" << args.output << "\n";


### PR DESCRIPTION
## Summary

- add a shared `--threads` option to the C++ edge benchmark
- apply the requested CPU thread count before loading ONNX Runtime, NCNN, and MNN models
- configure ONNX Runtime for sequential execution with one inter-op thread
- avoid repeated MNN tensor/session resize calls when the input shape is unchanged
- document the thread option for fair cross-backend CPU comparisons

## Motivation

The existing benchmark hard-codes one CPU thread independently in each backend. A single validated option makes CPU comparisons reproducible and prevents backend-specific thread defaults from skewing latency results.

## Validation

- Windows UCRT64 / MinGW GCC 16.1 Release build with MNN and warning flags: passed
- MNN SKU-110K single-image smoke test at 1280 px with `--threads 4`: passed (141 detections)
- invalid `--threads 0`: rejected with exit code 2
- `git diff --check`: passed

Related to #51.

Full deployment validation and benchmark report: [TECHNICAL_SUMMARY_ZH.md](https://github.com/Snape-arch/YOLO-Master/blob/issue51-fair-cpu-threading/examples/YOLO-Master-Edge-Deployment/TECHNICAL_SUMMARY_ZH.md)
