### PR TITLE
fix(ui): render OBB and classification result tables

### DIFF
--- a/app.py
+++ b/app.py
@@ -196,28 +196,24 @@ class YOLO_Master_WebUI:
         
         # 4.2 Data Extraction (Build DataFrame)
         data_list = []
-        if res.boxes:
-            for box in res.boxes:
-                try:
-                    # Compatibility handling: box.cls might be tensor or float
-                    cls_id = int(box.cls[0]) if box.cls.numel() > 0 else 0
-                    cls_name = model.names[cls_id]
-                    conf_val = float(box.conf[0]) if box.conf.numel() > 0 else 0.0
-                    coords = box.xyxy[0].tolist()
-                    
-                    row = {
-                        "Class ID": cls_id,
-                        "Class Name": cls_name,
-                        "Confidence": round(conf_val, 3),
-                        "x1": round(coords[0], 1),
-                        "y1": round(coords[1], 1),
-                        "x2": round(coords[2], 1),
-                        "y2": round(coords[3], 1)
-                    }
-                    data_list.append(row)
-                except Exception:
-                    pass
-        
+        detections = res.obb if res.obb is not None else res.boxes
+        if detections is not None:
+            for box in detections:
+                cls_id = int(box.cls[0])
+                row = {"Class ID": cls_id, "Class Name": model.names[cls_id], "Confidence": round(float(box.conf[0]), 3)}
+                if res.obb is not None:
+                    keys = ("cx", "cy", "width", "height", "angle (rad)")
+                    coordinates = box.xywhr[0].tolist()
+                else:
+                    keys = ("x1", "y1", "x2", "y2")
+                    coordinates = box.xyxy[0].tolist()
+                row.update({key: round(value, 3) for key, value in zip(keys, coordinates)})
+                data_list.append(row)
+        elif res.probs is not None:
+            for cls_id in res.probs.top5:
+                data_list.append({"Class ID": cls_id, "Class Name": model.names[cls_id],
+                                  "Confidence": round(float(res.probs.data[cls_id]), 3)})
+
         df = pd.DataFrame(data_list)
         
         # 4.3 Summary Info
@@ -229,7 +225,7 @@ class YOLO_Master_WebUI:
             f"### ✅ Inference Done\n"
             f"- **Model:** `{Path(self.model_manager.current_model_path).name}`\n"
             f"- **Time:** `{infer_time:.1f}ms`\n"
-            f"- **Objects:** {len(data_list)}\n"
+            f"- **{'Classes shown' if res.probs is not None else 'Objects'}:** {len(data_list)}\n"
             f"- **Device:** `{model_device}`"
         )
         

--- a/tests/test_webui_task_results.py
+++ b/tests/test_webui_task_results.py
@@ -1,0 +1,55 @@
+"""Check actual UI result parsing without requiring Gradio or downloaded models."""
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+import cv2
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+from ultralytics.engine.results import Results
+
+
+@pytest.mark.parametrize("task,count", [("obb", 1), ("detect", 1), ("empty", 0), ("cls", 2)])
+def test_webui_preserves_task_results(task, count):
+    """Use real Results containers and the unchanged public inference method signature."""
+    tree = ast.parse((Path(__file__).resolve().parents[1] / "app.py").read_text(encoding="utf-8"))
+    ui = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "YOLO_Master_WebUI")
+    method = next(node for node in ui.body if isinstance(node, ast.FunctionDef) and node.name == "inference")
+    scope = {"np": np, "pd": pd, "cv2": cv2, "Path": Path, "List": list}
+    exec(compile(ast.Module(body=[method], type_ignores=[]), "app.py", "exec"), scope)  # noqa: S102 - trusted local AST
+    image = np.zeros((32, 32, 3), dtype=np.uint8)
+    fields = (
+        {"obb": torch.tensor([[16.0, 16.0, 8.0, 6.0, 0.2, 0.9, 0.0]])}
+        if task == "obb"
+        else (
+            {"probs": torch.tensor([0.8, 0.2])}
+            if task == "cls"
+            else {"boxes": torch.tensor([[1.0, 1.0, 8.0, 8.0, 0.9, 0.0]]) if task == "detect" else torch.empty(0, 6)}
+        )
+    )
+    names = {0: "first", 1: "second"}
+    result = Results(image, "fixture.jpg", names, **fields)
+    result.speed = {"inference": 1.0}
+
+    class Model:
+        def __call__(self, *args, **kwargs):
+            return [result]
+
+    model = Model()
+    model.names = names
+    manager = SimpleNamespace(
+        load_model=lambda *args: model, current_model_path="fixture.pt", get_current_model_info=lambda: "cpu"
+    )
+    _, table, summary = scope["inference"](
+        SimpleNamespace(model_manager=manager), task, image, "fixture.pt", "", 0.25, 0.7, "cpu", 100, 2, True, []
+    )
+    assert len(table) == count
+    assert f"{'Classes shown' if task == 'cls' else 'Objects'}:** {count}" in summary
+    if task == "obb":
+        assert table.iloc[0]["angle (rad)"] == pytest.approx(0.2)
+    if task == "cls":
+        assert table.iloc[0]["Class Name"] == "first"


### PR DESCRIPTION
The WebUI exposes OBB and classification tasks but builds its result table only from Results.boxes. An image with one rotated detection is plotted correctly while the table and object count show zero.

Read OBB coordinates and angle from Results.obb; read top class probabilities from Results.probs. Preserve horizontal-box output and label classification summaries as classes shown. Remove the silent per-row exception handler so malformed results are not presented as successful zero detections.

Validation: 4 tests passed on this independent branch using real Results containers for OBB, horizontal detection, empty detection and classification. Tests execute the actual inference method with a fake model; they do not require Gradio installation or model downloads. This validates result parsing, not a live browser rendering session. Test Ruff lint/format, production critical-error lint and git diff --check pass. Repository-wide lint/format retain existing findings; codespell is unavailable.

Based directly on main b44ea12. No training or A2 changes included.