### PR TITLE
fix(model-zoo): validate each redirect before following

### DIFF
--- a/tests/test_model_zoo_redirects.py
+++ b/tests/test_model_zoo_redirects.py
@@ -1,0 +1,63 @@
+"""Validate redirect destinations before network access, without contacting remote hosts."""
+
+import hashlib
+import io
+from typing import ClassVar
+from unittest.mock import Mock
+from urllib.request import Request
+
+import pytest
+
+from tools import model_zoo_automation as zoo
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://github.com/a.onnx",
+        "https://127.0.0.1/a.onnx",
+        "https://github.com:8443/a.onnx",
+        "https://user:pass@github.com/a.onnx",
+    ],
+)
+def test_reject_redirect_before_following(url):
+    """No Request for a disallowed Location may be returned to urllib."""
+    with pytest.raises(ValueError):
+        zoo.CheckedRedirectHandler().redirect_request(Request("https://github.com/a.onnx"), None, 302, "Found", {}, url)
+
+
+def test_allowed_redirect_stays_supported():
+    """Release assets on allowed HTTPS hosts must continue working."""
+    redirected = zoo.CheckedRedirectHandler().redirect_request(
+        Request("https://github.com/a.onnx"), None, 302, "Found", {}, "https://objects.githubusercontent.com/a.onnx"
+    )
+    assert redirected.full_url == "https://objects.githubusercontent.com/a.onnx"
+
+
+@pytest.mark.parametrize("bad_digest", [False, True])
+def test_download_uses_checked_opener_and_keeps_integrity_checks(tmp_path, monkeypatch, bad_digest):
+    """Changing redirect handling must not drop length and SHA256 checks."""
+
+    class Response(io.BytesIO):
+        headers: ClassVar[dict] = {"Content-Length": "4"}
+
+        def geturl(self):
+            return "https://github.com/a.onnx"
+
+    opener = Mock()
+    opener.open.return_value = Response(b"test")
+    factory = Mock(return_value=opener)
+    monkeypatch.setattr(zoo.urllib.request, "build_opener", factory)
+    data = {
+        "weights": {
+            "url": "https://github.com/a.onnx",
+            "size_bytes": 4,
+            "sha256": "0" * 64 if bad_digest else hashlib.sha256(b"test").hexdigest(),
+        }
+    }
+    if bad_digest:
+        with pytest.raises(ValueError, match="SHA-256"):
+            zoo.download_weights(data, tmp_path / "model.onnx")
+    else:
+        assert zoo.download_weights(data, tmp_path / "model.onnx").read_bytes() == b"test"
+    assert isinstance(factory.call_args.args[0], zoo.CheckedRedirectHandler)

--- a/tools/model_zoo_automation.py
+++ b/tools/model_zoo_automation.py
@@ -77,7 +77,9 @@ def validate_submission(path: Path, changed_files: list[str] | None = None) -> d
             errors.append(f"benchmark.{key} must be an integer in [{low}, {high}]")
 
     if changed_files is not None:
-        submissions = [p for p in changed_files if p.startswith("model-zoo/submissions/") and p.endswith((".yaml", ".yml"))]
+        submissions = [
+            p for p in changed_files if p.startswith("model-zoo/submissions/") and p.endswith((".yaml", ".yml"))
+        ]
         forbidden = [p for p in changed_files if Path(p).suffix.lower() in {".pt", ".pth", ".ckpt", ".onnx", ".engine"}]
         if len(submissions) != 1:
             errors.append("PR must add or update exactly one model-zoo/submissions YAML file")
@@ -88,15 +90,36 @@ def validate_submission(path: Path, changed_files: list[str] | None = None) -> d
     return data
 
 
+def validate_download_url(url: str) -> None:
+    """Validate every URL before sending requests, including redirects."""
+    parsed = urlparse(url)
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname not in ALLOWED_HOSTS
+        or parsed.port not in (None, 443)
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        raise ValueError("weight download must use HTTPS on an allowlisted host and port without credentials")
+
+
+class CheckedRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Apply the download policy before urllib follows each Location header."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        validate_download_url(newurl)
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
 def download_weights(data: dict, destination: Path) -> Path:
     weights = data["weights"]
+    validate_download_url(weights["url"])
+    opener = urllib.request.build_opener(CheckedRedirectHandler())
     request = urllib.request.Request(weights["url"], headers={"User-Agent": "YOLO-Master-model-zoo/1"})
     hasher, total = hashlib.sha256(), 0
     destination.parent.mkdir(parents=True, exist_ok=True)
-    with urllib.request.urlopen(request, timeout=60) as response, destination.open("wb") as output:
-        final_host = urlparse(response.geturl()).hostname
-        if final_host not in ALLOWED_HOSTS:
-            raise ValueError(f"redirected to non-allowlisted host: {final_host}")
+    with opener.open(request, timeout=60) as response, destination.open("wb") as output:
+        validate_download_url(response.geturl())
         content_length = response.headers.get("Content-Length")
         if content_length and int(content_length) != weights["size_bytes"]:
             raise ValueError("Content-Length does not match declared size_bytes")
@@ -121,8 +144,15 @@ def run_benchmark(data: dict, output_dir: Path) -> dict:
     cfg = data["benchmark"]
     model = YOLO(str(weight_path), task="detect")
     metrics = model.val(
-        data=cfg["dataset"], imgsz=cfg["imgsz"], batch=cfg["batch"], device="cpu",
-        project=str(output_dir), name="validation", exist_ok=True, plots=False, verbose=False,
+        data=cfg["dataset"],
+        imgsz=cfg["imgsz"],
+        batch=cfg["batch"],
+        device="cpu",
+        project=str(output_dir),
+        name="validation",
+        exist_ok=True,
+        plots=False,
+        verbose=False,
     )
     results = {str(k): float(v) for k, v in getattr(metrics, "results_dict", {}).items() if isinstance(v, (int, float))}
     speed = {str(k): float(v) for k, v in getattr(metrics, "speed", {}).items() if isinstance(v, (int, float))}


### PR DESCRIPTION
The model-zoo downloader validates only the final hostname after urllib has followed redirects. Apply the existing HTTPS/host policy before every redirect request, as well as before the initial request, and reject alternate ports and embedded credentials. Keep final-URL, declared-size and SHA256 checks.

Validation: 7 regression cases passed on this independent branch. Offline tests reject HTTP downgrade, non-allowlisted destinations, alternate ports and credentials before returning a redirect Request, accept the normal HTTPS release-asset path, verify use of the checked opener, and retain digest validation. Tests pass Ruff lint/format; production critical-error lint and git diff --check pass. No live exploit or external network probe was performed. Repository-wide lint/format have existing findings and codespell is unavailable.

Based directly on main b44ea12; limited to the downloader and its tests.