### PR TITLE
fix(molora): merging grouped-conv base layers crashes or composes wrong delta

### DIFF
--- a/tests/test_molora.py
+++ b/tests/test_molora.py
@@ -32,6 +32,7 @@ from ultralytics.nn.peft.molora.utils import (
     _molora_scales,
     init_lora_expert_a,
     init_lora_expert_b,
+    _conv_expert_delta,
 )
 from ultralytics.nn.modules.moe.modules import MOE_LOSS_REGISTRY
 
@@ -312,6 +313,36 @@ class TestMoLoRALayer:
         layer.merge_weights()
         layer.unmerge_weights()
         assert layer.merged is False
+
+    @pytest.mark.parametrize("groups", [1, 2, 4, 8])
+    def test_conv_expert_delta_matches_forward_grouped(self, groups):
+        conv = nn.Conv2d(32, 64, 3, padding=1, groups=groups)
+        exp = MoLoRAExpert(conv, r=8, alpha=16)
+        with torch.no_grad():
+            exp.lora_A.weight.normal_(0, 0.1)
+            exp.lora_B.weight.normal_(0, 0.1)
+        x = torch.randn(2, 32, 8, 8)
+        delta = _conv_expert_delta(exp.lora_A, exp.lora_B, exp.scaling)
+        composed = F.conv2d(x, delta, stride=conv.stride, padding=conv.padding, dilation=conv.dilation)
+        assert torch.allclose(exp(x), composed, atol=1e-5)
+
+    @pytest.mark.parametrize("groups", [2, 4, 8])
+    def test_merge_unmerge_grouped_conv(self, groups):
+        conv = nn.Conv2d(32, 64, 3, padding=1, groups=groups)
+        layer = MoLoRALayer(conv, r=8, alpha=16, num_experts=4, top_k=2)
+        with torch.no_grad():  # default init zeroes lora_B, which would make merge a no-op
+            for exp in layer.experts:
+                exp.lora_A.weight.normal_(0, 0.1)
+                exp.lora_B.weight.normal_(0, 0.1)
+        original = conv.weight.detach().clone()
+        layer.merge_weights()
+        assert layer.merged is True
+        assert not torch.allclose(conv.weight, original)
+        out = layer(torch.randn(2, 32, 8, 8))
+        assert out.shape == (2, 64, 8, 8)
+        layer.unmerge_weights()
+        assert layer.merged is False
+        assert torch.allclose(conv.weight, original, atol=1e-6)
 
     def test_routing_stats(self):
         conv = nn.Conv2d(16, 32, 3, padding=1)

--- a/ultralytics/nn/peft/molora/layer.py
+++ b/ultralytics/nn/peft/molora/layer.py
@@ -822,8 +822,10 @@ class MoLoRALayer(nn.Module):
             weights = torch.full((self.num_experts,), 1.0 / self.num_experts)
         with torch.no_grad():
             if self.experts[0].is_conv:
+                base_groups = getattr(self.base_layer, "groups", 1)
                 for weight, e in zip(weights.tolist(), self.experts):
-                    _merge_conv_delta(self.base_layer.weight, e.lora_A, e.lora_B, e.scaling * weight)
+                    _merge_conv_delta(self.base_layer.weight, e.lora_A, e.lora_B, e.scaling * weight,
+                                      groups=base_groups)
             else:
                 for weight, e in zip(weights.tolist(), self.experts):
                     _merge_linear_delta(self.base_layer.weight, e.lora_A, e.lora_B, e.scaling * weight)
@@ -847,8 +849,10 @@ class MoLoRALayer(nn.Module):
         with torch.no_grad():
             weights = self._merge_metadata.get("expert_weights") or [1.0 / self.num_experts] * self.num_experts
             if self.experts[0].is_conv:
+                base_groups = getattr(self.base_layer, "groups", 1)
                 for weight, e in zip(weights, self.experts):
-                    _unmerge_conv_delta(self.base_layer.weight, e.lora_A, e.lora_B, e.scaling * weight)
+                    _unmerge_conv_delta(self.base_layer.weight, e.lora_A, e.lora_B, e.scaling * weight,
+                                        groups=base_groups)
             else:
                 for weight, e in zip(weights, self.experts):
                     _unmerge_linear_delta(self.base_layer.weight, e.lora_A, e.lora_B, e.scaling * weight)

--- a/ultralytics/nn/peft/molora/utils.py
+++ b/ultralytics/nn/peft/molora/utils.py
@@ -181,6 +181,33 @@ def count_parameters(model: nn.Module) -> Dict[str, int]:
 # Merge / Unmerge helpers
 # ---------------------------------------------------------------------------
 
