### PR TITLE
fix(train): reset accumulation after epoch recovery

### DIFF
--- a/tests/test_ddp_lifecycle_ema_nan.py
+++ b/tests/test_ddp_lifecycle_ema_nan.py
@@ -7,7 +7,11 @@ from torch import nn
 
 from ultralytics.engine.extensions import AdapterRuntimeController
 from ultralytics.engine.extensions.recovery import TrainingRecoveryController
-from ultralytics.engine.trainer import BaseTrainer, validate_adapter_configuration
+from ultralytics.engine.trainer import (
+    BaseTrainer,
+    _reset_optimizer_accumulation_after_recovery,
+    validate_adapter_configuration,
+)
 from ultralytics.nn.peft.molora import MoLoRAConfig, MoLoRALayer, get_peft_molora_model
 from ultralytics.utils.errors import MoERouterError
 from ultralytics.utils.patches import torch_load
@@ -346,6 +350,18 @@ def test_nonfinite_amp_recovery_switches_to_fp32(tmp_path):
     assert t._handle_nan_recovery(0) is True
     assert t.amp is False
     assert t.scaler.is_enabled() is False
+
+
+def test_epoch_recovery_restarts_optimizer_accumulation_cursor():
+    """An epoch replay must not inherit the completed pass's last optimizer-step index."""
+    model = nn.Linear(1, 1)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+    model(torch.ones(1, 1)).sum().backward()
+
+    last_opt_step = _reset_optimizer_accumulation_after_recovery(optimizer)
+
+    assert last_opt_step == -1
+    assert all(parameter.grad is None for parameter in model.parameters())
 
 
 def test_nonfinite_gradient_skips_optimizer_on_all_ranks():

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -26,6 +26,7 @@ from torch import distributed as dist
 from torch import nn, optim
 
 from ultralytics.cfg import _YOLO_CLI_COMMAND, get_cfg, get_save_dir
+from ultralytics.data.utils import check_cls_dataset, check_det_dataset, convert_ndjson_to_yolo_if_needed
 from ultralytics.engine.extensions import (
     AdapterRuntimeController,
     MixtureRuntimeController,
@@ -34,7 +35,6 @@ from ultralytics.engine.extensions import (
     validate_adapter_configuration,
 )
 from ultralytics.engine.telemetry import TrainingTelemetry
-from ultralytics.data.utils import check_cls_dataset, check_det_dataset, convert_ndjson_to_yolo_if_needed
 from ultralytics.nn.distill_model import DistillationModel
 from ultralytics.nn.foundation_distill_model import (
     FoundationDistillationModel,
@@ -103,6 +103,12 @@ def _distributed_env() -> tuple[int, int, int] | None:
             f"Invalid distributed environment: RANK={rank}, LOCAL_RANK={local_rank}, WORLD_SIZE={world_size}."
         )
     return rank, local_rank, world_size
+
+
+def _reset_optimizer_accumulation_after_recovery(optimizer: optim.Optimizer) -> int:
+    """Clear restored gradients and restart the optimizer accumulation cursor for an epoch replay."""
+    optimizer.zero_grad()
+    return -1
 
 
 def _validate_cuda_ddp_device(device: torch.device, env: tuple[int, int, int] | None) -> None:
@@ -822,6 +828,9 @@ class BaseTrainer:
 
             # NaN recovery
             if self._handle_nan_recovery(epoch):
+                # The same epoch is replayed from a restored optimizer state. Keeping the previous pass's
+                # accumulation cursor suppresses optimizer steps until the replay catches up with that index.
+                last_opt_step = _reset_optimizer_accumulation_after_recovery(self.optimizer)
                 self._finalize_moe_map_saturation_epoch(recovered=True, validated=validated)
                 continue
             self._finalize_moe_map_saturation_epoch(recovered=False, validated=validated)


### PR DESCRIPTION
## Summary

- reset the optimizer accumulation cursor when an epoch is replayed after non-finite-state recovery
- clear restored gradients before replaying the epoch
- add a regression test for the reset contract

## Problem

When `_handle_nan_recovery(epoch)` succeeds, the training loop restores a healthy checkpoint and replays the same epoch. However, the local `last_opt_step` value still points into the failed pass. Because replayed batch indices start from the beginning of that same epoch, the stale cursor suppresses optimizer steps until the replay catches up, potentially leaving only the final batch to update the model.

This change resets the cursor to `-1` and clears gradients before continuing with the replay. It fixes recovery correctness; it does not claim to eliminate the original AMP overflow that may trigger recovery.

## Validation

- `pytest tests/test_ddp_lifecycle_ema_nan.py -q`: 49 passed, 1 skipped
- `python agent/scripts/validate_yolo_master_skill.py --suite quick --pretty --summary-only`: 36/36 passed
- Ruff check and format checks pass for the changed files