### PR TITLE
fix(lora): sync PEFT scaling state to EMA

### DIFF
--- a/examples/lora_examples/yolo_master_lora_peft_ema_report.md
+++ b/examples/lora_examples/yolo_master_lora_peft_ema_report.md
@@ -1,0 +1,62 @@
+# YOLO-Master PEFT LoRA EMA 同步实验报告
+
+本报告记录 `peft_ema_sync_rtx4060_v1` 协议。该协议用于验证 PEFT LoRA 的非张量 `scaling`
+状态同步到 EMA 后，在 Brain Tumor 和 VisDrone 垂类场景中的 rank 扫描结果。
+
+六组正式实验基于仓库提交 `a510883` 加本地 PEFT EMA 修复运行；实验完成后，修复提交才重放到
+更新后的 `upstream/main`。因此结果应以本报告列出的完整协议为准，不能套用后续默认配置解释。
+
+## 问题与修复
+
+启用 `lora_alpha_warmup` 后，在线模型的 LoRA `scaling` 会随 epoch 增长，但 PEFT 0.19.1 将该状态
+保存在普通 Python 字典中，而不是 `state_dict` 张量。标准 EMA 更新因此不会复制它，导致在线模型使用
+LoRA、EMA 验证模型却保持零缩放。典型现象是训练 loss 下降，但 mAP 持续下降或归零。
+
+修复在以下生命周期边界同步在线模型与 EMA 的 LoRA `scaling`：
+
+- 每个 epoch 更新 alpha warmup 后；
+- 验证前；
+- checkpoint 序列化前；
+- 断点续训恢复后。
+
+## 实验环境与协议
+
+- GPU：NVIDIA GeForce RTX 4060 Laptop GPU（8188 MiB）
+- Python：3.11.15
+- PyTorch：2.13.0+cu126
+- PEFT：0.19.1
+- 模型：YOLO-Master-EsMoE-N 预训练权重
+- Rank：`r=4,8,16`，保持 `lora_alpha=2*r`
+- Backend：配置为 `auto`，实际解析为 `peft`
+- AMP：关闭，避免把数值稳定性问题混入 EMA 修复验证
+- Router/gating：不纳入 LoRA 目标模块
+
+Brain Tumor 使用全部训练集、`imgsz=640`、`batch=8`、最多 40 epochs、`patience=15`、
+`lora_alpha_warmup=3`。VisDrone 使用 20% 训练集、完整验证集、`imgsz=640`、`batch=2`、
+30 epochs、`lora_alpha_warmup=5` 和多尺度训练。
+
+## Rank 扫描结果
+
+| 数据集 | Rank | 完成轮数 | 最佳轮次 | mAP50 | mAP50-95 | 可训练参数 | Adapter 参数 | 时间（分钟） | 日志峰值显存 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Brain Tumor | 4 | 17 | 2 | 0.40754 | 0.26097 | 409,174 | 64,000 | 10.38 | 3.79 GB |
+| Brain Tumor | 8 | 40 | 33 | 0.47810 | **0.34647** | 473,174 | 128,000 | 25.38 | 3.83 GB |
+| Brain Tumor | 16 | 17 | 2 | 0.47357 | 0.31845 | 601,174 | 256,000 | 10.62 | 3.84 GB |
+| VisDrone | 4 | 30 | 20 | 0.09152 | 0.04601 | 410,734 | 64,000 | 73.14 | 8.68 GB |
+| VisDrone | 8 | 30 | 20 | 0.09799 | 0.04926 | 474,734 | 128,000 | 69.06 | 8.69 GB |
+| VisDrone | 16 | 30 | 28 | 0.11454 | **0.05797** | 602,734 | 256,000 | 76.62 | 8.72 GB |
+
+峰值显存来自训练日志的 `GPU_mem` 最大值；不同 CUDA/PyTorch 版本的内存统计口径可能不同。
+完整机器可读结果见 `yolo_master_lora_peft_ema_results.csv`。
+
+## 结论
+
+- Brain Tumor 推荐 `r=8`：mAP50-95 最高，且比 `r=16` 少 128,000 个 Adapter 参数。
+- VisDrone 推荐 `r=16`：密集小目标场景从更大的 LoRA 容量中获得了持续收益。
+- 两个场景不存在统一最佳 rank，rank 应根据领域复杂度分别选择。
+- `best.pt` 重新验证结果与训练记录一致，修复后未再出现 LoRA EMA 缩放为零导致的指标崩溃。
+
+## 可比性限制
+
+本协议不能与仓库中的历史协议直接合并。历史结果可能使用 fallback 后端、AMP、不同 batch、
+不同图像尺寸或不同数据比例。跨协议数值只能作为背景参考，rank 结论应在同一协议内部比较。

