### PR TITLE
fix(moe): treat torch.jit tracing like ONNX export in the Optimized MoE blocks.

### DIFF
--- a/tests/test_moe_tracing_guard.py
+++ b/tests/test_moe_tracing_guard.py
@@ -1,0 +1,32 @@
+# 🐧Please note that this file has been modified by Tencent on 2026/08/30. All Tencent Modifications are Copyright (C) 2026 Tencent.
+"""Tracing must not freeze one batch's routing into the graph."""
+
+import pytest
+import torch
+
+from ultralytics.nn.modules.moe.modules import OptimizedMOE, OptimizedMOEImproved
+
+
+def _distinguishable(block):
+    """Give every expert a different constant so a wrong route shows up in the output."""
+    with torch.no_grad():
+        for index, expert in enumerate(block.experts):
+            for parameter in expert.parameters():
+                parameter.mul_(0).add_((index + 1) * 0.05)
+    return block.eval()
+
+
+@pytest.mark.parametrize("cls", [OptimizedMOE, OptimizedMOEImproved])
+def test_torchscript_trace_matches_eager_for_other_routes(cls):
+    """torch.jit.trace records one batch's Top-K decision; the dense path keeps it faithful."""
+    torch.manual_seed(0)
+    block = _distinguishable(cls(in_channels=16, out_channels=16, num_experts=4, top_k=1))
+    samples = [torch.randn(1, 16, 8, 8) * (1 + 3 * scale) for scale in range(6)]
+
+    traced = torch.jit.trace(block, samples[0], check_trace=False)
+    for sample in samples:
+        with torch.no_grad():
+            eager, scripted = block(sample), traced(sample)
+        if isinstance(eager, tuple):
+            eager, scripted = eager[0], scripted[0]
+        assert torch.allclose(eager, scripted, atol=1e-4), "traced graph routes differently from eager"

--- a/ultralytics/nn/modules/moe/modules.py
+++ b/ultralytics/nn/modules/moe/modules.py
@@ -856,9 +856,10 @@ class OptimizedMOE(nn.Module):
         flat_indices = routing_indices.view(B, self.top_k)  # [B, k]
         flat_weights = routing_weights.view(B, self.top_k)  # [B, k]
 
-        if torch.onnx.is_in_onnx_export():
-            # ONNX tracing cannot capture data-dependent ``if mask.any()``
-            # skips. Use a dense path: compute all experts, gather Top-K, sum.
+        if torch.onnx.is_in_onnx_export() or torch.jit.is_tracing():
+            # Neither ONNX export nor ``torch.jit.trace`` can capture data-dependent
+            # ``if mask.any()`` skips; both record this batch's routing as the graph.
+            # Use a dense path: compute all experts, gather Top-K, sum.
             all_outs = torch.stack([self.experts[i](x) for i in range(self.num_experts)], dim=1)  # [B, E, out_C, H, W]
             for k in range(self.top_k):
                 idx_k = flat_indices[:, k]  # [B]
@@ -1114,8 +1115,9 @@ class OptimizedMOEImproved(nn.Module):
         if getattr(self, "detach_routing", False):
             weights_flat = weights_flat.detach()
 
-        if torch.onnx.is_in_onnx_export():
-            # ONNX tracing cannot capture ``if mask.any()`` skips.
+        if torch.onnx.is_in_onnx_export() or torch.jit.is_tracing():
+            # Neither ONNX export nor ``torch.jit.trace`` can capture ``if mask.any()``
+            # skips; both freeze this batch's routing into the graph.
             # Dense path: compute all experts, gather Top-K, weighted-sum.
             all_outs = torch.stack([self.experts[i](x) for i in range(self.num_experts)], dim=1)  # [B, E, out_C, H, W]
             for k in range(adaptive_top_k):


### PR DESCRIPTION
## Problem

`ES_MOE` treats `torch.jit.is_tracing()` like `torch.onnx.is_in_onnx_export()`; `OptimizedMOE` and `OptimizedMOEImproved` check only the ONNX flag. Their sparse path branches on `if mask.any()`, which a tracer cannot capture, so `torch.jit.trace` bakes one batch's Top-K decision into the graph without warning.

Tracing a 4-expert Top-1 block on one sample and then running five other samples through the traced graph: all five come back routed like the first, up to 0.6687 elementwise difference from eager.

## Fix

Both guards become `torch.onnx.is_in_onnx_export() or torch.jit.is_tracing()`. Eager training and inference are unchanged; as with ONNX export, the traced graph evaluates all experts instead of `top_k`.

## Tests

`tests/test_moe_tracing_guard.py` traces each block and compares it against eager on six inputs of increasing scale. Fails on `main`, passes here.

```
PYTHONPATH=. python -m pytest tests/test_moe_tracing_guard.py -q
```
