### PR TITLE
docs(reproduce): add Issue #49 VisDrone and SKU-110K results

### DIFF
--- a/scripts/reproduce/_reproduce_common.py
+++ b/scripts/reproduce/_reproduce_common.py
@@ -215,6 +215,20 @@ def _make_wandb_callbacks(run_name: str, dataset: "DatasetSpec", spec: "ModelSpe
                     log[out_key] = float(v)
                 except (TypeError, ValueError):
                     pass
+
+        # Issue #49 requires the canonical metric name "moe_loss".
+        # Current trainers may expose the same routed auxiliary loss as
+        # "mixture_aux_loss", so publish both names without overwriting a
+        # native moe_loss value when one is available.
+        for prefix in ("train", "val"):
+            canonical = f"{prefix}/moe_loss"
+            fallback = f"{prefix}/mixture_aux_loss"
+            if canonical not in log and data.get(fallback) is not None:
+                try:
+                    log[canonical] = float(data[fallback])
+                except (TypeError, ValueError):
+                    pass
+
         try:
             run.log(log, step=epoch)
         except Exception as exc:  # noqa: BLE001
@@ -272,8 +286,15 @@ def write_summary(project: Path, dataset: DatasetSpec, models=MODELS, sparse_eva
                 "dense_eval": (spec.uses_esmoe and not sparse_eval) if spec.uses_esmoe else "n/a",
                 "epoch": res.get("epoch", ""),
             }
+            metric_fallbacks = {
+                "train/moe_loss": "train/mixture_aux_loss",
+                "val/moe_loss": "val/mixture_aux_loss",
+            }
             for k in METRIC_KEYS:
-                row[k] = _float_or_blank(res.get(k))
+                value = res.get(k)
+                if value in (None, "") and k in metric_fallbacks:
+                    value = res.get(metric_fallbacks[k])
+                row[k] = _float_or_blank(value)
             w.writerow(row)
     return out
 

--- a/scripts/reproduce/results/issue49_465114810_sku110k.csv
+++ b/scripts/reproduce/results/issue49_465114810_sku110k.csv
@@ -1,0 +1,3 @@
+dataset,model,evaluation,best_epoch,precision,recall,mAP50,mAP50-95,train_hours,best_weight_mb,wandb_url
+SKU-110K,v0.1-N,standard,91,0.90319,0.83643,0.88250,0.54279,3.275,14.8,https://wandb.ai/465114810-ab/yolo-master-issue49-465114810/runs/68e3g0lf
+SKU-110K,EsMoE-N,dense,93,0.90764,0.83626,0.88434,0.54519,3.301,5.9,https://wandb.ai/465114810-ab/yolo-master-issue49-465114810/runs/674mjnj5

--- a/scripts/reproduce/results/issue49_465114810_sku110k.md
+++ b/scripts/reproduce/results/issue49_465114810_sku110k.md
@@ -1,0 +1,18 @@
+# Issue #49 SKU-110K reproduction results
+
+Git commit: `096f09a`
+
+Configuration: `epochs=100`, `imgsz=640`, `batch=32`, `workers=8`, `seed=42`
+
+GPU: NVIDIA GeForce RTX 4090 D
+
+| Model | Evaluation | Best epoch | Precision | Recall | mAP50 | mAP50-95 | Hours | Best weight | W&B |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| v0.1-N | standard | 91 | 0.90319 | 0.83643 | 0.88250 | 0.54279 | 3.275 | 14.8 MB | https://wandb.ai/465114810-ab/yolo-master-issue49-465114810/runs/68e3g0lf |
+| EsMoE-N | dense | 93 | 0.90764 | 0.83626 | 0.88434 | 0.54519 | 3.301 | 5.9 MB | https://wandb.ai/465114810-ab/yolo-master-issue49-465114810/runs/674mjnj5 |
+
+Dataset note: 3 truncated training JPEG files were excluded, leaving 8,216 training images.
+
+EsMoE-N uses corrected dense validation with `--no-sparse-eval`.
+
+The routed auxiliary loss is also logged under the canonical W&B name `moe_loss`.

--- a/scripts/reproduce/results/issue49_465114810_visdrone.csv
+++ b/scripts/reproduce/results/issue49_465114810_visdrone.csv
@@ -1,0 +1,3 @@
+dataset,model,evaluation,best_epoch,precision,recall,mAP50,mAP50-95,train_hours,best_weight_mb,wandb_url
+VisDrone,v0.1-N,standard,88,0.43025,0.33008,0.30384,0.17009,2.178,14.812060356140137,https://wandb.ai/465114810-ab/yolo-master-issue49-465114810/runs/o2ur8w66
+VisDrone,EsMoE-N,dense,89,0.43094,0.33943,0.30861,0.17344,2.962,5.814877510070801,https://wandb.ai/465114810-ab/yolo-master-issue49-465114810/runs/6qd0dn71

--- a/scripts/reproduce/results/issue49_465114810_visdrone.md
+++ b/scripts/reproduce/results/issue49_465114810_visdrone.md
@@ -1,0 +1,19 @@
+# Issue #49 VisDrone reproduction results
+
+Git commit: `096f09a`
+
+Configuration: `epochs=100`, `imgsz=640`, `batch=32`, `workers=8`, `seed=42`
+
+GPU: NVIDIA GeForce RTX 4090 D
+
+W&B project: `yolo-master-issue49-465114810`
+
+
+| Model | Evaluation | Best epoch | Precision | Recall | mAP50 | mAP50-95 | Hours | Best weight | W&B |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| v0.1-N | standard | 88 | 0.43025 | 0.33008 | 0.30384 | 0.17009 | 2.178 | 14.8 MB | https://wandb.ai/465114810-ab/yolo-master-issue49-465114810/runs/o2ur8w66 |
+| EsMoE-N | dense | 89 | 0.43094 | 0.33943 | 0.30861 | 0.17344 | 2.962 | 5.8 MB | https://wandb.ai/465114810-ab/yolo-master-issue49-465114810/runs/6qd0dn71 |
+
+Notes: EsMoE-N uses corrected dense validation with `--no-sparse-eval`.
+
+The routed auxiliary loss is also logged under the canonical name `moe_loss`.


### PR DESCRIPTION
## Summary

Related to #49.

This PR adds reproducible 100-epoch results for:

- YOLO-Master-v0.1-N on VisDrone
- YOLO-Master-EsMoE-N on VisDrone
- YOLO-Master-v0.1-N on SKU-110K
- YOLO-Master-EsMoE-N on SKU-110K

It also publishes the existing `mixture_aux_loss` under the canonical W&B metric name `moe_loss`, while preserving the original metric name.

## Changes

- Add canonical W&B aliases:
  - `train/moe_loss`
  - `val/moe_loss`
- Preserve:
  - `train/mixture_aux_loss`
  - `val/mixture_aux_loss`
- Add VisDrone result files:
  - `scripts/reproduce/results/issue49_465114810_visdrone.csv`
  - `scripts/reproduce/results/issue49_465114810_visdrone.md`
- Add SKU-110K result files:
  - `scripts/reproduce/results/issue49_465114810_sku110k.csv`
  - `scripts/reproduce/results/issue49_465114810_sku110k.md`

## Training configuration

| Item | Value |
|---|---|
| GPU | NVIDIA GeForce RTX 4090 D, 24 GB |
| Epochs | 100 |
| Image size | 640 |
| Batch size | 32 |
| Workers | 8 |
| Seed | 42 |
| Pretrained weights | Disabled |
| Optimizer | `auto` |
| W&B project | `yolo-master-issue49-465114810` |

## Results

Best epoch is selected by maximum validation `mAP50-95`.

| Dataset | Model | Evaluation | Best epoch | Precision | Recall | mAP50 | mAP50-95 | Hours |
|---|---|---|---:|---:|---:|---:|---:|---:|
| VisDrone | v0.1-N | standard | 88 | 0.43025 | 0.33008 | 0.30384 | 0.17009 | 2.178 |
| VisDrone | EsMoE-N | dense | 89 | 0.43094 | 0.33943 | 0.30861 | 0.17344 | 2.962 |
| SKU-110K | v0.1-N | standard | 91 | 0.90319 | 0.83643 | 0.88250 | 0.54279 | 3.275 |
| SKU-110K | EsMoE-N | dense | 93 | 0.90764 | 0.83626 | 0.88434 | 0.54519 | 3.301 |

## Public W&B runs

### VisDrone

- v0.1-N: https://wandb.ai/465114810-ab/yolo-master-issue49-465114810/runs/o2ur8w66
- EsMoE-N: https://wandb.ai/465114810-ab/yolo-master-issue49-465114810/runs/6qd0dn71

### SKU-110K

- v0.1-N: https://wandb.ai/465114810-ab/yolo-master-issue49-465114810/runs/68e3g0lf
- EsMoE-N: https://wandb.ai/465114810-ab/yolo-master-issue49-465114810/runs/674mjnj5

All links were verified in a logged-out private browser window.

## EsMoE validation

EsMoE-N was evaluated with:

```bash
--no-sparse-eval