### PR TITLE
fix(moe): fill legacy-checkpoint attributes so released v0.1 weights load properly

### DIFF
--- a/ultralytics/nn/modules/moe/modules.py
+++ b/ultralytics/nn/modules/moe/modules.py
@@ -1066,7 +1066,32 @@ class OptimizedMOEImproved(nn.Module):
         else:
             self._current_top_k = self.top_k
 
+    def _ensure_compat_attrs(self):
+        """Fill attributes added after some checkpoints were saved.
+
+        A module restored from an older checkpoint keeps only the attributes that
+        were pickled, so ``forward`` would raise ``AttributeError`` on anything
+        introduced later. Filling the defaults here (once, lazily) lets legacy
+        weights run without a crash.
+        """
+        if not hasattr(self, "add_residual"):
+            # A checkpoint that predates this attribute was trained without the
+            # residual; the __init__ default of True would add a tensor the block
+            # never saw and collapse classification confidence.
+            self.add_residual = False
+        for name, default in (
+            ("progressive_sparsity", False),
+            ("detach_routing", False),
+            ("_training_step", 0),
+            ("warmup_steps", 5000),
+        ):
+            if not hasattr(self, name):
+                setattr(self, name, default)
+        if not hasattr(self, "_current_top_k"):
+            self._current_top_k = getattr(self, "num_experts", getattr(self, "top_k", 1))
+
     def forward(self, x):
+        self._ensure_compat_attrs()
         B, C, H, W = x.shape
 
         if self.training and self.progressive_sparsity:

--- a/ultralytics/nn/modules/moe/routers.py
+++ b/ultralytics/nn/modules/moe/routers.py
@@ -214,7 +214,7 @@ class BaseRouter(nn.Module):
         assignment_overflow_mask = None
         fallback_surrogate = None
         capacity = None
-        if self.capacity_factor is not None and training:
+        if training and getattr(self, "capacity_factor", None) is not None:
             if not math.isfinite(float(self.capacity_factor)) or self.capacity_factor <= 0:
                 raise MoERouterError("capacity_factor must be finite and > 0")
             capacity = max(1, math.ceil(self.capacity_factor * B * effective_top_k / self.num_experts))


### PR DESCRIPTION
## The Issue

A module restored from a checkpoint saved before a given attribute was introduced keeps only the pickled attributes, so `forward` raise `AttributeError` on anything added later. On the released YOLO-Master-v0.1 checkpoints this makes the model fail to load on current main.

```bash
AttributeError: 'EfficientSpatialRouter' object has no attribute 'capacity_factor'
```

and once the router is handled, the next failure is `OptimizedMOEImproved` missing `_training_step` and `add_residual`.

## Repro
```python
# On current main, with any released v0.1 checkpoint (e.g. YOLO-Master-v0.1-N.pt):

import torch
from ultralytics import YOLO

m = YOLO('YOLO-Master-v0.1-N.pt')
m.model.eval()
m.model(torch.randn(1, 3, 640, 640))
```
## Fix

- `OptimizedMOEImproved`: add a lazy `_ensure_compat_attrs` called once at the top of `forward`. It fills `add_residual` to `False` when absent, since a checkpoint that predates the attribute was trained without the residual and the `__init__` default of `True` would add a tensor the block never saw and collapse classification confidence; it also fills `progressive_sparsity`, `detach_routing`, `_training_step`, `warmup_steps`, `_current_top_k`.
- `BaseRouter`: evaluate `training` before `capacity_factor` in the capacity guard, and read the attribute with `getattr(..., None)`, so a checkpoint that predates `capacity_factor` does not raise during eval.

## ✅ Validation

- Before: loading and running `YOLO-Master-v0.1-N.pt` raises the `capacity_factor` AttributeError above. 
- After: the model loads and runs a forward pass. Verified on v0.1-N. There is no behavior change for freshly constructed models: the compat fills trigger only when an attribute is absent from an old pickle.

## 📁 Files Changed
`ultralytics/nn/modules/moe/modules.py` 
`ultralytics/nn/modules/moe/routers.py` 
