### PR TITLE
docs(export): fix runnable Exporter examples

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -512,15 +512,17 @@ class Exporter:
         export_deepx: Export model to DEEPX format.
 
     Examples:
-        Export a YOLO26 model to TorchScript format
+        Export a randomly initialized YOLO26 architecture to TorchScript format
+        >>> from ultralytics import YOLO
         >>> from ultralytics.engine.exporter import Exporter
-        >>> exporter = Exporter()
-        >>> exporter(model="yolo26n.pt")  # exports to yolo26n.torchscript
+        >>> model = YOLO("yolo26n.yaml", verbose=False).model
+        >>> exporter = Exporter(overrides={"format": "torchscript", "imgsz": 32})
+        >>> exported_path = exporter(model=model)
 
         Export with specific arguments
-        >>> args = {"format": "onnx", "dynamic": True, "quantize": 8, "data": "coco8.yaml"}
+        >>> args = {"format": "torchscript", "imgsz": 64, "batch": 1}
         >>> exporter = Exporter(overrides=args)
-        >>> exporter(model="yolo26n.pt")
+        >>> exported_path = exporter(model=model)
     """
 
     def __init__(self, cfg=DEFAULT_CFG, overrides=None, _callbacks: dict | None = None):


### PR DESCRIPTION
The `Exporter` class examples pass a filename string to an API that expects a model module. Running the doctest on upstream b44ea125 fails with `AttributeError: 'str' object has no attribute 'named_modules'` during export preflight.

Build a randomly initialized model from YAML and pass its `.model` to both examples. Small TorchScript exports keep the examples runnable without downloading pretrained weights or requiring an additional export backend. Capture the returned path so the doctest does not depend on its printed representation. This changes documentation only.

Validation:
- Reproduced the failure on upstream b44ea125.
- `python -m pytest --doctest-modules ultralytics/engine/exporter.py -q`: 1 passed after the change, including real TorchScript exports.
- `ruff format --check ultralytics/engine/exporter.py` and `git diff --check` passed.
- Ruff lint still reports pre-existing diagnostics outside the changed examples; codespell is not installed in the validation environment.