### PR TITLE
[犀牛鸟-A2]：Fix Windows agent validator UTF-8 decoding

### DIFF
--- a/agent/runtime/cli/validate.py
+++ b/agent/runtime/cli/validate.py
@@ -305,8 +305,11 @@ def run_dispatcher_case(case: dict[str, Any]) -> dict[str, Any]:
     cmd = [sys.executable, str(DISPATCHER), "--json", json.dumps(request, ensure_ascii=False)]
     env = apply_env_overrides(os.environ.copy(), case.get("env"))
     env["YOLO_MASTER_AGENT_RUNTIME_CACHE"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
     start = time.perf_counter()
-    proc = subprocess.run(cmd, capture_output=True, text=True, cwd=REPO_ROOT, env=env)
+    proc = subprocess.run(
+        cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", cwd=REPO_ROOT, env=env, check=False
+    )
     elapsed = time.perf_counter() - start
     stdout = proc.stdout.strip()
     stderr = proc.stderr.strip()

--- a/tests/test_agent_experiment_manifest.py
+++ b/tests/test_agent_experiment_manifest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -15,6 +16,7 @@ from agent.runtime.cli.contract import (
     write_manifest,
 )
 from agent.runtime.cli.normalize import normalize_request
+from agent.runtime.cli.validate import run_dispatcher_case
 from ultralytics.cfg.mixture_catalog import DEFAULT_MIXTURE_MODEL_ROOT
 
 
@@ -144,3 +146,22 @@ def test_manifest_preserves_pipeline_evidence_and_redacts_secrets(tmp_path: Path
 
     manifest["status"] = "failed"
     assert manifest_checksum(manifest) != manifest["manifest_sha256"]
+
+
+def test_agent_validator_decodes_dispatcher_output_as_utf8(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep non-ASCII dispatcher JSON independent of the Windows locale."""
+    payload = {"skill": "yolo.system", "status": "ok", "summary": "检测完成"}
+
+    def fake_run(*_args, **kwargs):
+        assert kwargs["encoding"] == "utf-8"
+        assert kwargs["errors"] == "replace"
+        assert kwargs["env"]["PYTHONIOENCODING"] == "utf-8"
+        return SimpleNamespace(stdout=json.dumps(payload, ensure_ascii=False), stderr="", returncode=0)
+
+    monkeypatch.setattr("agent.runtime.cli.validate.subprocess.run", fake_run)
+    result = run_dispatcher_case(
+        {"name": "utf8-output", "request": {"skill": "yolo.system"}, "expect": {"status": "ok"}}
+    )
+
+    assert result["passed"] is True
+    assert result["payload"]["summary"] == "检测完成"


### PR DESCRIPTION
## Summary

- force the validator's dispatcher subprocess to emit and decode UTF-8 independently of the Windows locale
- keep subprocess failures available to the validator with explicit `check=False`
- add a regression test covering non-ASCII JSON output

## Problem

On Windows systems using a Chinese locale, `subprocess.run(..., text=True)` decodes output with the system code page. The dispatcher emits UTF-8 JSON, so the validator can raise `UnicodeDecodeError` before parsing the payload and then fail while handling the missing output.

## Tests

- `python -m pytest tests/test_agent_experiment_manifest.py -q` (`7 passed`)
- `python agent/runtime/cli/validate.py --suite quick --out F:\yolo-runs\rhino-admission\agent-quick-pr-rebased.json --pretty --summary-only` (`36/36 passed`)
- `python scripts/check_changed_quality.py --base origin/main` reports 9 pre-existing Ruff findings in `agent/runtime/cli/validate.py`; the baseline reports the same findings plus `PLW1510` at the changed `subprocess.run`, which this PR removes. Ruff format and codespell checks pass.