### PR TITLE
fix(multitask): harden routing, E2E supervision, and checkpoint loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ All notable changes to YOLO-Master are documented in this file.
 | Area | Release status | What v26.08 adds |
 |---|---|---|
 | **Ultralytics 8.4.101 / YOLO26** | **Stable upstream base** | Native task flows, checkpoint compatibility, export integrity, and additive mixture registration |
-| **MultiTask** | **Preview** | Unified detection, segmentation, pose, classification, depth, and OBB branches with optional task routing |
+| **MultiTask** | **Preview** | Unified detection, segmentation, pose, classification, depth, normal, and semantic branches with optional task routing; OBB uses its dedicated task model |
 | **Shared Expert MoE** | **Validated component** | Model-scoped expert-pool reuse with cross-model isolation |
 | **MoA / MoT** | **Experimental profiles** | Routed attention and transformer blocks, sparse paths, scene-aware routing, and shared temperature scheduling |
 | **PEFT Planner / LOVO** | **Opt-in** | Architecture-conditioned placement, V-PEFT solvers, validation, and FewShot-LoRA controls |
@@ -189,9 +189,9 @@ yolo mixtures kind=latent format=json
                                │
                       Optional TaskRouter
                                │
-        ┌──────────┬─────────┬──────┬──────────┬───────┬─────┐
-        │ Detect   │ Segment │ Pose │ Classify │ Depth │ OBB │
-        └──────────┴─────────┴──────┴──────────┴───────┴─────┘
+        ┌──────────┬─────────┬──────┬──────────┬───────┬────────┬──────────┐
+        │ Detect   │ Segment │ Pose │ Classify │ Depth │ Normal │ Semantic │
+        └──────────┴─────────┴──────┴──────────┴───────┴────────┴──────────┘
 ```
 
 | Component | Role |
@@ -210,7 +210,7 @@ yolo multitask train \
 ```
 
 > [!NOTE]
-> The current unified COCO pipeline has aligned trainable labels for detection, instance segmentation, and human pose. Classification, depth, and OBB require suitable task labels before they contribute a training loss. The current `multitask` prediction map uses `DetectionPredictor`; a public `tasks=[...]` multi-output inference API is not documented in this release.
+> The current unified COCO pipeline has aligned trainable labels for detection, instance segmentation, and human pose. Classification, depth, normal, and semantic branches require suitable aligned labels before they contribute a training loss. Unified MultiTask OBB training is unsupported; use the dedicated OBB model. The current `multitask` prediction map uses `DetectionPredictor`; a public `tasks=[...]` multi-output inference API is not documented in this release.
 
 **Implementation:** `ultralytics/nn/modules/multitask/` · `ultralytics/models/yolo/multitask/` · `ultralytics/nn/tasks.py`
 

--- a/docs/release-notes/v26.08.md
+++ b/docs/release-notes/v26.08.md
@@ -32,7 +32,7 @@
 
 ### MultiTask training hardening
 
-The MultiTask path adds `MultiTaskBatchSampler` with round-robin or weighted task sampling. Its serializable state is stored with the training checkpoint so a resumed run keeps deterministic task proportions. Missing supervision is represented by validity masks, and only valid task labels contribute to `MultiTaskLoss`. The current unified COCO path has aligned detection, instance-segmentation, and human-pose labels; classification, depth, and OBB require matching annotations.
+The MultiTask path adds `MultiTaskBatchSampler` with round-robin or weighted task sampling. Its serializable state is stored with the training checkpoint so a resumed run keeps deterministic task proportions. Missing supervision is represented by validity masks, and only valid task labels contribute to `MultiTaskLoss`. The current unified COCO path has aligned detection, instance-segmentation, and human-pose labels; classification, depth, normal, and semantic branches require aligned annotations. Unified MultiTask OBB training is not supported; use a dedicated OBB model.
 
 ### Latent Mixture configuration and export safety
 

--- a/tests/test_latent_mixture.py
+++ b/tests/test_latent_mixture.py
@@ -192,6 +192,21 @@ def test_yolo26_latent_yaml_builds_and_runs():
     assert output is not None
 
 