--- a/examples/lora_examples/yolo_master_lora_peft_ema_results.csv
+++ b/examples/lora_examples/yolo_master_lora_peft_ema_results.csv
@@ -1,0 +1,7 @@
+protocol_id,dataset,rank,alpha,max_epochs,completed_epochs,fraction,amp,batch,imgsz,effective_backend,alpha_warmup,best_epoch,precision,recall,mAP50,mAP50_95,trainable_params,adapter_params,train_time_min,peak_gpu_memory_gb,status
+peft_ema_sync_rtx4060_v1,brain_tumor,4,8,40,17,1.0,False,8,640,peft,3,2,0.43386,0.57434,0.40754,0.26097,409174,64000,10.38,3.79,completed_early_stop
+peft_ema_sync_rtx4060_v1,brain_tumor,8,16,40,40,1.0,False,8,640,peft,3,33,0.45512,0.77818,0.47810,0.34647,473174,128000,25.38,3.83,completed
+peft_ema_sync_rtx4060_v1,brain_tumor,16,32,40,17,1.0,False,8,640,peft,3,2,0.43767,0.75353,0.47357,0.31845,601174,256000,10.62,3.84,completed_early_stop
+peft_ema_sync_rtx4060_v1,visdrone,4,8,30,30,0.2,False,2,640,peft,5,20,0.27431,0.14468,0.09152,0.04601,410734,64000,73.14,8.68,completed
+peft_ema_sync_rtx4060_v1,visdrone,8,16,30,30,0.2,False,2,640,peft,5,20,0.24676,0.14905,0.09799,0.04926,474734,128000,69.06,8.69,completed
+peft_ema_sync_rtx4060_v1,visdrone,16,32,30,30,0.2,False,2,640,peft,5,28,0.30409,0.15179,0.11454,0.05797,602734,256000,76.62,8.72,completed

--- a/tests/test_lora_selective_ema_lifecycle.py
+++ b/tests/test_lora_selective_ema_lifecycle.py
@@ -44,6 +44,31 @@ class TinyFallbackGraph(nn.Module):
         return self.layer(x)
 
 
