### PR TITLE
fix(mixture): count routed auxiliary loss once for vector task losses

### DIFF
--- a/tests/test_mixture_loss_composition.py
+++ b/tests/test_mixture_loss_composition.py
@@ -1,12 +1,13 @@
 """Tests for composing native task criteria with routed auxiliary losses."""
 
+import pytest
 import torch
-import torch.nn as nn
+from torch import nn
 
-from ultralytics.nn.mixture_loss import CompositeCriterion, build_composite_criterion
+from ultralytics.nn.mixture_loss import CompositeCriterion, build_composite_criterion, compose_native_result
+from ultralytics.nn.modules.latent_mixture import LatentMixture
 from ultralytics.nn.modules.moa import C2fMoA
 from ultralytics.nn.modules.routing_protocol import clear_aux_records
-from ultralytics.nn.modules.latent_mixture import LatentMixture
 
 
 class NativeCriterion:
@@ -20,6 +21,40 @@ class NativeCriterion:
 
     def update(self):
         self.updates += 1
+
+
+@pytest.mark.parametrize("entrypoint", ["wrapper", "direct"])
+@pytest.mark.parametrize("shape", [(), (1,), (3,), (5,)])
+def test_vector_native_loss_counts_aux_once_with_correct_gradients(monkeypatch, entrypoint, shape):
+    """Trainer reduction must not multiply auxiliary regularization by the task's loss-item count."""
+    model = nn.Sequential(C2fMoA(16, 16, n=1, num_heads=3)).train()
+    native_loss = torch.ones(shape, requires_grad=True)
+    native_items = native_loss.detach().reshape(-1).clone()
+    aux = torch.tensor(2.0, requires_grad=True)
+    monkeypatch.setattr("ultralytics.nn.mixture_loss._collect_mixture_aux_loss", lambda *args, **kwargs: aux)
+
+    if entrypoint == "wrapper":
+        loss, items = CompositeCriterion(model, lambda *args: (native_loss, native_items))(None, {})
+    else:
+        loss, items = compose_native_result(model, native_loss, native_items)
+
+    torch.testing.assert_close(loss.sum(), native_loss.sum() + aux)
+    loss.sum().backward()
+    torch.testing.assert_close(native_loss.grad, torch.ones_like(native_loss))
+    torch.testing.assert_close(aux.grad, torch.ones_like(aux))
+    torch.testing.assert_close(items[:-1], native_items)
+    torch.testing.assert_close(items[-1], aux.detach())
+    assert not items.requires_grad
+
+
+def test_dense_direct_composition_preserves_native_vector():
+    """Dense models keep the native loss shape, tensors, and gradient path unchanged."""
+    model = nn.Linear(2, 2)
+    native_loss = torch.ones(3, requires_grad=True)
+    native_items = native_loss.detach()
+    loss, items = compose_native_result(model, native_loss, native_items)
+    assert loss is native_loss
+    assert items is native_items
 
 
 def test_dense_model_keeps_exact_native_criterion():

--- a/ultralytics/nn/mixture_loss.py
+++ b/ultralytics/nn/mixture_loss.py
@@ -413,7 +413,7 @@ class CompositeCriterion:
             aux_budget=_model_arg(self.model, "mixture_aux_budget", 3.0),
         )
         self.model._last_mixture_aux_loss = aux.detach()
-        total = native_loss + aux
+        total = native_loss.sum() + aux
         if isinstance(native_items, torch.Tensor):
             items = torch.cat((native_items.reshape(-1), aux.detach().reshape(1)))
         elif isinstance(native_items, (list, tuple)):
@@ -448,7 +448,7 @@ def compose_native_result(model: nn.Module, native_loss: torch.Tensor, native_it
         aux_budget=_model_arg(model, "mixture_aux_budget", 3.0),
     )
     model._last_mixture_aux_loss = aux.detach()
-    return native_loss + aux, torch.cat((native_items.reshape(-1), aux.detach().reshape(1)))
+    return native_loss.sum() + aux, torch.cat((native_items.reshape(-1), aux.detach().reshape(1)))
 
 
 __all__ = [


### PR DESCRIPTION
Detection and segmentation criteria return a vector of native loss components. Adding a scalar routed auxiliary loss to that vector broadcasts it into every component, and the trainer's subsequent sum counts it repeatedly. For example, native losses [1, 2, 3] with aux=2 produce 12 instead of 8.

Reduce the native loss before adding the auxiliary term in both CompositeCriterion and compose_native_result. Native loss gradients and logged task components are preserved; dense models keep their existing return tensors. This intentionally corrects the effective regularization of routed vector-loss tasks.

Validation:
- Added scalar, one-component, three-component and five-component cases for both entry points, checking totals, native/auxiliary gradients and logging; also checked dense vector identity. Four regression cases fail before the fix.
- Composition, model configuration, default configuration, MultiTask and foundation-mixture tests: 122 passed, 1 skipped.
- Real v0.1-N CPU forward/backward: native total 0.3153165 plus aux 3 gives total 3.3153164, with finite gradients.
- Changed-test Ruff lint, critical-error lint on mixture_loss.py, formatting of both files and git diff --check pass.

Broader-check limitations: the additional mixture_aux_loss suite has one existing parameter-free EMA device assertion failure on this CUDA-capable Windows host (both baseline and fixed code choose cuda:0 while the test expects CPU). Repository-wide lint/format also report existing findings, and codespell is unavailable. No full GPU training or distributed run is claimed.