+def test_latent_detection_model_load_skips_non_tensor_extra_state():
+    config = ROOT / "ultralytics/cfg/models/26/yolo26-master-latent-n-resinit010.yaml"
+    source = DetectionModel(config, ch=3, nc=80, verbose=False)
+    target = DetectionModel(config, ch=3, nc=80, verbose=False)
+    source_latent = next(module for module in source.modules() if isinstance(module, LatentMixture))
+    target_latent = next(module for module in target.modules() if isinstance(module, LatentMixture))
+    source_latent.residual_gain.data.fill_(0.37)
+
+    assert any(key.endswith("._extra_state") for key in source.state_dict())
+    target.load(source, verbose=False)
+
+    assert target_latent.residual_gain.item() == pytest.approx(0.37)
+    assert target_latent.value_fusion_mode == "router_only"
+
+
 def test_yolo26_latent_initperturb_yaml_builds_and_runs():
     model = DetectionModel(
         ROOT / "ultralytics/cfg/models/26/yolo26-master-latent-n-initperturb020.yaml",

--- a/tests/test_multitask.py
+++ b/tests/test_multitask.py
@@ -8,7 +8,9 @@ import pytest
 import torch
 import torch.nn as nn
 
+from ultralytics.nn.mixture_loss import CompositeCriterion
 from ultralytics.nn.modules.multitask.head import MultiTaskHead
+from ultralytics.nn.modules.multitask.router import TaskRouter
 from ultralytics.utils.loss import MultiTaskLoss
 from ultralytics.models.yolo.multitask.train import (
     MultiTaskTrainer,
@@ -518,11 +520,19 @@ class TestMultiTaskHeadInit:
         assert head.cv4_depth is None
         assert head.cv4_obb is None
 
-    def test_all_tasks_default(self):
+    def test_all_trainable_tasks_default_without_obb(self):
         head = MultiTaskHead(nc=80, ch=(64, 128, 256))
-        assert head.active_tasks == ["classify", "depth", "detect", "normal", "obb", "pose", "segment", "semantic"]
-        for attr in ["cv4_seg", "cv4_pose", "cv4_cls", "cv4_depth", "cv4_normal", "cv4_semantic", "cv4_obb"]:
+        assert head.active_tasks == ["classify", "depth", "detect", "normal", "pose", "segment", "semantic"]
+        for attr in ["cv4_seg", "cv4_pose", "cv4_cls", "cv4_depth", "cv4_normal", "cv4_semantic"]:
             assert getattr(head, attr) is not None, f"{attr} should not be None"
+        assert head.cv4_obb is None
+        assert set(TaskRouter.available_tasks().values()) == set(head.active_tasks)
+
+    def test_legacy_obb_head_cannot_be_activated_for_training(self):
+        head = MultiTaskHead(nc=80, ch=(64, 128, 256), tasks=["detect", "obb"])
+        assert head.cv4_obb is not None
+        with pytest.raises(ValueError, match="dedicated OBB model"):
+            head.set_active_tasks(["detect", "obb"])
 
     def test_subset_tasks(self):
         head = MultiTaskHead(nc=20, ch=(64, 128), tasks=["detect", "segment", "pose"], kpt_shape=(5, 3))
@@ -547,10 +557,15 @@ class TestMultiTaskHeadInit:
         assert hasattr(head, "one2one")
         assert isinstance(head.one2one, dict)
 
-    def test_end2end_is_true(self):
-        """end2end property is True when one2one property exists (base Detect logic)."""
+    def test_end2end_defaults_true_with_complete_one2one_heads(self):
         head = MultiTaskHead(nc=80, ch=(64, 128), tasks=["detect"])
         assert head.end2end is True
+        assert set(head.one2one) >= {"box_head", "cls_head"}
+
+    def test_end2end_false_disables_one2one_forward(self):
+        head = MultiTaskHead(nc=80, ch=(64, 128), tasks=["detect"], end2end=False).train()
+        assert head.end2end is False
+        assert "one2many" not in head(_make_fpn_features(ch=(64, 128)))
 
     def test_task_importance_shape(self):
         head = MultiTaskHead(nc=80, ch=(64, 128), tasks=["detect", "segment", "pose"])
@@ -639,7 +654,6 @@ class TestMultiTaskHeadForwardHead:
             "depth",
             "normal",
             "semantic",
-            "angle",
             "cls_logits",
         ]:
             assert key in out, f"Missing key: {key}"
@@ -654,10 +668,21 @@ class TestMultiTaskHeadForward:
     """Top-level forward() mode switching."""
 
     def test_train_returns_one2many_one2one(self):
-        head = MultiTaskHead(nc=10, ch=(64, 128, 256), tasks=["detect", "segment"], nm=16, npr=128).train()
+        head = MultiTaskHead(
+            nc=10,
+            ch=(64, 128, 256),
+            tasks=["detect", "segment", "pose"],
+            nm=16,
+            npr=128,
+            kpt_shape=(5, 3),
+        ).train()
         out = head(_make_fpn_features())
         assert isinstance(out, dict) and "one2many" in out and "one2one" in out
         assert "boxes" in out["one2many"] and "mask_coefficient" in out["one2many"]
+        assert out["one2one"]["mask_coefficient"] is out["one2many"]["mask_coefficient"]
+        assert out["one2one"]["proto"] is out["one2many"]["proto"]
+        assert out["one2one"]["kpts"] is out["one2many"]["kpts"]
+        assert not hasattr(head, "one2one_cv4_seg") and not hasattr(head, "one2one_cv4_pose")
 
     def test_eval_returns_tuple(self):
         torch.manual_seed(0)
@@ -749,25 +774,23 @@ class TestMultiTaskHeadForward:
 
 
 class TestMultiTaskHeadLifecycle:
-    @pytest.mark.xfail(
-        reason="Known: parent Detect.bias_init accesses one2one['box_head'] but "
-        "MultiTaskHead always has end2end=True (property) while parent "
-        "Detect.__init__ only creates one2one_cv2/cv3 when explicit end2end=True."
-    )
     def test_bias_init_does_not_crash_for_all_tasks(self):
-        """bias_init works when both one2many and one2one have full head dicts.
-        Note: detect-only head may fail bias_init because one2one dict lacks box_head/cls_head
-        (the parent Detect.__init__ only creates one2one_cv* when end2end=True, but
-        MultiTaskHead.end2end is always True via property). This is a known limitation.
-        """
-        head = MultiTaskHead(nc=10, ch=(64, 128, 256), tasks=None)  # all tasks
-        head.bias_init()  # should not raise
+        """Default construction creates the complete one-to-many and one-to-one detection lifecycle."""
+        head = MultiTaskHead(nc=10, ch=(64, 128, 256), tasks=None)
+        head.stride = torch.tensor([8.0, 16.0, 32.0])
+        head.bias_init()
 
-    def test_fuse_clears_all_heads(self):
-        head = MultiTaskHead(nc=10, ch=(64, 128, 256), tasks=["detect", "segment"])
+    def test_fuse_keeps_supervised_auxiliary_heads(self):
+        head = MultiTaskHead(
+            nc=10, ch=(64, 128, 256), tasks=["detect", "segment", "pose"], nm=16, kpt_shape=(5, 3)
+        ).eval()
+        head.stride = torch.tensor([8.0, 16.0, 32.0])
         head.fuse()
-        for attr in ["cv2", "cv3", "cv4_seg", "cv4_pose", "cv4_depth", "cv4_normal", "cv4_semantic", "cv4_obb"]:
-            assert getattr(head, attr) is None, f"{attr} should be None after fuse"
+
+        assert head.cv2 is None and head.cv3 is None
+        assert head.cv4_seg is not None and head.cv4_pose is not None
+        _, raw = head(_make_fpn_features())
+        assert "mask_coefficient" in raw["one2one"] and "kpts" in raw["one2one"]
 
     def test_gradient_flow_detect(self):
         torch.manual_seed(0)
@@ -797,7 +820,7 @@ class TestMultiTaskHeadLifecycle:
         ).train()
         out = head.forward_head(_make_fpn_features())
         total = out["boxes"].mean()
