### PR TITLE
Add strict multi-seed MoT ablation runner and aggregator

### DIFF
--- a/scripts/aggregate_mot_ablation_seeds.py
+++ b/scripts/aggregate_mot_ablation_seeds.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Aggregate multi-seed MoE/MoT/MoA ablations with completeness checks.
+
+The training summaries contain seed-dependent accuracy and stability metrics. A
+single optional benchmark CSV supplies architecture-dependent latency, FLOPs,
+and parameter counts, which do not need to be remeasured for every seed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import statistics
+from collections import defaultdict
+from pathlib import Path
+
+
+METRICS = {
+    "map50_95": ("metrics/mAP50-95(B)", "mAP50-95"),
+    "map50": ("metrics/mAP50(B)", "mAP50"),
+    "final_train_total_loss": ("final_train_total_loss",),
+}
+PROFILE_FIELDS = ("latency_ms_p50", "latency_ms_p95", "latency_ms_p99", "flops_g", "params_m")
+
+
+def read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        return list(csv.DictReader(handle))
+
+
+def as_float(value: object) -> float | None:
+    try:
+        result = float(value) if value not in {None, ""} else None
+    except (TypeError, ValueError):
+        return None
+    return result if result is not None and math.isfinite(result) else None
+
+
+def as_bool(value: object) -> bool:
+    return str(value).strip().lower() in {"1", "true", "yes", "y"}
+
+
+def seed_sort_key(seed: str) -> tuple[int, int | str]:
+    return (0, int(seed)) if seed.isdigit() else (1, seed)
+
+
+def mean_std(values: list[float]) -> tuple[float, float]:
+    return statistics.mean(values), statistics.stdev(values) if len(values) > 1 else 0.0
+
+
+def load_optional_by_key(path: Path | None) -> dict[str, dict[str, str]]:
+    if not path:
+        return {}
+    if not path.exists():
+        raise FileNotFoundError(path)
+    rows = read_csv(path)
+    if any(not row.get("key") for row in rows):
+        raise ValueError(f"profile CSV has a row without key: {path}")
+    return {row["key"]: row for row in rows}
+
+
+def collect_seed_rows(
+    root: Path,
+    expected_seeds: list[str] | None = None,
+    allow_incomplete: bool = False,
+) -> dict[str, list[dict[str, str]]]:
+    summaries = sorted(root.glob("seed_*/summary.csv"), key=lambda path: seed_sort_key(path.parent.name[5:]))
+    if not summaries:
+        raise ValueError(f"no seed_*/summary.csv files found under {root}")
+
+    discovered_seeds = [path.parent.name[5:] for path in summaries]
+    if expected_seeds is not None:
+        expected = sorted({str(seed) for seed in expected_seeds}, key=seed_sort_key)
+        if discovered_seeds != expected:
+            raise ValueError(f"seed mismatch: expected {expected}, found {discovered_seeds}")
+
+    grouped: dict[str, list[dict[str, str]]] = defaultdict(list)
+    model_sets: dict[str, set[str]] = {}
+    for summary in summaries:
+        seed = summary.parent.name[5:]
+        rows = read_csv(summary)
+        keys = [row.get("key", "") for row in rows]
+        if not rows or any(not key for key in keys):
+            raise ValueError(f"empty or malformed summary: {summary}")
+        if len(keys) != len(set(keys)):
+            raise ValueError(f"duplicate model key in {summary}")
+        model_sets[seed] = set(keys)
+        for row in rows:
+            grouped[row["key"]].append({**row, "seed": seed, "source": str(summary)})
+
+    if not allow_incomplete:
+        expected_models = set.union(*model_sets.values())
+        incomplete = {
+            seed: sorted(expected_models - keys)
+            for seed, keys in model_sets.items()
+            if keys != expected_models
+        }
+        if incomplete:
+            raise ValueError(f"incomplete model coverage by seed: {incomplete}")
+    return grouped
+
+
+def aggregate(
+    root: Path,
+    latency_csv: Path | None = None,
+    build_csv: Path | None = None,
+    *,
+    baseline_key: str = "v10",
+    expected_seeds: list[str] | None = None,
+    allow_incomplete: bool = False,
+    map_gain_threshold: float = 0.01,
+    latency_reduction_threshold_pct: float = 10.0,
+) -> list[dict[str, object]]:
+    grouped = collect_seed_rows(root, expected_seeds=expected_seeds, allow_incomplete=allow_incomplete)
+    latency = load_optional_by_key(latency_csv)
+    builds = load_optional_by_key(build_csv)
+    output: list[dict[str, object]] = []
+
+    for key, rows in sorted(grouped.items()):
+        ordered_rows = sorted(rows, key=lambda row: seed_sort_key(row["seed"]))
+        item: dict[str, object] = {
+            "key": key,
+            "label": ordered_rows[0].get("label", key),
+            "n_seeds": len(ordered_rows),
+            "seeds": ",".join(row["seed"] for row in ordered_rows),
+            "nan_any": any(as_bool(row.get("nan_detected")) for row in ordered_rows),
+            "loss_diverged_any": any(as_bool(row.get("loss_diverged")) for row in ordered_rows),
+        }
+        for output_name, source_names in METRICS.items():
+            values = []
+            for row in ordered_rows:
+                value = next((parsed for name in source_names if (parsed := as_float(row.get(name))) is not None), None)
+                if value is not None:
+                    values.append(value)
+            if values:
+                mean, std = mean_std(values)
+                item.update(
+                    {
+                        f"{output_name}_mean": mean,
+                        f"{output_name}_std": std,
+                        f"{output_name}_min": min(values),
+                        f"{output_name}_max": max(values),
+                    }
+                )
+
+        profile = {**builds.get(key, {}), **latency.get(key, {})}
+        fallback = ordered_rows[0]
+        for field in PROFILE_FIELDS:
+            value = as_float(profile.get(field))
+            if value is None:
+                value = as_float(fallback.get(field))
+            if value is not None:
+                item[field] = value
+        output.append(item)
+
+    baseline = next((row for row in output if row["key"] == baseline_key), None)
+    if baseline is None:
+        raise ValueError(f"baseline key {baseline_key!r} is absent")
+    baseline_map = as_float(baseline.get("map50_95_mean"))
+    baseline_p50 = as_float(baseline.get("latency_ms_p50"))
+    for row in output:
+        current_map = as_float(row.get("map50_95_mean"))
+        current_p50 = as_float(row.get("latency_ms_p50"))
+        map_delta = current_map - baseline_map if current_map is not None and baseline_map is not None else None
+        latency_delta = (
+            (current_p50 - baseline_p50) / baseline_p50 * 100
+            if current_p50 is not None and baseline_p50 not in {None, 0}
+            else None
+        )
+        if map_delta is not None:
+            row["map50_95_delta_vs_baseline"] = map_delta
+        if latency_delta is not None:
+            row["latency_delta_pct_vs_baseline"] = latency_delta
+        row["meaningful_gain"] = bool(
+            (map_delta is not None and map_delta > map_gain_threshold)
+            or (latency_delta is not None and latency_delta < -latency_reduction_threshold_pct)
+        )
+    return output
+
+
+def write_csv(path: Path, rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = sorted({key for row in rows for key in row})
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def fmt(row: dict[str, object], key: str, digits: int = 4) -> str:
+    value = as_float(row.get(key))
+    return f"{value:.{digits}f}" if value is not None else "N/A"
+
+
+def write_markdown(path: Path, rows: list[dict[str, object]], title: str, note: str | None = None) -> None:
+    lines = [
+        f"# {title}",
+        "",
+        "| Model | Seeds | mAP50-95 mean±std | mAP50 mean±std | P50/P95/P99 ms | "
+        "Actual FLOPs (G) | Params (M) | Stable | Gain gate |",
+        "|---|---:|---:|---:|---:|---:|---:|:---:|:---:|",
+    ]
+    for row in rows:
+        map95 = f"{fmt(row, 'map50_95_mean')}±{fmt(row, 'map50_95_std')}"
+        map50 = f"{fmt(row, 'map50_mean')}±{fmt(row, 'map50_std')}"
+        latency = "/".join(fmt(row, key, 2) for key in ("latency_ms_p50", "latency_ms_p95", "latency_ms_p99"))
+        stable = "yes" if not row.get("nan_any") and not row.get("loss_diverged_any") else "no"
+        gain = "pass" if row.get("meaningful_gain") else "fail"
+        lines.append(
+            f"| {row.get('label', row['key'])} | {row['n_seeds']} | {map95} | {map50} | {latency} | "
+            f"{fmt(row, 'flops_g', 3)} | {fmt(row, 'params_m', 3)} | {stable} | {gain} |"
+        )
+    if note:
+        lines.extend(["", f"> {note}"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, required=True, help="Directory containing seed_*/summary.csv.")
+    parser.add_argument("--latency-csv", type=Path, help="One hardware-controlled benchmark CSV shared by all seeds.")
+    parser.add_argument("--build-csv", type=Path)
+    parser.add_argument("--baseline", default="v10")
+    parser.add_argument("--expected-seeds", nargs="+")
+    parser.add_argument("--allow-incomplete", action="store_true")
+    parser.add_argument("--map-gain-threshold", type=float, default=0.01)
+    parser.add_argument("--latency-reduction-threshold-pct", type=float, default=10.0)
+    parser.add_argument("--title", default="MoE/MoT/MoA multi-seed ablation")
+    parser.add_argument("--note")
+    parser.add_argument("--out-csv", type=Path)
+    parser.add_argument("--out-md", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    rows = aggregate(
+        args.root,
+        args.latency_csv,
+        args.build_csv,
+        baseline_key=args.baseline,
+        expected_seeds=args.expected_seeds,
+        allow_incomplete=args.allow_incomplete,
+        map_gain_threshold=args.map_gain_threshold,
+        latency_reduction_threshold_pct=args.latency_reduction_threshold_pct,
+    )
+    out_csv = args.out_csv or args.root / "aggregate_multiseed.csv"
+    out_md = args.out_md or args.root / "aggregate_multiseed.md"
+    write_csv(out_csv, rows)
+    write_markdown(out_md, rows, title=args.title, note=args.note)
+    print(f"wrote {out_csv}")
+    print(f"wrote {out_md}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_coco128_mot_3seed.sh
+++ b/scripts/run_coco128_mot_3seed.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reproducible COCO128 pilot for the Issue #54 MoE/MoT/MoA comparison.
+# Environment variables may override defaults without editing this file.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON="${PYTHON:-python3}"
+DATA="${DATA:-$ROOT/ultralytics/cfg/datasets/coco128.yaml}"
+PROJECT_ROOT="${PROJECT_ROOT:-$ROOT/runs/mot_ablation_coco128_3seed}"
+EPOCHS="${EPOCHS:-100}"
+IMGSZ="${IMGSZ:-640}"
+BATCH="${BATCH:-16}"
+WORKERS="${WORKERS:-0}"
+DEVICE="${DEVICE:-0}"
+SEEDS="${SEEDS:-42 123 3407}"
+MODELS="${MODELS:-v10 v10_mot v10_moa v10_moa_mot}"
+BENCHMARK="${BENCHMARK:-1}"
+WARMUP="${WARMUP:-100}"
+REPS="${REPS:-1000}"
+
+read -r -a seed_args <<<"$SEEDS"
+read -r -a model_args <<<"$MODELS"
+
+mkdir -p "$PROJECT_ROOT"
+for seed in "${seed_args[@]}"; do
+  echo "[$(date --iso-8601=seconds)] starting seed=$seed models=$MODELS"
+  "$PYTHON" "$ROOT/scripts/compare_mot_ablation.py" \
+    --train \
+    --models "${model_args[@]}" \
+    --data "$DATA" \
+    --epochs "$EPOCHS" \
+    --imgsz "$IMGSZ" \
+    --batch "$BATCH" \
+    --workers "$WORKERS" \
+    --device "$DEVICE" \
+    --seed "$seed" \
+    --project "$PROJECT_ROOT/seed_$seed" \
+    --exist-ok
+  echo "[$(date --iso-8601=seconds)] completed seed=$seed"
+done
+
+aggregate_args=(
+  --root "$PROJECT_ROOT"
+  --expected-seeds "${seed_args[@]}"
+  --title "COCO128 MoE/MoT/MoA 3-seed pilot"
+  --note "COCO128 is a smoke benchmark whose train and validation images overlap; do not present these metrics as full-COCO generalization results."
+)
+
+if [[ "$BENCHMARK" == "1" ]]; then
+  profile_dir="$PROJECT_ROOT/profile"
+  "$PYTHON" "$ROOT/scripts/compare_mot_ablation.py" \
+    --benchmark \
+    --actual-flops \
+    --models "${model_args[@]}" \
+    --device "$DEVICE" \
+    --imgsz "$IMGSZ" \
+    --warmup "$WARMUP" \
+    --reps "$REPS" \
+    --project "$profile_dir"
+  aggregate_args+=(--latency-csv "$profile_dir/latency_${DEVICE}_${IMGSZ}.csv")
+fi
+
+"$PYTHON" "$ROOT/scripts/aggregate_mot_ablation_seeds.py" "${aggregate_args[@]}"
+echo "[$(date --iso-8601=seconds)] all COCO128 runs and aggregation completed"

--- a/tests/test_aggregate_mot_ablation_seeds.py
+++ b/tests/test_aggregate_mot_ablation_seeds.py
@@ -1,0 +1,80 @@
+"""Regression tests for strict multi-seed MoT ablation aggregation."""
+
+from pathlib import Path
+
+import pytest
+
+from scripts.aggregate_mot_ablation_seeds import aggregate, write_markdown
+
+
+HEADER = "key,label,metrics/mAP50(B),metrics/mAP50-95(B),final_train_total_loss,nan_detected,loss_diverged\n"
+
+
+def write_seed(root: Path, seed: int, rows: list[str]) -> None:
+    seed_dir = root / f"seed_{seed}"
+    seed_dir.mkdir(parents=True)
+    (seed_dir / "summary.csv").write_text(HEADER + "".join(rows), encoding="utf-8")
+
+
+def test_aggregate_combines_seed_metrics_and_one_profile(tmp_path: Path):
+    root = tmp_path / "runs"
+    write_seed(root, 42, ["v10,baseline,0.2,0.1,5.0,False,False\n", "v10_mot,mot,0.3,0.2,6.0,False,False\n"])
+    write_seed(root, 123, ["v10,baseline,0.4,0.3,5.5,False,False\n", "v10_mot,mot,0.5,0.4,6.5,False,False\n"])
+    profile = tmp_path / "latency.csv"
+    profile.write_text(
+        "key,latency_ms_p50,latency_ms_p95,latency_ms_p99,flops_g,params_m\n"
+        "v10,10,11,12,8.5,3.4\n"
+        "v10_mot,20,21,22,12.2,4.0\n",
+        encoding="utf-8",
+    )
+
+    rows = aggregate(root, profile, expected_seeds=["42", "123"])
+    by_key = {row["key"]: row for row in rows}
+
+    assert by_key["v10"]["seeds"] == "42,123"
+    assert by_key["v10"]["map50_95_mean"] == pytest.approx(0.2)
+    assert by_key["v10"]["map50_95_std"] == pytest.approx(2**0.5 / 10)
+    assert by_key["v10_mot"]["latency_ms_p99"] == 22.0
+    assert by_key["v10_mot"]["meaningful_gain"] is True
+
+
+def test_aggregate_rejects_missing_seed(tmp_path: Path):
+    root = tmp_path / "runs"
+    write_seed(root, 42, ["v10,baseline,0.2,0.1,5.0,False,False\n"])
+
+    with pytest.raises(ValueError, match="seed mismatch"):
+        aggregate(root, expected_seeds=["42", "123"])
+
+
+def test_aggregate_rejects_incomplete_model_coverage(tmp_path: Path):
+    root = tmp_path / "runs"
+    write_seed(root, 42, ["v10,baseline,0.2,0.1,5.0,False,False\n", "v10_mot,mot,0.3,0.2,6.0,False,False\n"])
+    write_seed(root, 123, ["v10,baseline,0.4,0.3,5.5,False,False\n"])
+
+    with pytest.raises(ValueError, match="incomplete model coverage"):
+        aggregate(root)
+
+
+def test_markdown_uses_uncertainty_and_pilot_note(tmp_path: Path):
+    output = tmp_path / "summary.md"
+    rows = [
+        {
+            "key": "v10",
+            "label": "baseline",
+            "n_seeds": 3,
+            "map50_95_mean": 0.2,
+            "map50_95_std": 0.01,
+            "map50_mean": 0.3,
+            "map50_std": 0.02,
+            "nan_any": False,
+            "loss_diverged_any": False,
+            "meaningful_gain": False,
+        }
+    ]
+
+    write_markdown(output, rows, title="pilot", note="smoke only")
+    text = output.read_text(encoding="utf-8")
+
+    assert "mean±std" in text
+    assert "0.2000±0.0100" in text
+    assert "> smoke only" in text


### PR DESCRIPTION
Related to #54.

## What changed

- add `scripts/run_coco128_mot_3seed.sh` to run the four Issue #54 variants over configurable seeds;
- run one hardware-controlled P50/P95/P99 and actual-FLOPs benchmark after training instead of repeating architecture-only measurements per seed;
- add `scripts/aggregate_mot_ablation_seeds.py` to compute sample mean/std/min/max, stability flags, deltas against a configurable baseline, and the Issue gain gate;
- fail closed when an expected seed is missing, a summary has duplicate keys, or model coverage differs across seeds;
- make the COCO128 train/validation overlap limitation explicit in the generated Markdown;
- add focused regression tests for aggregation, completeness gates, uncertainty rendering, and pilot notes.

## Why

`compare_mot_ablation.py` is intentionally a single-run tool. Issue #54 comparisons are easy to overstate when one seed is missing, a model silently fails, or a single lucky seed is reported without uncertainty. This PR adds a small orchestration and audit layer without changing model behavior or adding an unvalidated hybrid YAML.

## Reproduction evidence

The runner was exercised on RTX 5090 with seeds `42, 123, 3407`, four N-scale variants, 100 epochs, 640 px, batch 16, AMP, and training from scratch.

| Model | mAP50-95 mean±std | mAP50 mean±std | P50/P95/P99 (ms) | Actual GFLOPs | Params (M) | Stable | Gain gate |
|---|---:|---:|---:|---:|---:|:---:|:---:|
| EsMoE-N | 0.00117±0.00175 | 0.00361±0.00532 | 12.711/12.813/13.960 | 8.664 | 3.450 | yes | baseline |
| MoT-N | 0.00008±0.00003 | 0.00051±0.00014 | 29.143/32.648/35.203 | 12.263 | 4.055 | yes | fail |
| MoA-N | 0.00009±0.00001 | 0.00043±0.00012 | 27.451/31.235/32.098 | 9.235 | 3.577 | yes | fail |
| MoA+MoT-N | 0.00037±0.00024 | 0.00140±0.00099 | 30.367/35.149/35.763 | 12.962 | 4.057 | yes | fail |

All 12 runs completed 100 epochs with no NaN or loss-divergence flag. None of the experimental variants passed `>0.01` absolute mAP50-95 gain or `>10%` latency reduction against EsMoE.

## Scope and limitations

- COCO128 is a smoke/pilot dataset whose train and validation image sets overlap.
- The models were trained from scratch and the measured mAP is near zero, so these values are not evidence of detection quality or full-COCO generalization.
- Latency and FLOPs are one controlled architecture benchmark shared across seeds; they are not averaged as if seed-dependent.
- The negative pilot is included only to validate the runner and demonstrate why seed uncertainty and completeness gates matter.
- This PR deliberately does not add a hybrid model configuration because the Issue #54 synergy gate was not met.

## Validation

```text
pytest tests/test_aggregate_mot_ablation_seeds.py -q
4 passed in 0.02s

bash -n scripts/run_coco128_mot_3seed.sh
```