### PR TITLE
fix(trainer): log the recorded non-finite diagnostic when NaN recovery recurrently replays an epoch

### DIFF
--- a/ultralytics/engine/extensions/recovery.py
+++ b/ultralytics/engine/extensions/recovery.py
@@ -483,6 +483,26 @@ class TrainingRecoveryController:
         trainer.nan_recovery_attempts += 1
         if trainer.nan_recovery_attempts > 3:
             raise RuntimeError(f"Training failed: NaN persisted for {trainer.nan_recovery_attempts} epochs")
+        # Surface the rollback before the recorded diagnostic is cleared below. Without this line a NaN
+        # recovery silently replays the whole epoch and the only visible signal is the eventual abort.
+        # The diagnostic is rank-local, so also log from any rank that holds one, not just rank 0.
+        diagnostic = getattr(trainer, "_nonfinite_diagnostic", None)
+        if rank in {-1, 0} or diagnostic is not None:
+            detail = ""
+            if isinstance(diagnostic, dict):
+                detail = (
+                    f"; first non-finite event: {diagnostic.get('component')} at epoch "
+                    f"{diagnostic.get('epoch')} step {diagnostic.get('step')}"
+                )
+                if diagnostic.get("parameter"):
+                    detail += f", parameter {diagnostic['parameter']}"
+                if diagnostic.get("loss_items"):
+                    detail += f", loss_items {diagnostic['loss_items']}"
+            prefix = f"[rank {rank}] " if rank != -1 else ""
+            LOGGER.warning(
+                f"{prefix}Non-finite training state ({reason}) at epoch {epoch + 1}: restoring the healthy "
+                f"checkpoint and replaying the epoch (NaN recovery attempt {trainer.nan_recovery_attempts}/3){detail}."
+            )
         checkpoint = torch_load(io.BytesIO(payload), map_location="cpu", weights_only=False)
         snapshot = checkpoint.get("model")
         if snapshot is None:


### PR DESCRIPTION
## Overview

Observed and diagnosed when approaching the following task:

A3 Priority-2 MoT pretraining: v0.1-MoT, COCO, 8x A100-SXM4-80GB, Python 3.14 / torch 2.11 / NCCL 2.28.9, repo @ acce839; the same code path still exists on `main` @ 0996b7d.

`RecoveryController.recover()` is designed to restore `last_healthy.pt` and the epoch loop replays the same epoch whenever a non-finite loss/gradient/EMA is detected, but it does so **silently**. It builds a `reason` string and the script has already recorded a `_nonfinite_diagnostic` yet neither is ever logged: the diagnostic is cleared at the end of `recover()` without being surfaced. Each NaN rollback therefore costs a full epoch with **zero console output**, and the only visible signal is the eventual `RuntimeError: NaN persisted` after 3+ attempts.

This PR emits one warning on every rollback with the global reason, the epoch being replayed, the attempt count, and
the recorded first non-finite event (which layer/step). The diagnostic is rank-local so it logs from rank 0 and from any
rank that holds one.

## The issue

Training a from-scratch attention-heavy config (v0.1 backbone + C2fMoT neck config) under AMP on 8x A100 DDP:
- The progress bar showed `1/700` complete all iterations and validate, then **`Epoch 1/700` started again**, with
  `box_loss` jumping back up (3.405 at the end of the epoch -> 3.672 on the replay).
- `results.csv` stayed empty and `weights/` contained only `last_healthy.pt`.
- **Nothing printed.** Because the replay is silent it was first mistaken for a NCCL deadlock, then a memory issue; only reading `recover()` revealed it was a non-finite-gradient rollback (`trainer._gradient_nonfinite`, set right after `scaler.unscale_`). Root cause on our side was fp16 overflow in the attention blocks (fixed with `amp=False`), but the trainer gave no indication of that for several replayed epochs.

## 📍Repro

Force one non-finite gradient event and watch the epoch replay with no output on `main`:
```python
from ultralytics import YOLO
m = YOLO("ultralytics/cfg/models/master/v0_1/det/yolo-master-n.yaml")

def repro(trainer):   # mark the graph non-finite once, on the first epoch
    if trainer.epoch == 0 and not getattr(trainer, "_poisoned", False):
        trainer._gradient_nonfinite = True
        trainer._record_nonfinite_diagnostic("gradient", epoch=0, step=1, parameter="model.0.conv.weight")
        trainer._poisoned = True

m.add_callback("on_train_batch_end", repro)
m.train(data="coco8.yaml", epochs=2, imgsz=64, batch=4, device=0, workers=0, plots=False)
```
- **Before:** epoch 1 replays (`1/2` twice) with no explanation.
- **After:** a warning precedes the replay:

```
WARNING Non-finite training state (Gradient NaN/Inf) at epoch 1: restoring the healthy checkpoint and replaying the epoch (NaN recovery attempt 1/3); first non-finite event: gradient at epoch 0 step 1, parameter model.0.conv.weight.
```
(Under DDP the line is prefixed `[rank N]`.)

## Fix

In `recover()`, after `nan_recovery_attempts` is incremented and the `> 3` abort check, and **before** the diagnostic is
cleared, log the rollback. No behaviour change to the recovery itself.

## ✅ Validation

- `ruff check --select E,F` and `ruff format --check` on the changed file: clean.
- `py_compile` + import of `ultralytics.engine.extensions.recovery`: OK.
- The message-building logic exercised with a sample diagnostic renders the line shown above.
- It is purely additive. 

## 📁 File changed
`ultralytics/engine/extensions/recovery.py`