-        for k in ["mask_coefficient", "kpts", "depth", "normal", "semantic", "angle", "cls_logits"]:
+        for k in ["mask_coefficient", "kpts", "depth", "normal", "semantic", "cls_logits"]:
             total = total + out[k].mean()
         total.backward()
         assert _has_grad(head)
@@ -809,6 +832,20 @@ class TestMultiTaskHeadLifecycle:
 
 
 class TestMultiTaskHeadTaskRouter:
+    def test_balance_loss_is_nonnegative_and_updates_router(self):
+        router = TaskRouter(dim=16, num_tasks=3, top_k=1).train()
+        router(torch.randn(2, 16, 8, 8))
+
+        loss = router.compute_balance_loss()
+        assert loss.requires_grad
+        assert torch.isfinite(loss) and loss >= 0
+        loss.backward()
+        assert _has_grad(router.affinity_router)
+
+    def test_balance_loss_is_zero_before_first_forward(self):
+        router = TaskRouter(dim=16, num_tasks=3, top_k=1)
+        assert router.compute_balance_loss().item() == 0.0
+
     def test_without_taskrouter_no_routing_stats(self):
         head = MultiTaskHead(nc=10, ch=(64, 128, 256), tasks=["detect", "segment"], use_task_router=False).train()
         out = head.forward_head(_make_fpn_features())
@@ -907,6 +944,21 @@ class TestMultiTaskLoss:
         assert model.state_dict()
         ema.update(model)
 
+    def test_end2end_schedule_updates_and_resumes_through_composite(self):
+        model = self._make_model(["detect", "segment", "pose"])
+        model.args.epochs = 100
+        criterion = MultiTaskLoss(model)
+        composite = CompositeCriterion(model, criterion)
+        initial_o2m = criterion.det_loss.o2m
+
+        composite.updates = 9
+        assert criterion.updates == 9
+        composite.update()
+
+        assert composite.updates == criterion.updates == 10
+        assert criterion.det_loss.o2m < initial_o2m
+        assert criterion.det_loss.o2o == pytest.approx(1.0 - criterion.det_loss.o2m)
+
     def test_forward_empty_preds_returns_zeros(self):
         loss = MultiTaskLoss(self._make_model(["detect"]))
         total, items = loss.forward({}, {})
@@ -965,6 +1017,36 @@ class TestMultiTaskLoss:
         total, items = loss.forward(preds, batch)
         assert items.shape == (9,) and torch.isfinite(total), f"total={total.item()}"
         # seg_loss is computed but may be 0 for random data through E2ELoss path
+
+    def test_end2end_auxiliary_losses_use_one2one_assignments(self, monkeypatch):
+        torch.manual_seed(0)
+        model = self._make_model(["detect", "segment", "pose"])
+        criterion = MultiTaskLoss(model)
+        calls = {"segment": 0, "pose": 0}
+        original_segment = criterion.seg_loss_one2one.loss
+        original_pose = criterion.pose_loss_one2one.loss
+
+        def segment_loss(preds, batch):
+            calls["segment"] += 1
+            return original_segment(preds, batch)
+
+        def pose_loss(preds, batch):
+            calls["pose"] += 1
+            return original_pose(preds, batch)
+
+        monkeypatch.setattr(criterion.seg_loss_one2one, "loss", segment_loss)
+        monkeypatch.setattr(criterion.pose_loss_one2one, "loss", pose_loss)
+        preds = model.model[-1](_make_fpn_features())
+        batch = {
+            "batch_idx": torch.tensor([0, 1], dtype=torch.long),
+            "cls": torch.tensor([[0.0], [1.0]], dtype=torch.float32),
+            "bboxes": torch.tensor([[0.5, 0.5, 0.4, 0.4], [0.5, 0.5, 0.3, 0.3]], dtype=torch.float32),
+            "masks": torch.randint(0, 2, (2, 160, 160), dtype=torch.uint8),
+            "keypoints": torch.tensor([[[0.5, 0.5, 1.0]] * 5, [[0.4, 0.4, 1.0]] * 5]),
+        }
+
+        total, _ = criterion(preds, batch)
+        assert torch.isfinite(total) and calls == {"segment": 1, "pose": 1}
 
     def test_pose_loss_zero_without_keypoints(self):
         torch.manual_seed(0)
@@ -1042,6 +1124,26 @@ class TestMultiTaskLoss:
         assert torch.isfinite(total) and (items[5:] > 0).all()
         for branch in ("cv4_cls", "cv4_depth", "cv4_normal", "cv4_semantic"):
             assert _has_grad(getattr(model.model[-1], branch))
+
+    def test_semantic_loss_normalizes_over_valid_pixels_only(self):
+        criterion = MultiTaskLoss.__new__(MultiTaskLoss)
+        nn.Module.__init__(criterion)
+        criterion.model = SimpleNamespace(end2end=False, model=[SimpleNamespace(task_router=None)])
+        criterion.task_weights = {"detect": 0.0, "semantic": 1.0}
+        criterion.det_loss = lambda preds, batch: (torch.zeros(1), torch.zeros(3))
+        criterion.seg_loss = criterion.pose_loss = criterion.cls_loss = None
+        criterion.semantic_loss = nn.CrossEntropyLoss(ignore_index=255, reduction="none")
+        logits = torch.tensor([[[[2.0, 10.0], [10.0, 10.0]], [[-1.0, -10.0], [-10.0, -10.0]]]], requires_grad=True)
+        preds = {"boxes": torch.zeros(1, 4, 1), "scores": torch.zeros(1, 2, 1), "semantic": logits}
+        target = torch.tensor([[[0, 255], [255, 255]]])
+
+        total, items = criterion(preds, {"semantic_mask": target})
+        expected = torch.nn.functional.cross_entropy(logits[:, :, :1, :1], target[:, :1, :1])
+        assert total.item() == pytest.approx(expected.item())
+        assert items[8].item() == pytest.approx(expected.item())
+        total.backward()
+        assert logits.grad is not None and logits.grad[:, :, 0, 0].abs().sum() > 0
+        assert logits.grad[:, :, 0, 1:].eq(0).all() and logits.grad[:, :, 1:].eq(0).all()
 
     def test_missing_dense_targets_do_not_create_supervision(self):
         """Absent auxiliary files and ignored semantic pixels must not produce false targets."""