+class TinyPeftLayer(nn.Module):
+    """Minimal PEFT-like layer whose scaling dictionary is absent from state_dict."""
+
+    def __init__(self):
+        super().__init__()
+        self.lora_A = nn.ModuleDict({"default": nn.Linear(2, 2, bias=False)})
+        self.lora_B = nn.ModuleDict({"default": nn.Linear(2, 2, bias=False)})
+        self.scaling = {"default": 0.0}
+
+    def forward(self, inputs):
+        return self.lora_B["default"](self.lora_A["default"](inputs)) * self.scaling["default"]
+
+
+class TinyPeftGraph(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layer = TinyPeftLayer()
+        self.lora_enabled = True
+        self.lora_backend = "peft"
+        self.lora_runtime_metadata = {"effective_backend": "peft"}
+
+    def forward(self, inputs):
+        return self.layer(inputs)
+
+
 def _trainer(model: nn.Module, *, warmup: int) -> SimpleNamespace:
     optimizer = torch.optim.SGD((parameter for parameter in model.parameters() if parameter.requires_grad), lr=0.1)
     trainer = SimpleNamespace(
@@ -110,13 +135,39 @@ def test_resume_restores_scheduled_scaling_online_and_ema(start_epoch: int):
     assert trainer.ema.ema.layer.scaling == pytest.approx(expected)
 
 
-def test_non_fallback_backend_does_not_rewrite_ema_treatment():
-    model = TinyFallbackGraph(backend="peft")
-    trainer, controller = _controller(model, warmup=0)
-    trainer.ema.ema.layer.scaling = 0.0
+def test_peft_backend_syncs_scaling_dictionary_to_ema():
+    model = TinyPeftGraph()
+    trainer = _trainer(model, warmup=0)
+    controller = AdapterRuntimeController(trainer)
+    trainer.adapter_controller = controller
+    trainer.ema = ModelEMA(model)
+    model.layer.scaling["default"] = 3.0
 
-    assert controller.sync_ema_treatment() == 0
-    assert trainer.ema.ema.layer.scaling == 0.0
+    assert controller.sync_ema_treatment() == 1
+    assert trainer.ema.ema.layer.scaling["default"] == 3.0
+
+
+def test_validation_syncs_peft_treatment_before_selecting_ema_model():
+    model = TinyPeftGraph()
+    trainer = _trainer(model, warmup=0)
+    controller = AdapterRuntimeController(trainer)
+    trainer.adapter_controller = controller
+    trainer.ema = ModelEMA(model)
+    model.layer.scaling["default"] = 3.0
+    trainer._sync_ema_buffers_for_validation = lambda: None
+    trainer._state_is_finite = lambda _value: True
+    trainer.best_fitness = None
+    trainer.loss = torch.tensor(1.0)
+
+    def validator(runtime_trainer):
+        assert runtime_trainer.ema.ema.layer.scaling["default"] == 3.0
+        return {"fitness": 1.0}
+
+    trainer.validator = validator
+    metrics, fitness = BaseTrainer.validate(trainer)
+
+    assert metrics == {}
+    assert fitness == 1.0
 
 
 def test_validation_syncs_fallback_treatment_before_selecting_ema_model():
@@ -157,3 +208,21 @@ def test_checkpoint_serialization_syncs_fallback_treatment():
 
     assert checkpoint["ema"].layer.scaling == model.layer.scaling
     assert checkpoint["ema"].layer.use_rslora is True
+
+
+def test_checkpoint_serialization_syncs_peft_treatment():
+    model = TinyPeftGraph()
+    trainer = _trainer(model, warmup=0)
+    trainer.adapter_controller = AdapterRuntimeController(trainer)
+    trainer.ema = ModelEMA(model)
+    model.layer.scaling["default"] = 3.0
+    trainer.scaler = SimpleNamespace(state_dict=lambda: {})
+    trainer.epoch = trainer.start_epoch = 0
+    trainer.best_fitness = trainer.fitness = 0.0
+    trainer.metrics = {}
+    trainer.read_results_csv = lambda: {}
+
+    serialized = TrainingRecoveryController(trainer).serialize_checkpoint(include_online_model=True)
+    checkpoint = torch.load(io.BytesIO(serialized), map_location="cpu", weights_only=False)
+
+    assert checkpoint["ema"].layer.scaling["default"] == 3.0

--- a/ultralytics/engine/extensions/adapters.py
+++ b/ultralytics/engine/extensions/adapters.py
@@ -224,18 +224,22 @@ class AdapterRuntimeController:
         self.trainer.lora_ortho_batch_counter = 0
 
     def sync_ema_treatment(self) -> int:
-        """Copy scheduled fallback scaling from online wrappers to matching EMA wrappers."""
+        """Copy scheduled LoRA scaling from online adapters to matching EMA adapters."""
         metadata = getattr(self.model, "lora_runtime_metadata", {}) or {}
         effective_backend = metadata.get("effective_backend", getattr(self.model, "lora_backend", None))
-        if effective_backend != "fallback":
+        if effective_backend not in {"fallback", "peft"}:
             return 0
         ema = getattr(getattr(self.trainer, "ema", None), "ema", None)
         if ema is None:
             return 0
-        from ultralytics.utils.lora.fallback import FewShotLoRAConv, ManualLoRAConv
 
         online_modules = dict(self.model.named_modules())
         ema_modules = dict(unwrap_model(ema).named_modules())
+        if effective_backend == "peft":
+            return self._sync_peft_ema_scaling(online_modules, ema_modules)
+
+        from ultralytics.utils.lora.fallback import FewShotLoRAConv, ManualLoRAConv
+
         synced = 0
         for name, online in online_modules.items():
             if not isinstance(online, (ManualLoRAConv, FewShotLoRAConv)):
@@ -248,6 +252,26 @@ class AdapterRuntimeController:
             if ema_identity != online_identity:
                 raise ValueError(f"EMA fallback adapter identity differs at '{name}'.")
             averaged.scaling = online.scaling
+            synced += 1
+        return synced
+
+    @staticmethod
+    def _sync_peft_ema_scaling(online_modules: dict, ema_modules: dict) -> int:
+        """Copy PEFT scaling dictionaries, which are intentionally absent from state_dict."""
+        synced = 0
+        for name, online in online_modules.items():
+            if getattr(online, "lora_A", None) is None:
+                continue
+            averaged = ema_modules.get(name)
+            if averaged is None or getattr(averaged, "lora_A", None) is None:
+                raise ValueError(f"EMA PEFT adapter layout differs at '{name}'.")
+            online_scaling = getattr(online, "scaling", None)
+            ema_scaling = getattr(averaged, "scaling", None)
+            if not isinstance(online_scaling, dict):
+                continue
+            if not isinstance(ema_scaling, dict) or set(ema_scaling) != set(online_scaling):
+                raise ValueError(f"EMA PEFT scaling layout differs at '{name}'.")
+            ema_scaling.update(online_scaling)
             synced += 1
         return synced
 


### PR DESCRIPTION
## Summary

- sync PEFT LoRA `scaling` dictionaries from the online model to EMA
- preserve the existing fallback LoRA EMA synchronization behavior
- cover validation and checkpoint serialization with regression tests
- document Brain Tumor and VisDrone rank-sweep results collected while reproducing the issue

## Problem

With PEFT 0.19.1 and `lora_alpha_warmup` enabled, the online LoRA model updates its scaling values during training, but the EMA model keeps the initial zero scaling.

PEFT stores this state in a regular Python dictionary rather than a tensor registered in `state_dict`, so the standard EMA update does not copy it.

This causes training loss to decrease while EMA validation metrics collapse, and saved EMA checkpoints may effectively evaluate with LoRA disabled.

Observed state before the fix:

```text
online scaling: {"default": 3.0}
EMA scaling:    {"default": 0.0}