+def _conv_expert_delta(lora_a: nn.Conv2d, lora_b: nn.Conv2d, scale: float) -> torch.Tensor:
+    """Full-rank delta [out_c, in_c, kH, kW] equivalent to lora_B(lora_A(x)) * scale.
+
+    lora_A is a dense 1x1 conv [r, in_c, 1, 1]. lora_B is a KxK conv that carries the
+    base layer's groups, so its weight is [out_c, r // groups, kH, kW] and each output
+    group composes only with its own slice of the r rank channels.
+    """
+    a = lora_a.weight.squeeze(-1).squeeze(-1)  # [r, in_c]
+    b = lora_b.weight
+    b_groups = getattr(lora_b, "groups", 1)
+    if b_groups == 1:
+        return torch.einsum("orkw,ri->oikw", b, a) * scale  # [out_c, in_c, kH, kW]
+    out_c, r_per_g = b.shape[0], b.shape[1]
+    bg = b.view(b_groups, out_c // b_groups, r_per_g, *b.shape[2:])
+    ag = a.view(b_groups, r_per_g, a.shape[1])
+    delta = torch.einsum("gorkw,gri->goikw", bg, ag)
+    return delta.reshape(out_c, a.shape[1], *b.shape[2:]) * scale
+
+
+def _fold_delta_for_groups(delta: torch.Tensor, groups: int) -> torch.Tensor:
+    """Fold a full [out_c, in_c, kH, kW] delta to the grouped base shape [out_c, in_c//g, kH, kW]."""
+    if groups <= 1:
+        return delta
+    in_c = delta.shape[1]
+    return delta.view(delta.shape[0], groups, in_c // groups, *delta.shape[2:]).sum(dim=1)
+
+
 def _merge_conv_delta(
     base_weight: nn.Parameter,
     lora_a: nn.Conv2d,
@@ -190,23 +217,16 @@ def _merge_conv_delta(
 ) -> None:
     """Merge a single LoRA expert delta into a Conv2d base weight.
 
-    Conv2d weight shape: [out_c, in_c//groups, kH, kW] (grouped)
+    Conv2d base weight shape: [out_c, in_c//groups, kH, kW] (grouped)
     lora_A: [r, in_c, 1, 1]  (1x1 conv, groups=1)
-    lora_B: [out_c, r, kH, kW]  (KxK conv, groups=1)
+    lora_B: [out_c, r//groups, kH, kW]  (KxK conv, groups follows the base layer)
 
-    Equivalent delta = lora_B @ lora_A via matmul + expand.
-    For grouped base conv, fold [out_c, in_c, kH, kW] -> [out_c, in_c//g, kH, kW].
+    The equivalent full delta is composed per group, then folded to the grouped
+    base shape when groups > 1.
     """
     with torch.no_grad():
-        a = lora_a.weight.squeeze(-1).squeeze(-1)  # [r, in_c]
-        b = lora_b.weight  # [out_c, r, kH, kW]
-        delta = torch.einsum("orkw,ri->oikw", b, a) * scale  # [out_c, in_c, kH, kW]
-        if groups > 1:
-            in_c = delta.shape[1]
-            delta = delta.view(
-                delta.shape[0], groups, in_c // groups, *delta.shape[2:]
-            ).sum(dim=1)
-        base_weight.data.add_(delta)
+        delta = _conv_expert_delta(lora_a, lora_b, scale)
+        base_weight.data.add_(_fold_delta_for_groups(delta, groups))
 
 
 def _merge_linear_delta(
@@ -231,15 +251,8 @@ def _unmerge_conv_delta(
 ) -> None:
     """Unmerge a single LoRA expert delta from a Conv2d base weight."""
     with torch.no_grad():
-        a = lora_a.weight.squeeze(-1).squeeze(-1)
-        b = lora_b.weight
-        delta = torch.einsum("orkw,ri->oikw", b, a) * scale
-        if groups > 1:
-            in_c = delta.shape[1]
-            delta = delta.view(
-                delta.shape[0], groups, in_c // groups, *delta.shape[2:]
-            ).sum(dim=1)
-        base_weight.data.sub_(delta)
+        delta = _conv_expert_delta(lora_a, lora_b, scale)
+        base_weight.data.sub_(_fold_delta_for_groups(delta, groups))
 
 
 def _unmerge_linear_delta(


### PR DESCRIPTION
## The issue

**Observed when exporting to ONNX; blocks any MoLoRA merge / unmerge on model containing grouped conv.**

Merging MoLoRA experts into a grouped Conv2d base layer is broken in the two ways:

1. `merge_weights()` / `unmerge_weights()` never forward the base layer's `groups` to `_merge_conv_delta` / `_unmerge_conv_delta`, so the full delta `[out_c, in_c, kH, kW]` is applied to a grouped base weight `[out_c, in_c/groups, kH, kW]` and crashes:

    `RuntimeError: The size of tensor a (4) must match the size of tensor b (32) at non-singleton dimension 1`

2. The delta composition itself assumes a dense `lora_B` `[out_c, r, kH, kW]`, but `MoLoRAExpert` builds `lora_B` with the base layer's `groups`, so its weight is `[out_c, r/groups, kH, kW]`. For `1 < groups < r` the einsum raises a shape error. For `groups == r` the size-1 rank dim silently broadcasts, summing `lora_A` over all ranks instead of pairing each output group with its own rank slice, which is not the function the expert computes.

## Reproduction

```python
from ultralytics import YOLO
from ultralytics.nn.peft.molora import MoLoRAModel, MoLoRAConfig

m = MoLoRAModel(YOLO("yolo-master-moa-n.yaml").model, MoLoRAConfig())
m.merge(mode="uniform")
```

## Fix

Compose the delta per-group in a shared `_conv_expert_delta` helper, fold it to the grouped base shape, and pass `groups` through at both the merge and unmerge. Unmerge subtracts the identical delta, so merge -> unmerge restores the base weights exactly.

Dense bases `groups == 1` take the same einsum as before, so existing behavior is unchanged for the common case.

## ✅ Validation

- New parametrized tests: the composed delta matches the expert's actual forward (`lora_B(lora_A(x)) * scaling`) for groups 1/2/4/8, and merge/unmerge on grouped bases changes then exactly restores the base weights (`tests/test_molora.py`).
- `tests/test_molora.py`: **91 passed**. `tests/test_molora.py` + `tests/test_mixture_export.py`: **101 passed**.
- Reproduction above now merges and runs forward cleanly.
- Merged-model ONNX export re-validated e2e against eager and ORT (raw output diff ~1.8e-4 at FP32).