### PR TITLE
[犀牛鸟-A2]：Fix TAL conflict resolution for zero-IoU candidate ties

### DIFF
--- a/tests/test_tal_conflict_resolution.py
+++ b/tests/test_tal_conflict_resolution.py
@@ -1,0 +1,24 @@
+"""Regression tests for task-aligned assignment conflict resolution."""
+
+import torch
+
+from ultralytics.utils.tal import TaskAlignedAssigner
+
+
+def test_conflict_resolution_cannot_assign_anchor_to_non_candidate_gt():
+    """Zero-overlap ties must stay within the GTs that proposed the contested anchor."""
+    assigner = TaskAlignedAssigner(num_classes=3)
+    mask_pos = torch.tensor(
+        [[[1.0, 0.0, 0.0], [0.0, 1.0, 1.0], [0.0, 0.0, 1.0]]]
+    )
+    overlaps = torch.zeros_like(mask_pos)
+    align_metric = torch.zeros_like(mask_pos)
+    original_counts = mask_pos.sum(-1)
+
+    _, fg_mask, resolved = assigner.select_highest_overlaps(
+        mask_pos, overlaps, n_max_boxes=3, align_metric=align_metric
+    )
+
+    assert resolved[0, 0, 2] == 0
+    assert (resolved.sum(-1) <= original_counts).all()
+    assert (fg_mask <= 1).all()

--- a/ultralytics/utils/tal.py
+++ b/ultralytics/utils/tal.py
@@ -333,7 +333,8 @@ class TaskAlignedAssigner(nn.Module):
         if fg_mask.max() > 1:  # one anchor is assigned to multiple gt_bboxes
             mask_multi_gts = (fg_mask.unsqueeze(1) > 1).expand(-1, n_max_boxes, -1)  # (b, n_max_boxes, h*w)
 
-            max_overlaps_idx = overlaps.argmax(1)  # (b, h*w)
+            candidate_overlaps = overlaps.masked_fill(~mask_pos.bool(), -torch.inf)
+            max_overlaps_idx = candidate_overlaps.argmax(1)  # (b, h*w)
             is_max_overlaps = torch.zeros(mask_pos.shape, dtype=mask_pos.dtype, device=mask_pos.device)
             is_max_overlaps.scatter_(1, max_overlaps_idx.unsqueeze(1), 1)
             mask_pos = torch.where(mask_multi_gts, is_max_overlaps, mask_pos).float()  # (b, n_max_boxes, h*w)


### PR DESCRIPTION
## Summary

- restrict TAL conflict resolution to GTs that actually proposed the contested anchor
- prevent all-zero-IoU ties from assigning an anchor to a non-candidate GT
- add a focused regression test that verifies conflict resolution cannot increase any GT's candidate count

## Problem

`select_highest_overlaps()` currently calls `overlaps.argmax(1)` across every GT when an anchor is proposed by multiple GTs. Overlaps for non-candidate GT-anchor pairs are zero. If all candidate overlaps are also zero, `argmax` can select an unrelated lower-index GT that never proposed the anchor.

This was observed during the A2 VisDrone assignment smoke: one GT received more final positives than its pre-conflict top-k. The invalid exploratory run was excluded from the reported result.

The fix masks non-candidate overlap entries to `-inf` before `argmax`, so the selected GT is always one of the current candidates.

## Tests

```
python -m pytest tests/test_tal_conflict_resolution.py tests/test_tal_mps_regression.py -q
2 passed, 1 skipped
```

Related progress report: #246