--- a/ultralytics/cfg/models/26/yolo26-master-mt-n.yaml
+++ b/ultralytics/cfg/models/26/yolo26-master-mt-n.yaml
@@ -1,7 +1,7 @@
 # Ultralytics YOLO26-Master-MT Multi-Task Vision Model
 #
 # Default supervised path: detection, instance segmentation, and pose.
-# Classification/depth/OBB require dedicated data, criteria, and validation.
+# Classification/depth require aligned labels; unified MultiTask OBB is unsupported (use a dedicated OBB model).
 #
 # MOT-inspired architecture:
 #   - MoT blocks in neck: token-level routing to Transformer experts

--- a/ultralytics/models/yolo/multitask/train.py
+++ b/ultralytics/models/yolo/multitask/train.py
@@ -28,7 +28,6 @@ _TASK_LOSS_NAMES = {
     "depth": ("depth_loss",),
     "normal": ("normal_loss",),
     "semantic": ("semantic_loss",),
-    "obb": ("box_loss", "cls_loss", "dfl_loss", "angle_loss"),
 }
 _UNIFIED_LOSS_NAMES = (
     "box_loss",
@@ -153,14 +152,14 @@ def validate_multitask_contract(data: dict[str, Any], head) -> tuple[str, ...]:
 
     tasks = set(declared_tasks)
     tasks.add("detect")  # MultiTaskHead and its assignment/loss path always include detection.
+    if "obb" in tasks:
+        raise ValueError(
+            "Multi-task 'obb' is not supported: its target, loss, and validator path are incomplete. "
+            "Use a dedicated OBB model or remove 'obb' from data.tasks."
+        )
     unknown = tasks.difference(_SUPPORTED_TASKS)
     if unknown:
         raise ValueError(f"Unsupported multi-task branches: {sorted(unknown)}")
-    if "obb" in tasks:
-        raise ValueError(
-            "Multi-task 'obb' is not trainable yet: its COCO-aligned target, loss, and validator path are incomplete. "
-            "Use a dedicated OBB model or remove 'obb' from data.tasks."
-        )
     without_loss = tasks.difference(_LOSS_BACKED_TASKS)
     without_validation = tasks.difference(_VALIDATION_EVIDENCE)
     if without_loss or without_validation:

--- a/ultralytics/nn/mixture_loss.py
+++ b/ultralytics/nn/mixture_loss.py
@@ -357,6 +357,15 @@ class CompositeCriterion:
         self.native_criterion = native_criterion
         self.enabled = has_routed_modules(model)
 
+    @property
+    def updates(self) -> int:
+        """Expose the native criterion schedule position."""
+        return int(getattr(self.native_criterion, "updates", 0))
+
+    @updates.setter
+    def updates(self, value: int) -> None:
+        setattr(self.native_criterion, "updates", int(value))
+
     def __getattr__(self, name: str):
         if name in {"model", "native_criterion", "enabled"}:
             raise AttributeError(name)

--- a/ultralytics/nn/modules/multitask/head.py
+++ b/ultralytics/nn/modules/multitask/head.py
@@ -12,7 +12,6 @@ MOT-inspired design:
 
 from __future__ import annotations
 
-import copy
 from typing import Optional
 
 import torch
@@ -24,6 +23,10 @@ from ultralytics.nn.modules.block import Proto26
 from ultralytics.nn.modules.conv import Conv
 
 
+DEFAULT_MULTITASK_TASKS = ("detect", "segment", "pose", "classify", "depth", "normal", "semantic")
+COMPATIBILITY_ONLY_TASKS = frozenset({"obb"})
+
+
 class MultiTaskHead(Detect):
     """Unified multi-task head with sparse and dense prediction branches.
 
@@ -32,10 +35,11 @@ class MultiTaskHead(Detect):
     for all configured tasks.
 
     Args:
-        nc: Number of classes (shared across detection/seg/pose/obb).
+        nc: Number of classes shared by detection and related branches.
         ch: Tuple of input channel sizes from FPN (e.g. (256, 512, 1024)).
-        tasks: List of active task names. Supported: "detect", "segment", "pose",
-               "classify", "depth", "normal", "semantic", "obb".
+        tasks: List of built task names. Trainable branches are "detect", "segment", "pose", "classify", "depth",
+            "normal", and "semantic". "obb" remains construction-compatible for legacy checkpoints but is not a
+            supported unified multi-task training branch.
         nm: Number of mask coefficients (segment).
         npr: Number of mask prototypes (segment).
         kpt_shape: (num_keypoints, dims) for pose estimation.
@@ -57,27 +61,28 @@ class MultiTaskHead(Detect):
         depth_bins: int = 80,
         semantic_nc: int = 0,
         reg_max: int = 16,
-        end2end: bool = False,
+        end2end: bool = True,
         use_task_router: bool = False,
         task_router_dim: Optional[int] = None,
     ):
-        # Default: all tasks
+        # Default to branches with a complete unified training contract.
         if tasks is None:
-            tasks = ["detect", "segment", "pose", "classify", "depth", "normal", "semantic", "obb"]
+            tasks = list(DEFAULT_MULTITASK_TASKS)
         self._built_tasks = set(tasks)
         self._built_tasks.add("detect")
         self._active_tasks = set(self._built_tasks)
         self._use_task_router = use_task_router
 
-        # Initialize Detect base (detection always present)
+        # Initialize Detect base (detection always present) and keep its branch lifecycle explicit.
         super().__init__(nc, reg_max, end2end, ch)
+        self.end2end = end2end
 
         # ── Task-specific heads ──────────────────────────────────────────
-        self._build_segment_head(ch, nm, npr, end2end)
-        self._build_pose_head(ch, kpt_shape, end2end)
-        self._build_classify_head(ch, end2end)
+        self._build_segment_head(ch, nm, npr)
+        self._build_pose_head(ch, kpt_shape)
+        self._build_classify_head(ch)
         self._build_dense_heads(ch, depth_bins, semantic_nc)
-        self._build_obb_head(ch, end2end)
+        self._build_obb_head(ch)
 
         # ── TaskRouter (optional) ────────────────────────────────────────
         if use_task_router:
@@ -111,7 +116,7 @@ class MultiTaskHead(Detect):
         self.task_importance = nn.Parameter(torch.zeros(num_active))
 
     # ── Task builders ────────────────────────────────────────────────────
-    def _build_segment_head(self, ch, nm, npr, end2end):
+    def _build_segment_head(self, ch, nm, npr):
         if "segment" not in self._active_tasks:
             self.nm = 0
             self.proto = None
@@ -122,10 +127,8 @@ class MultiTaskHead(Detect):
         self.proto = Proto26(ch, npr, nm, self.nc)
         c4 = max(ch[0] // 4, nm)
         self.cv4_seg = nn.ModuleList(nn.Sequential(Conv(x, c4, 3), Conv(c4, c4, 3), nn.Conv2d(c4, nm, 1)) for x in ch)
-        if end2end:
-            self.one2one_cv4_seg = copy.deepcopy(self.cv4_seg)
 
-    def _build_pose_head(self, ch, kpt_shape, end2end):
+    def _build_pose_head(self, ch, kpt_shape):
         if "pose" not in self._active_tasks:
             self.kpt_shape = (0, 0)
             self.nk = 0
@@ -137,10 +140,8 @@ class MultiTaskHead(Detect):
         self.cv4_pose = nn.ModuleList(
             nn.Sequential(Conv(x, c4, 3), Conv(c4, c4, 3), nn.Conv2d(c4, self.nk, 1)) for x in ch
         )
-        if end2end:
-            self.one2one_cv4_pose = copy.deepcopy(self.cv4_pose)
 
-    def _build_classify_head(self, ch, end2end):
+    def _build_classify_head(self, ch):
         if "classify" not in self._active_tasks:
             self.cv4_cls = None
             self.global_pool = None
@@ -184,7 +185,7 @@ class MultiTaskHead(Detect):
             else None
         )
 
-    def _build_obb_head(self, ch, end2end):
+    def _build_obb_head(self, ch):
         if "obb" not in self._active_tasks:
             self.ne = 0
             self.cv4_obb = None
@@ -194,8 +195,6 @@ class MultiTaskHead(Detect):
         self.cv4_obb = nn.ModuleList(
             nn.Sequential(Conv(x, c4, 3), Conv(c4, c4, 3), nn.Conv2d(c4, self.ne, 1)) for x in ch
         )
-        if end2end:
-            self.one2one_cv4_obb = copy.deepcopy(self.cv4_obb)
 
     # ── Property helpers ─────────────────────────────────────────────────
     @property
@@ -288,7 +287,13 @@ class MultiTaskHead(Detect):
         tasks = set(tasks)
         if "detect" not in tasks:
             tasks.add("detect")
-        unknown = tasks.difference({"detect", "segment", "pose", "classify", "depth", "normal", "semantic", "obb"})
+        compatibility_only = tasks.intersection(COMPATIBILITY_ONLY_TASKS)
+        if compatibility_only:
+            raise ValueError(
+                "Multi-task 'obb' is not trainable: use a dedicated OBB model or remove 'obb' from data.tasks. "
+                "The compatibility-only angle head is retained solely for loading legacy checkpoints."
+            )
+        unknown = tasks.difference(DEFAULT_MULTITASK_TASKS)
         if unknown:
             raise ValueError(f"Unsupported multi-task branches: {sorted(unknown)}")
         unavailable = tasks.difference(self._built_tasks)
@@ -319,17 +324,10 @@ class MultiTaskHead(Detect):
 
     @property
     def one2one(self):
-        d = dict()
-        if self.has_task("segment") and hasattr(self, "one2one_cv4_seg"):
-            d["mask_head"] = self.one2one_cv4_seg
-        if self.has_task("pose") and hasattr(self, "one2one_cv4_pose"):
-            d["pose_head"] = self.one2one_cv4_pose
-        if self.has_task("obb") and hasattr(self, "one2one_cv4_obb"):
-            d["obb_head"] = self.one2one_cv4_obb
-        if hasattr(self, "one2one_cv2"):
-            d["box_head"] = self.one2one_cv2
-            d["cls_head"] = self.one2one_cv3
-        return d
+        """Return the independently trained one-to-one detection heads."""
+        if not hasattr(self, "one2one_cv2"):
+            return {}
+        return {"box_head": self.one2one_cv2, "cls_head": self.one2one_cv3}
 
     # ── Core forward ─────────────────────────────────────────────────────
     def forward_head(self, x: list[torch.Tensor], **kwargs) -> dict[str, torch.Tensor]:
@@ -346,6 +344,7 @@ class MultiTaskHead(Detect):
         box_head = kwargs.get("box_head", self.cv2)
         cls_head = kwargs.get("cls_head", self.cv3)
         skip_task_router = bool(kwargs.pop("skip_task_router", False))
+        skip_auxiliary_tasks = bool(kwargs.pop("skip_auxiliary_tasks", False))
 
         routed_features, routing_stats = (
             ({task: x for task in self._active_tasks}, None) if skip_task_router else self._route_task_features(x)
@@ -359,7 +358,7 @@ class MultiTaskHead(Detect):
             preds["routing_stats"] = routing_stats
 
         # ── Segmentation ─────────────────────────────────────────────────
-        if self.has_task("segment"):
+        if self.has_task("segment") and not skip_auxiliary_tasks:
             x_mod = routed_features.get("segment", x)
             mask_head = kwargs.get("mask_head", self.cv4_seg)
             if mask_head is not None:
@@ -369,40 +368,40 @@ class MultiTaskHead(Detect):
                 preds["proto"] = self.proto(x_mod) if self.proto is not None else None
 
         # ── Pose ─────────────────────────────────────────────────────────
-        if self.has_task("pose"):
+        if self.has_task("pose") and not skip_auxiliary_tasks:
             x_mod = routed_features.get("pose", x)
             pose_head = kwargs.get("pose_head", self.cv4_pose)
             if pose_head is not None:
                 preds["kpts"] = torch.cat([pose_head[i](x_mod[i]).view(bs, self.nk, -1) for i in range(self.nl)], 2)
 
         # ── Depth ────────────────────────────────────────────────────────
-        if self.has_task("depth"):
+        if self.has_task("depth") and not skip_auxiliary_tasks:
             x_mod = routed_features.get("depth", x)
             depth_head = kwargs.get("depth_head", self.cv4_depth)
             if depth_head is not None:
                 preds["depth"] = F.softplus(depth_head(x_mod[0]))
 
-        if self.has_task("normal"):
+        if self.has_task("normal") and not skip_auxiliary_tasks:
             x_mod = routed_features.get("normal", x)
             normal_head = kwargs.get("normal_head", self.cv4_normal)
             if normal_head is not None:
                 preds["normal"] = F.normalize(normal_head(x_mod[0]), dim=1, eps=1e-6)
 
-        if self.has_task("semantic"):
+        if self.has_task("semantic") and not skip_auxiliary_tasks:
             x_mod = routed_features.get("semantic", x)
             semantic_head = kwargs.get("semantic_head", self.cv4_semantic)
             if semantic_head is not None:
                 preds["semantic"] = semantic_head(x_mod[0])
 
-        # ── OBB ──────────────────────────────────────────────────────────
-        if self.has_task("obb"):
+        # ── OBB compatibility output ────────────────────────────────────
+        if self.has_task("obb") and not skip_auxiliary_tasks:
             x_mod = routed_features.get("obb", x)
             obb_head = kwargs.get("obb_head", self.cv4_obb)
             if obb_head is not None:
                 preds["angle"] = torch.cat([obb_head[i](x_mod[i]).view(bs, self.ne, -1) for i in range(self.nl)], 2)
 
         # ── Classification ───────────────────────────────────────────────
-        if self.has_task("classify") and self.cv4_cls is not None:
+        if self.has_task("classify") and self.cv4_cls is not None and not skip_auxiliary_tasks:
             x_mod = routed_features.get("classify", x)
             preds["cls_logits"] = self.cv4_cls(x_mod[-1])  # global image-level classification
 
@@ -424,7 +423,13 @@ class MultiTaskHead(Detect):
             # routing it again would nevertheless update TaskRouter weights
             # and replace the primary branch diagnostics.
             one2one_kwargs["skip_task_router"] = True
+            one2one_kwargs["skip_auxiliary_tasks"] = True
             one2one = self.forward_head(x_detach, **one2one_kwargs)
+            # Auxiliary heads are supervised on the routed one-to-many features. Reuse those trained dense predictions
+            # for candidate-aligned validation/export instead of maintaining unsupervised one-to-one copies.
+            for key in ("mask_coefficient", "proto", "kpts", "angle"):
+                if key in preds:
+                    one2one[key] = preds[key]
             preds = {"one2many": preds, "one2one": one2one}
 
         if self.training:
@@ -532,8 +537,5 @@ class MultiTaskHead(Detect):
         # Additional init for task branches can be added here
 
     def fuse(self) -> None:
-        """Fuse detection heads while retaining dense branches required by the export schema."""
+        """Remove one-to-many detection heads while retaining every supervised auxiliary branch."""
         self.cv2 = self.cv3 = None
-        self.cv4_seg = None
-        self.cv4_pose = None
-        self.cv4_obb = None

--- a/ultralytics/nn/modules/multitask/router.py
+++ b/ultralytics/nn/modules/multitask/router.py
@@ -46,7 +46,8 @@ TASK_SEGMENT = 1
 TASK_POSE = 2
 TASK_CLASSIFY = 3
 TASK_DEPTH = 4
-TASK_OBB = 5
+TASK_NORMAL = 5
+TASK_SEMANTIC = 6
 
 TASK_NAMES = {
     TASK_DETECT: "detect",
@@ -54,7 +55,8 @@ TASK_NAMES = {
     TASK_POSE: "pose",
     TASK_CLASSIFY: "classify",
     TASK_DEPTH: "depth",
-    TASK_OBB: "obb",
+    TASK_NORMAL: "normal",
+    TASK_SEMANTIC: "semantic",
 }
 
 
@@ -70,7 +72,7 @@ class TaskRouter(FP32RouterMixin, nn.Module):
 
     Args:
         dim: Input channel dimension.
-        num_tasks: Number of task experts (default 6: det/seg/pose/cls/depth/obb).
+        num_tasks: Number of task slots (default 7: detect/segment/pose/classify/depth/normal/semantic).
         top_k: Active task experts per token (default 2: primary + secondary).
         temperature: Router softmax temperature.
         balance_loss_coeff: Load-balancing loss weight.
@@ -81,7 +83,7 @@ class TaskRouter(FP32RouterMixin, nn.Module):
     def __init__(
         self,
         dim: int,
-        num_tasks: int = 6,
+        num_tasks: int = 7,
         top_k: int = 2,
         temperature: float = 1.0,
         balance_loss_coeff: float = 0.01,
@@ -132,15 +134,14 @@ class TaskRouter(FP32RouterMixin, nn.Module):
         )
 
         self.last_affinity: Optional[torch.Tensor] = None
+        self.last_assignment: Optional[torch.Tensor] = None
         self.last_routing_stats: dict = {}
 
     @property
     def top_k(self) -> int:
         return self._top_k
 
-    def forward(
-        self, x: torch.Tensor
-    ) -> Tuple[torch.Tensor, torch.Tensor, dict]:
+    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, dict]:
         """Route spatial tokens to task experts.
 
         Args:
@@ -155,22 +156,27 @@ class TaskRouter(FP32RouterMixin, nn.Module):
 
         # Stage 1: Compute task affinity (MoT-style token routing)
         affinity_logits = self.affinity_router(x.float())  # [B, T, H, W]
-        affinity = F.softmax(affinity_logits / self.temperature.float(), dim=1)  # [B, T, H, W]
+        router_probs = F.softmax(affinity_logits / self.temperature.float(), dim=1)  # [B, T, H, W]
 
         # Top-K hard selection + soft blending
         if self._top_k < self.num_tasks:
-            topk_vals, topk_idx = affinity.topk(self._top_k, dim=1)
-            topk_weights = topk_vals / (topk_vals.sum(dim=1, keepdim=True) + 1e-8)
-            sparse_affinity = torch.zeros_like(affinity)
+            topk_vals, topk_idx = router_probs.topk(self._top_k, dim=1)
+            topk_weights = topk_vals / topk_vals.sum(dim=1, keepdim=True).clamp_min(1e-8)
+            sparse_affinity = torch.zeros_like(router_probs)
             sparse_affinity.scatter_(1, topk_idx, topk_weights)
+            assignment = torch.zeros_like(router_probs).scatter_(1, topk_idx, 1.0 / self._top_k)
             if self.training:
-                affinity = sparse_affinity * 0.98 + affinity * 0.02  # exploration
+                affinity = sparse_affinity * 0.98 + router_probs * 0.02  # exploration
             else:
                 affinity = sparse_affinity
         else:
             topk_idx = torch.arange(self.num_tasks, device=x.device).view(1, -1, 1, 1).expand(B, -1, H, W)
+            assignment = torch.full_like(router_probs, 1.0 / self.num_tasks)
+            affinity = router_probs
 
-        self.last_affinity = affinity.detach()
+        # Keep soft probabilities graph-connected until the criterion consumes the auxiliary loss.
+        self.last_affinity = router_probs
+        self.last_assignment = assignment.detach()
 
         # Stage 2: Generate task-specific features via weighted fusion
         # Each token is softly routed to its top-K task experts
@@ -180,7 +186,7 @@ class TaskRouter(FP32RouterMixin, nn.Module):
         # Compute task-feature similarity and share complementary information
         shared_features = self.cross_task_proj(x)  # [B, C, H, W]
         if self.shared_channels > 0:
-            shared_features = shared_features[:, :self.shared_channels]  # [B, shared_C, H, W]
+            shared_features = shared_features[:, : self.shared_channels]  # [B, shared_C, H, W]
 
         # Routing diagnostics
         with torch.no_grad():
@@ -195,14 +201,12 @@ class TaskRouter(FP32RouterMixin, nn.Module):
         return task_features, shared_features, self.last_routing_stats
 
     def compute_balance_loss(self) -> torch.Tensor:
-        """Load-balancing loss: encourage uniform task expert usage (GShard style)."""
-        if self.last_affinity is None:
+        """Return the Switch/GShard auxiliary loss for balanced task-slot usage."""
+        if self.last_affinity is None or self.last_assignment is None:
             return torch.zeros((), device=self.temperature.device)
-        probs = self.last_affinity.float()
-        probs = probs.reshape(probs.shape[0], self.num_tasks, -1).mean(-1).mean(0)
-        probs = probs / probs.sum().clamp_min(1e-8)
-        uniform = torch.ones_like(probs) / self.num_tasks
-        return self.num_tasks * (probs * uniform.log() / probs.clamp_min(1e-8)).sum()
+        importance = self.last_affinity.float().mean(dim=(0, 2, 3))
+        usage = self.last_assignment.float().mean(dim=(0, 2, 3))
+        return self.num_tasks * torch.sum(importance * usage)
 
     @staticmethod
     def available_tasks() -> dict[int, str]:

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -1461,17 +1461,23 @@ class MultiTaskLoss(nn.Module):
 
         # Segmentation loss
         self.seg_loss = None
+        self.seg_loss_one2one = None
         if head.has_task("segment"):
             from ultralytics.utils.loss import v8SegmentationLoss
 
             self.seg_loss = v8SegmentationLoss(model)
+            if end2end:
+                self.seg_loss_one2one = v8SegmentationLoss(model, tal_topk=7, tal_topk2=1)
 
         # Pose loss
         self.pose_loss = None
+        self.pose_loss_one2one = None
         if head.has_task("pose"):
             from ultralytics.utils.loss import v8PoseLoss
 
             self.pose_loss = v8PoseLoss(model)
+            if end2end:
+                self.pose_loss_one2one = v8PoseLoss(model, tal_topk=7, tal_topk2=1)
 
         self.cls_loss = nn.BCEWithLogitsLoss(reduction="none") if head.has_task("classify") else None
         self.semantic_loss = (
@@ -1496,6 +1502,22 @@ class MultiTaskLoss(nn.Module):
 
         # MoT auxiliary loss coefficient
         self.moe_loss_coeff = 0.01
+
+    @property
+    def updates(self) -> int:
+        """Expose the end-to-end assignment schedule position for trainer resume."""
+        return int(getattr(self.det_loss, "updates", 0))
+
+    @updates.setter
+    def updates(self, value: int) -> None:
+        if hasattr(self.det_loss, "updates"):
+            self.det_loss.updates = int(value)
+
+    def update(self) -> None:
+        """Advance the end-to-end assignment schedule used by detection and auxiliary tasks."""
+        update = getattr(self.det_loss, "update", None)
+        if callable(update):
+            update()
 
     def forward(self, preds: dict, batch: dict) -> tuple[torch.Tensor, torch.Tensor]:
         """Compute combined multi-task loss.
@@ -1586,19 +1608,23 @@ class MultiTaskLoss(nn.Module):
                 "proto": one2many.get("proto"),
                 "feats": one2many.get("feats", []),
             }
-            if one2one is not None:
-                seg_preds["one2one"] = {
-                    "boxes": one2one.get("boxes"),
-                    "scores": one2one.get("scores"),
-                    "mask_coefficient": one2one.get("mask_coefficient"),
-                    "proto": one2one.get("proto"),
-                }
             seg_loss_val, seg_items = self.seg_loss(seg_preds, batch)
-            w = self.task_weights.get("segment", 0.5)
-            # v8SegmentationLoss includes detection terms for target assignment. Detection is already accounted for
-            # above, so only add the instance-mask and semantic components here to avoid double-counting box/cls/DFL.
-            seg_component = seg_loss_val[1] + (seg_loss_val[4] if len(seg_loss_val) > 4 else 0.0)
-            total_loss = total_loss + w * seg_component
+            # v8SegmentationLoss includes detection terms for target assignment. Detection is already accounted for,
+            # so add only task-specific components and use the E2E assignment schedule for the auxiliary head.
+            seg_one2many = seg_loss_val[1] + (seg_loss_val[4] if len(seg_loss_val) > 4 else 0.0)
+            seg_component = seg_one2many
+            if one2one is not None and self.seg_loss_one2one is not None:
+                seg_one2one_preds = {
+                    "boxes": one2one["boxes"],
+                    "scores": one2one["scores"],
+                    "mask_coefficient": one2many["mask_coefficient"],
+                    "proto": one2many.get("proto"),
+                    "feats": one2one.get("feats", one2many.get("feats", [])),
+                }
+                seg_one2one_loss, _ = self.seg_loss_one2one(seg_one2one_preds, batch)
+                seg_one2one = seg_one2one_loss[1] + (seg_one2one_loss[4] if len(seg_one2one_loss) > 4 else 0.0)
+                seg_component = self.det_loss.o2m * seg_one2many + self.det_loss.o2o * seg_one2one
+            total_loss = total_loss + self.task_weights.get("segment", 0.5) * seg_component
             loss_items["seg_loss"] = seg_component.detach()
 
         # ── Pose loss (flat format) ──────────────────────────────────
@@ -1614,20 +1640,28 @@ class MultiTaskLoss(nn.Module):
                 "kpts": one2many["kpts"],
                 "feats": one2many.get("feats", []),
             }
-            if one2one is not None:
-                pose_preds["one2one"] = {
-                    "boxes": one2one.get("boxes"),
-                    "scores": one2one.get("scores"),
-                    "kpts": one2one.get("kpts"),
-                }
             pose_loss_val, pose_items = self.pose_loss(pose_preds, batch)
-            w = self.task_weights.get("pose", 1.0)
-            # v8PoseLoss returns [box, keypoint, keypoint-objectness, cls, DFL]. The detection terms are already
-            # included in det_loss, therefore the unified criterion adds only the pose-specific terms.
-            pose_component = (
+            # v8PoseLoss returns [box, keypoint, keypoint-objectness, cls, DFL]. Add only pose-specific terms and
+            # supervise the shared keypoint predictions under both E2E assignment policies.
+            pose_one2many = (
                 pose_loss_val[1] + pose_loss_val[2] if len(pose_loss_val) > 2 else torch.zeros((), device=device)
             )
-            total_loss = total_loss + w * pose_component
+            pose_component = pose_one2many
+            if one2one is not None and self.pose_loss_one2one is not None:
+                pose_one2one_preds = {
+                    "boxes": one2one["boxes"],
+                    "scores": one2one["scores"],
+                    "kpts": one2many["kpts"],
+                    "feats": one2one.get("feats", one2many.get("feats", [])),
+                }
+                pose_one2one_loss, _ = self.pose_loss_one2one(pose_one2one_preds, batch)
+                pose_one2one = (
+                    pose_one2one_loss[1] + pose_one2one_loss[2]
+                    if len(pose_one2one_loss) > 2
+                    else torch.zeros((), device=device)
+                )
+                pose_component = self.det_loss.o2m * pose_one2many + self.det_loss.o2o * pose_one2one
+            total_loss = total_loss + self.task_weights.get("pose", 1.0) * pose_component
             loss_items["pose_loss"] = pose_component.detach()
 
         # ── Image multi-label classification loss ─────────────────────────
@@ -1688,8 +1722,10 @@ class MultiTaskLoss(nn.Module):
             semantic_pred = F.interpolate(
                 one2many["semantic"], size=semantic_target.shape[-2:], mode="bilinear", align_corners=False
             )
-            if (semantic_target != 255).any():
-                semantic_loss_val = self.semantic_loss(semantic_pred, semantic_target).mean()
+            semantic_valid = semantic_target != 255
+            if semantic_valid.any():
+                semantic_per_pixel = self.semantic_loss(semantic_pred, semantic_target)
+                semantic_loss_val = semantic_per_pixel[semantic_valid].mean()
                 total_loss = total_loss + self.task_weights.get("semantic", 0.5) * semantic_loss_val
                 loss_items["semantic_loss"] = semantic_loss_val.detach()
 
@@ -1698,7 +1734,7 @@ class MultiTaskLoss(nn.Module):
             task_router = getattr(self.model.model[-1], "task_router", None)
             if task_router is not None:
                 balance_loss = task_router.compute_balance_loss()
-                total_loss = total_loss + 0.01 * balance_loss
+                total_loss = total_loss + task_router.balance_loss_coeff * balance_loss
 
         # Build loss_items tensor for logging compatibility
         items = [

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -601,7 +601,10 @@ def copy_attr(a, b, include=(), exclude=()):
 
 
 def intersect_dicts(da, db, exclude=()):
-    """Return a dictionary of intersecting keys with matching shapes, excluding 'exclude' keys, using da values.
+    """Return intersecting tensor entries with matching shapes, excluding keys containing any excluded string.
+
+    Non-tensor extra state is intentionally skipped because this helper is used for transferable model weights, not
+    strict restoration of module configuration or runtime metadata.
 
     Args:
         da (dict): First dictionary.
@@ -609,9 +612,17 @@ def intersect_dicts(da, db, exclude=()):
         exclude (tuple, optional): Keys to exclude.
 
     Returns:
-        (dict): Dictionary of intersecting keys with matching shapes.
+        (dict): Dictionary of intersecting tensor entries with matching shapes.
     """
-    return {k: v for k, v in da.items() if k in db and all(x not in k for x in exclude) and v.shape == db[k].shape}
+    return {
+        k: v
+        for k, v in da.items()
+        if k in db
+        and all(x not in k for x in exclude)
+        and isinstance(v, torch.Tensor)
+        and isinstance(db[k], torch.Tensor)
+        and v.shape == db[k].shape
+    }
 
 
 def is_parallel(model):


### PR DESCRIPTION
## Summary
- make TaskRouter balance loss graph-connected and use configured weighting
- align MultiTask E2E segment/pose supervision across one-to-many and one-to-one assignments
- preserve auxiliary outputs through fusion/export and resume E2E schedules correctly
- normalize semantic loss over valid pixels only and close unsupported unified OBB training paths
- make transferable checkpoint intersection skip non-tensor extra state

## Validation
- MultiTask + Latent: 111 passed, 1 skipped
- default/model config integrity: 12 passed
- mixture loss composition + P0 system gates: 9 passed
- Ruff check and format passed
- git diff --check passed
- real ONNX round-trip skipped because onnx is not installed in the current environment
