### PR TITLE
fix(data): restore GC state and preserve archive inputs

### DIFF
--- a/tests/test_io_review_regressions.py
+++ b/tests/test_io_review_regressions.py
@@ -1,0 +1,57 @@
+"""Exercise cache failure cleanup and non-destructive dataset archives."""
+
+import gc
+import pickle
+from zipfile import ZipFile
+
+import numpy as np
+import pytest
+
+from ultralytics.data.utils import load_dataset_cache_file
+from ultralytics.utils.downloads import delete_dsstore, zip_directory
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+@pytest.mark.parametrize("kind", ["valid", "missing", "invalid"])
+def test_cache_restores_gc_state(tmp_path, enabled, kind):
+    """Restore the caller's GC state on successful, missing and corrupt cache loads."""
+    original = gc.isenabled()
+    path = tmp_path / "labels.cache"
+    if kind == "valid":
+        with path.open("wb") as handle:
+            np.save(handle, {"version": "test"})
+    elif kind == "invalid":
+        path.write_bytes(b"corrupt")
+    try:
+        (gc.enable if enabled else gc.disable)()
+        if kind == "valid":
+            assert load_dataset_cache_file(path) == {"version": "test"}
+        else:
+            with pytest.raises((FileNotFoundError, ValueError, pickle.UnpicklingError)):
+                load_dataset_cache_file(path)
+        assert gc.isenabled() == enabled
+    finally:
+        (gc.enable if original else gc.disable)()
+
+
+def test_zip_excludes_metadata_without_deleting_source(tmp_path):
+    """Exclude complete metadata directories while leaving input files unchanged."""
+    root = tmp_path / "images"
+    (root / "nested" / "__MACOSX").mkdir(parents=True)
+    for name in ["image.jpg", ".DS_Store", "nested/__MACOSX/resource", "nested/keep.jpg"]:
+        (root / name).write_bytes(b"fixture")
+    before = {str(p.relative_to(root)): p.read_bytes() for p in root.rglob("*") if p.is_file()}
+    archive = zip_directory(root, progress=False)
+    with ZipFile(archive) as handle:
+        assert set(handle.namelist()) == {"image.jpg", "nested/keep.jpg"}
+    assert before == {str(p.relative_to(root)): p.read_bytes() for p in root.rglob("*") if p.is_file()}
+
+
+def test_explicit_metadata_cleanup_handles_directories(tmp_path):
+    """The standalone cleanup API must handle real directories as well as files."""
+    (tmp_path / "__MACOSX").mkdir()
+    (tmp_path / "__MACOSX" / "resource").touch()
+    (tmp_path / ".DS_Store").touch()
+    (tmp_path / "keep.jpg").touch()
+    delete_dsstore(tmp_path)
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["keep.jpg"]

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -877,10 +877,14 @@ def load_dataset_cache_file(path: Path) -> dict:
     """Load an Ultralytics *.cache dictionary from path."""
     import gc
 
-    gc.disable()  # reduce pickle load time https://github.com/ultralytics/ultralytics/pull/1585
-    cache = np.load(str(path), allow_pickle=True).item()  # load dict
-    gc.enable()
-    return cache
+    was_enabled = gc.isenabled()
+    try:
+        gc.disable()  # reduce pickle load time
+        return np.load(str(path), allow_pickle=True).item()
+    finally:
+        if was_enabled:
+            gc.enable()
+
 
 
 def save_dataset_cache_file(prefix: str, path: Path, x: dict, version: str):

--- a/ultralytics/utils/downloads.py
+++ b/ultralytics/utils/downloads.py
@@ -91,8 +91,11 @@ def delete_dsstore(path: str | Path, files_to_delete: tuple[str, ...] = (".DS_St
     for file in files_to_delete:
         matches = list(Path(path).rglob(file))
         LOGGER.info(f"Deleting {file} files: {matches}")
-        for f in matches:
-            f.unlink()
+        for f in sorted(matches, key=lambda entry: len(entry.parts), reverse=True):
+            if f.is_dir() and not f.is_symlink():
+                shutil.rmtree(f)
+            else:
+                f.unlink()
 
 
 def zip_directory(
@@ -120,13 +123,12 @@ def zip_directory(
     """
     from zipfile import ZIP_DEFLATED, ZIP_STORED, ZipFile
 
-    delete_dsstore(directory)
     directory = Path(directory)
     if not directory.is_dir():
         raise FileNotFoundError(f"Directory '{directory}' does not exist.")
 
     # Zip with progress bar
-    files = [f for f in directory.rglob("*") if f.is_file() and all(x not in f.name for x in exclude)]  # files to zip
+    files = [f for f in directory.rglob("*") if f.is_file() and not any(part in exclude for part in f.relative_to(directory).parts)]  # files to zip
     zip_file = directory.with_suffix(".zip")
     compression = ZIP_DEFLATED if compress else ZIP_STORED
     with ZipFile(zip_file, "w", compression) as f:


### PR DESCRIPTION
Loading a missing or corrupt dataset cache leaves cyclic garbage collection disabled. Archiving a dataset containing a __MACOSX directory also fails because cleanup calls unlink on a directory.

Restore the caller's original GC state in a finally block. Archive creation now excludes metadata by relative path components without deleting source files. The explicit delete_dsstore utility handles real directories separately from files/symlinks and processes nested entries first.

Validation: 8 regression cases passed on this independent branch, covering valid/missing/corrupt caches with GC initially on/off, archive contents and source preservation, and explicit directory cleanup. Test lint/format, critical-error lint for production files, and git diff --check pass. Repository-wide lint/format still contain pre-existing findings; codespell is unavailable. No long training is claimed.

Based directly on main b44ea12; no experiment files included.