### PR TITLE
[犀牛鸟-E3]：五族混合系统的路由透视镜

### DIFF
--- a/tools/e3_routing/.gitignore
+++ b/tools/e3_routing/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.ruff_cache/
+artifacts/
+results/**/*.json
+docs/p0/
+docs/p1/
+docs/p2/
+configs/p2/*-codeload-compat.yaml

--- a/tools/e3_routing/README.md
+++ b/tools/e3_routing/README.md
@@ -1,0 +1,72 @@
+# E3 unified routing observability for YOLO-Master
+
+This directory combines the three E3 acceptance levels into one reviewable contribution. It observes real routed
+modules through removable forward hooks and does not alter model forward signatures or routing decisions.
+
+## Acceptance map
+
+| Level | Deliverable | Audited result |
+| --- | --- | --- |
+| P0 | One schema, structured logs and static plots for MoE/MoT/Latent | 52 events, 13 modules, 52/52 repeat match, batch 2/4 max load delta 0 |
+| P1 | Live dashboard for at least three families and <10% slowdown | Three-family HTTP dashboard; 108 paired full steps; all median and CI upper bounds <10% |
+| P2 | Original-image token overlays, two-minute demo, more families | True MoT/MoA overlays; five-family audit; 1:55 real UI demo |
+
+P2 deliberately reports MoE, Latent and MoLoRA as spatially `UNSUPPORTED`: their observed contracts do not expose
+a reversible two-dimensional token axis. Sample-level or expert-axis vectors are never reshaped into plausible but
+false heatmaps.
+
+## Layout
+
+```text
+tools/e3_routing/
+├── src/e3_p0/             # unified event schema, collection and static plots
+├── src/e3_p1/             # live dashboard and paired overhead gates
+├── src/e3_p2/             # spatial capture, overlays and mechanism analyses
+├── schemas/               # e3.routing/v1.0.0 JSON Schema
+├── configs/               # current-main configs plus untouched frozen configs
+├── tests/                 # 113 phase and CLI-contract tests
+├── scripts/               # latest-main compatibility smoke
+└── artifacts/             # locally generated outputs (ignored by Git)
+```
+
+## Review-first checks
+
+From the YOLO-Master repository root:
+
+```bat
+cd tools\e3_routing
+python -m pip install -e ".[test]"
+run_tests.cmd
+run_smoke.cmd --output artifacts\latest-main-smoke.json
+```
+
+The compatibility smoke loads MoE, MoT, Latent and MoA detector configs from the containing checkout, runs real
+forward passes, checks hook output equality, verifies true MoT/MoA `[B,E,H,W]` captures, and re-audits the explicit
+non-spatial boundary for MoE, Latent and MoLoRA.
+
+## Formal evidence
+
+The archived experiments under `configs/frozen/` are bound to source commit
+`07d330325b5a26b75aabfc75389f9bcbc0d40245`; the historical
+increment boundary is `acce839c7e895d6b179de7f7093fa879e237cc7b`. See [RESULTS.md](docs/RESULTS.md) for the numerical
+claims and [REPRODUCIBILITY.md](docs/REPRODUCIBILITY.md) for the distinction between archived evidence and the
+latest-main compatibility gate.
+
+The active configs use the containing checkout and were refreshed against upstream main
+`7bfbfd374a6b44720f98366e088f3a962e16321d`. Run P0 once before the P1 benchmark/dashboard so the local ignored
+`artifacts/p0/LATEST.txt` and event stream exist.
+
+Phase design and acceptance details are summarized in [P0.md](docs/P0.md), [P1.md](docs/P1.md), and
+[P2.md](docs/P2.md). The full manifest-bound evidence repositories remain available separately:
+
+- P0: <https://github.com/Ricky-7-Yan/YOLO-Master-E3-P0>
+- P1: <https://github.com/Ricky-7-Yan/YOLO-Master-E3-P1>
+- P2: <https://github.com/Ricky-7-Yan/YOLO-Master-E3-P2>
+
+## Scope and limitations
+
+- Formal results are CPU/coco8 or a deterministic 32-image coco128 subset.
+- Models are randomly initialized; observations are cold-start mechanism evidence, not trained accuracy claims.
+- Negative timing values are scheduler noise, not observer speedups.
+- Correlations and detector-output coupling do not establish routing causality.
+- Generated reruns are ignored; only compact, manifest-bound formal evidence is included for review.

--- a/tools/e3_routing/configs/frozen/p0/p0.yaml
+++ b/tools/e3_routing/configs/frozen/p0/p0.yaml
@@ -1,0 +1,31 @@
+run_id: p0-20260831-cpu-multisample
+schema_version: e3.routing/v1.0.0
+
+# The source tree is kept separate from this tool repository.
+runtime_root: ../YOLO-Master-main-07d3303
+official_locked_base_ref: acce839c7e895d6b179de7f7093fa879e237cc7b
+official_runtime_ref: 07d330325b5a26b75aabfc75389f9bcbc0d40245
+official_runtime_tree: e4a900338bd6679d5ad9f8673e466b250ba2c711
+official_source_archive_url: https://codeload.github.com/Tencent/YOLO-Master/zip/07d330325b5a26b75aabfc75389f9bcbc0d40245
+official_source_archive_sha256: 774abaa264028f1aca4b6d14c3db249f8a75bc253b4131c272f6dc8a8c744c49
+
+device: cpu
+seed: 0
+dataset: coco8.yaml
+dataset_split: val
+sample_indices: [0, 1, 2, 3]
+image_size: 64
+primary_batch_size: 1
+boundary_batch_sizes: [2, 4]
+repeat_primary_passes: 2
+batch_consistency_tolerance: 0.00001
+selection_policy: leaf_routed_modules
+moe_snapshot_interval: 1
+
+profiles:
+  moe:
+    model_config: ultralytics/cfg/models/26/yolo26-master-n.yaml
+  mot:
+    model_config: ultralytics/cfg/models/26/yolo26-master-mot-n.yaml
+  latent:
+    model_config: ultralytics/cfg/models/26/yolo26-master-latent-n.yaml

--- a/tools/e3_routing/configs/frozen/p1/p1.yaml
+++ b/tools/e3_routing/configs/frozen/p1/p1.yaml
@@ -1,0 +1,28 @@
+run_id: p1-20260901-cpu-split
+
+runtime_root: ../YOLO-Master-main-07d3303
+p0_repo_root: ../YOLO-Master-E3-P0
+official_runtime_ref: 07d330325b5a26b75aabfc75389f9bcbc0d40245
+official_runtime_tree: e4a900338bd6679d5ad9f8673e466b250ba2c711
+
+device: cpu
+seed: 0
+dataset: coco8.yaml
+dataset_split: val
+sample_indices: [0, 1]
+image_size: 64
+batch_size: 2
+warmup_pairs: 5
+measured_pairs: 30
+bootstrap_resamples: 5000
+target_slowdown_percent: 10.0
+loss_match_rtol: 0.000001
+loss_match_atol: 0.000001
+
+profiles:
+  moe:
+    model_config: ultralytics/cfg/models/26/yolo26-master-n.yaml
+  mot:
+    model_config: ultralytics/cfg/models/26/yolo26-master-mot-n.yaml
+  latent:
+    model_config: ultralytics/cfg/models/26/yolo26-master-latent-n.yaml

--- a/tools/e3_routing/configs/frozen/p1/p1_engine_crosscheck.yaml
+++ b/tools/e3_routing/configs/frozen/p1/p1_engine_crosscheck.yaml
@@ -1,0 +1,37 @@
+run_id: p1e-20260903-cpu-trainer-v3
+
+runtime_root: ../YOLO-Master-main-07d3303
+p0_repo_root: ../YOLO-Master-E3-P0
+official_runtime_ref: 07d330325b5a26b75aabfc75389f9bcbc0d40245
+official_runtime_tree: e4a900338bd6679d5ad9f8673e466b250ba2c711
+runtime_input_sha256:
+  ultralytics/engine/trainer.py: bb116de4da87c7cb074cc3a298f4e6ea89dea07bdccd1c56e8a92440e473caae
+  ultralytics/models/yolo/detect/train.py: 257f81fcbce922e9032f6d3908378f6e1d1b0648169d72f4a37f1448d2afb81e
+  ultralytics/nn/modules/routing_protocol.py: fb1182314dd74fbc2295a33fef927e9f7333b4e2906688e5c0ecd4f9a00340b3
+  ultralytics/cfg/models/26/yolo26-master-n.yaml: 135ae1f18197f42039dbd67d4e6104cd531c7d9d65ede77c8edb4d0afa11a223
+  ultralytics/cfg/models/26/yolo26-master-mot-n.yaml: 739aca4279cd2ae7813f4b0b5a16211efd68c74a1beaacc71d2431101dca6fda
+  ultralytics/cfg/models/26/yolo26-master-latent-n.yaml: 08307e7ca5e7aa68cb41f4a39d2eb0901e8cd20a9f3784edd2dd96ab0da11219
+
+device: cpu
+seed: 2300
+dataset: coco8.yaml
+image_size: 64
+batch_size: 2
+epochs: 5
+warmup_pairs: 2
+measured_pairs: 6
+target_slowdown_percent: 10.0
+
+optimizer:
+  name: SGD
+  learning_rate: 0.001
+  momentum: 0.9
+  weight_decay: 0.0005
+
+profiles:
+  moe:
+    model_config: ultralytics/cfg/models/26/yolo26-master-n.yaml
+  mot:
+    model_config: ultralytics/cfg/models/26/yolo26-master-mot-n.yaml
+  latent:
+    model_config: ultralytics/cfg/models/26/yolo26-master-latent-n.yaml

--- a/tools/e3_routing/configs/frozen/p1/p1_strengthened.yaml
+++ b/tools/e3_routing/configs/frozen/p1/p1_strengthened.yaml
@@ -1,0 +1,43 @@
+run_id: p1s-20260901-cpu-fullstep-v1
+
+runtime_root: ../YOLO-Master-main-07d3303
+p0_repo_root: ../YOLO-Master-E3-P0
+official_runtime_ref: 07d330325b5a26b75aabfc75389f9bcbc0d40245
+official_runtime_tree: e4a900338bd6679d5ad9f8673e466b250ba2c711
+
+device: cpu
+seed: 0
+dataset: coco8.yaml
+dataset_split: val
+sample_batches:
+  - [0, 1]
+  - [2, 3]
+image_size: 64
+batch_size: 2
+warmup_pairs: 6
+bootstrap_resamples: 10000
+target_slowdown_percent: 10.0
+loss_match_rtol: 0.000001
+loss_match_atol: 0.000001
+gradient_match_rtol: 0.00001
+gradient_match_atol: 0.00001
+gradient_clip_norm: 10.0
+writer_flush_each_step: true
+
+optimizer:
+  name: SGD
+  learning_rate: 0.001
+  momentum: 0.9
+  weight_decay: 0.0005
+  router_lr_scale: 0.5
+
+profiles:
+  moe:
+    model_config: ultralytics/cfg/models/26/yolo26-master-n.yaml
+    measured_pairs: 30
+  mot:
+    model_config: ultralytics/cfg/models/26/yolo26-master-mot-n.yaml
+    measured_pairs: 48
+  latent:
+    model_config: ultralytics/cfg/models/26/yolo26-master-latent-n.yaml
+    measured_pairs: 30

--- a/tools/e3_routing/configs/frozen/p2/appearance.yaml
+++ b/tools/e3_routing/configs/frozen/p2/appearance.yaml
@@ -1,0 +1,35 @@
+run_id: p2a-20260905-cpu-appearance-v2
+require_committed_source: true
+
+runtime_root: ../YOLO-Master-main-07d3303
+official_locked_base_ref: acce839c7e895d6b179de7f7093fa879e237cc7b
+official_runtime_ref: 07d330325b5a26b75aabfc75389f9bcbc0d40245
+official_runtime_tree: e4a900338bd6679d5ad9f8673e466b250ba2c711
+
+device: cpu
+seeds: [0, 1, 2]
+dataset: coco8.yaml
+dataset_split: val
+sample_indices: [0, 1, 2, 3]
+resolution: 128
+transformations:
+  - {name: identity, kind: identity}
+  - {name: brightness_090, kind: brightness, factor: 0.9}
+  - {name: brightness_110, kind: brightness, factor: 1.1}
+  - {name: contrast_090, kind: contrast, factor: 0.9}
+  - {name: contrast_110, kind: contrast, factor: 1.1}
+  - {name: gaussian_blur_075, kind: gaussian_blur, radius: 0.75}
+
+spatial_profiles:
+  mot:
+    model_config: ultralytics/cfg/models/26/yolo26-master-mot-n.yaml
+    router_class: _MoTRouter
+  moa:
+    model_config: ultralytics/cfg/models/26/yolo26-master-moa-n.yaml
+    router_class: _MoARouter
+
+source_fingerprints:
+  ultralytics/nn/modules/mot/router.py: 0fab250d4b472c979e28c76258768ce9c6e414fdc016dd3a29559ddcefd75fc1
+  ultralytics/nn/modules/moa/router.py: ad753404db8b740c909b38d4f74dc4912527ce931ea76f48609ae7dbeb8f517f
+  ultralytics/cfg/models/26/yolo26-master-mot-n.yaml: 739aca4279cd2ae7813f4b0b5a16211efd68c74a1beaacc71d2431101dca6fda
+  ultralytics/cfg/models/26/yolo26-master-moa-n.yaml: 20a57222cd4a51b11b39d51ca959a2d250e46c5e42b4ecf9fe6a9808e3147310

--- a/tools/e3_routing/configs/frozen/p2/blur_residual.yaml
+++ b/tools/e3_routing/configs/frozen/p2/blur_residual.yaml
@@ -1,0 +1,23 @@
+run_id: p2x-20260908-blur-residual-v1
+require_committed_source: true
+holdout_run_dir: artifacts/p2/p2h-20260907-dose-holdout-v1
+expected_holdout_run_id: p2h-20260907-dose-holdout-v1
+expected_holdout_manifest_sha256: 1beeb20bf31d2ad153ecfde466cbd8f66e9e45dd322f13c6c66e57eae82b2b2e
+image_source_run_dir: artifacts/p2/p2q-20260906-dose-response-v1
+expected_image_source_manifest_sha256: c1917ad0d254b01d33ce9883c33d7d085c3147633915c2cab6213dde95ecaafe
+expected_selected_image_and_label_set_sha256: 80020696759bd2b6a6e68bb645c9c748e90c4b6425489563a746f72fbd161c4f
+expected_image_count: 32
+canvas_size: 128
+family: gaussian_blur
+endpoint: probability_mae
+features:
+  - letterbox_content_fraction
+  - luminance_mean_0_255
+  - edge_total_variation_0_1
+bootstrap_draws: 10000
+bootstrap_seed: 20260908
+permutation_draws: 20000
+permutation_seed: 20261908
+alpha: 0.05
+top_k: 6
+max_evidence_bytes: 8388608

--- a/tools/e3_routing/configs/frozen/p2/dose_holdout.yaml
+++ b/tools/e3_routing/configs/frozen/p2/dose_holdout.yaml
@@ -1,0 +1,24 @@
+run_id: p2h-20260907-dose-holdout-v1
+require_committed_source: true
+parent_run_dir: artifacts/p2/p2q-20260906-dose-response-v1
+expected_parent_run_id: p2q-20260906-dose-response-v1
+expected_parent_manifest_sha256: c1917ad0d254b01d33ce9883c33d7d085c3147633915c2cab6213dde95ecaafe
+expected_image_count: 32
+expected_seeds: [0, 1, 2]
+bootstrap_draws: 10000
+bootstrap_seed: 20260907
+max_evidence_bytes: 8388608
+
+families:
+  - name: brightness
+    low_transform: brightness_095
+    middle_transform: brightness_090
+    high_transform: brightness_080
+  - name: contrast
+    low_transform: contrast_095
+    middle_transform: contrast_090
+    high_transform: contrast_080
+  - name: gaussian_blur
+    low_transform: gaussian_blur_025
+    middle_transform: gaussian_blur_075
+    high_transform: gaussian_blur_150

--- a/tools/e3_routing/configs/frozen/p2/dose_response.yaml
+++ b/tools/e3_routing/configs/frozen/p2/dose_response.yaml
@@ -1,0 +1,59 @@
+run_id: p2q-20260906-dose-response-v1
+require_committed_source: true
+study_kind: dose_response
+
+runtime_root: ../YOLO-Master-main-07d3303
+official_locked_base_ref: acce839c7e895d6b179de7f7093fa879e237cc7b
+official_runtime_ref: 07d330325b5a26b75aabfc75389f9bcbc0d40245
+official_runtime_tree: e4a900338bd6679d5ad9f8673e466b250ba2c711
+
+device: cpu
+family: moa
+target_module: model.16.m.0.router
+seeds: [0, 1, 2]
+dataset: coco128.yaml
+dataset_split: val
+expected_dataset_image_count: 128
+selected_image_count: 32
+selection_salt: e3-p2-coco128-image-v1
+resolution: 128
+transformations:
+  - {name: identity, kind: identity}
+  - {name: brightness_095, kind: brightness, factor: 0.95}
+  - {name: brightness_090, kind: brightness, factor: 0.9}
+  - {name: brightness_080, kind: brightness, factor: 0.8}
+  - {name: contrast_095, kind: contrast, factor: 0.95}
+  - {name: contrast_090, kind: contrast, factor: 0.9}
+  - {name: contrast_080, kind: contrast, factor: 0.8}
+  - {name: gaussian_blur_025, kind: gaussian_blur, radius: 0.25}
+  - {name: gaussian_blur_075, kind: gaussian_blur, radius: 0.75}
+  - {name: gaussian_blur_150, kind: gaussian_blur, radius: 1.5}
+
+dose_response_families:
+  - name: brightness
+    conditions:
+      - {transform: brightness_095, severity: 1, label: "0.95"}
+      - {transform: brightness_090, severity: 2, label: "0.90"}
+      - {transform: brightness_080, severity: 3, label: "0.80"}
+  - name: contrast
+    conditions:
+      - {transform: contrast_095, severity: 1, label: "0.95"}
+      - {transform: contrast_090, severity: 2, label: "0.90"}
+      - {transform: contrast_080, severity: 3, label: "0.80"}
+  - name: gaussian_blur
+    conditions:
+      - {transform: gaussian_blur_025, severity: 1, label: "0.25"}
+      - {transform: gaussian_blur_075, severity: 2, label: "0.75"}
+      - {transform: gaussian_blur_150, severity: 3, label: "1.50"}
+
+profile:
+  model_config: ultralytics/cfg/models/26/yolo26-master-moa-n.yaml
+  router_class: _MoARouter
+
+bootstrap_draws: 10000
+bootstrap_seed: 20260906
+max_evidence_bytes: 67108864
+
+source_fingerprints:
+  ultralytics/nn/modules/moa/router.py: ad753404db8b740c909b38d4f74dc4912527ce931ea76f48609ae7dbeb8f517f
+  ultralytics/cfg/models/26/yolo26-master-moa-n.yaml: 20a57222cd4a51b11b39d51ca959a2d250e46c5e42b4ecf9fe6a9808e3147310

--- a/tools/e3_routing/configs/frozen/p2/image_driver.yaml
+++ b/tools/e3_routing/configs/frozen/p2/image_driver.yaml
@@ -1,0 +1,19 @@
+run_id: p2i-20260905-image-driver-v1
+require_committed_source: true
+
+parent_run_dir: artifacts/p2/p2s-20260905-coco128-32-v1
+expected_parent_run_id: p2s-20260905-coco128-32-v1
+expected_parent_manifest_sha256: 42d85cb411ef3776bc03b857025dcb77304b5530c4b4b2b4218d0d773d8d45c1
+
+expected_image_count: 32
+expected_seeds: [0, 1, 2]
+candidate_transformations:
+  - brightness_090
+  - contrast_090
+  - gaussian_blur_075
+endpoints:
+  - probability_mae
+  - dominant_switch_fraction
+
+bootstrap_draws: 10000
+bootstrap_seed: 20260905

--- a/tools/e3_routing/configs/frozen/p2/image_scale.yaml
+++ b/tools/e3_routing/configs/frozen/p2/image_scale.yaml
@@ -1,0 +1,35 @@
+run_id: p2s-20260905-coco128-32-v1
+require_committed_source: true
+
+runtime_root: ../YOLO-Master-main-07d3303
+official_locked_base_ref: acce839c7e895d6b179de7f7093fa879e237cc7b
+official_runtime_ref: 07d330325b5a26b75aabfc75389f9bcbc0d40245
+official_runtime_tree: e4a900338bd6679d5ad9f8673e466b250ba2c711
+
+device: cpu
+family: moa
+target_module: model.16.m.0.router
+seeds: [0, 1, 2]
+dataset: coco128.yaml
+dataset_split: val
+expected_dataset_image_count: 128
+selected_image_count: 32
+selection_salt: e3-p2-coco128-image-v1
+resolution: 128
+transformations:
+  - {name: identity, kind: identity}
+  - {name: brightness_090, kind: brightness, factor: 0.9}
+  - {name: contrast_090, kind: contrast, factor: 0.9}
+  - {name: gaussian_blur_075, kind: gaussian_blur, radius: 0.75}
+
+profile:
+  model_config: ultralytics/cfg/models/26/yolo26-master-moa-n.yaml
+  router_class: _MoARouter
+
+bootstrap_draws: 10000
+bootstrap_seed: 20260905
+max_evidence_bytes: 67108864
+
+source_fingerprints:
+  ultralytics/nn/modules/moa/router.py: ad753404db8b740c909b38d4f74dc4912527ce931ea76f48609ae7dbeb8f517f
+  ultralytics/cfg/models/26/yolo26-master-moa-n.yaml: 20a57222cd4a51b11b39d51ca959a2d250e46c5e42b4ecf9fe6a9808e3147310

--- a/tools/e3_routing/configs/frozen/p2/layer_drilldown.yaml
+++ b/tools/e3_routing/configs/frozen/p2/layer_drilldown.yaml
@@ -1,0 +1,16 @@
+run_id: p2d-20260905-layer16-attribution-v2
+require_committed_source: true
+
+parent_run_dir: artifacts/p2/p2a-20260905-cpu-appearance-v2
+expected_parent_run_id: p2a-20260905-cpu-appearance-v2
+expected_parent_manifest_sha256: 7df8fbaf1d10d61d268559ff688cc81a67ab5c3e428b8deb45f1ea2904dd5d21
+
+family: moa
+target_module: model.16.m.0.router
+candidate_transformations:
+  - brightness_090
+  - brightness_110
+  - contrast_090
+  - contrast_110
+  - gaussian_blur_075
+margin_bin_count: 10

--- a/tools/e3_routing/configs/frozen/p2/output_coupling.yaml
+++ b/tools/e3_routing/configs/frozen/p2/output_coupling.yaml
@@ -1,0 +1,37 @@
+run_id: p2o-20260906-output-coupling-v2
+require_committed_source: true
+study_kind: output_coupling
+record_detector_outputs: true
+
+runtime_root: ../YOLO-Master-main-07d3303
+official_locked_base_ref: acce839c7e895d6b179de7f7093fa879e237cc7b
+official_runtime_ref: 07d330325b5a26b75aabfc75389f9bcbc0d40245
+official_runtime_tree: e4a900338bd6679d5ad9f8673e466b250ba2c711
+
+device: cpu
+family: moa
+target_module: model.16.m.0.router
+seeds: [0, 1, 2]
+dataset: coco128.yaml
+dataset_split: val
+expected_dataset_image_count: 128
+selected_image_count: 32
+selection_salt: e3-p2-coco128-image-v1
+resolution: 128
+transformations:
+  - {name: identity, kind: identity}
+  - {name: brightness_080, kind: brightness, factor: 0.8}
+  - {name: contrast_080, kind: contrast, factor: 0.8}
+  - {name: gaussian_blur_150, kind: gaussian_blur, radius: 1.5}
+
+profile:
+  model_config: ultralytics/cfg/models/26/yolo26-master-moa-n.yaml
+  router_class: _MoARouter
+
+bootstrap_draws: 10000
+bootstrap_seed: 20260906
+max_evidence_bytes: 67108864
+
+source_fingerprints:
+  ultralytics/nn/modules/moa/router.py: ad753404db8b740c909b38d4f74dc4912527ce931ea76f48609ae7dbeb8f517f
+  ultralytics/cfg/models/26/yolo26-master-moa-n.yaml: 20a57222cd4a51b11b39d51ca959a2d250e46c5e42b4ecf9fe6a9808e3147310

--- a/tools/e3_routing/configs/frozen/p2/p2.yaml
+++ b/tools/e3_routing/configs/frozen/p2/p2.yaml
@@ -1,0 +1,55 @@
+run_id: p2-20260904-cpu-five-family-v3
+schema_version: e3.spatial-routing/v1.0.0
+require_committed_source: true
+
+runtime_root: ../YOLO-Master-main-07d3303
+python_root: ../YOLO-Master-baseline/.venv
+official_locked_base_ref: acce839c7e895d6b179de7f7093fa879e237cc7b
+official_runtime_ref: 07d330325b5a26b75aabfc75389f9bcbc0d40245
+official_runtime_tree: e4a900338bd6679d5ad9f8673e466b250ba2c711
+official_source_archive_url: https://codeload.github.com/Tencent/YOLO-Master/zip/07d330325b5a26b75aabfc75389f9bcbc0d40245
+official_source_archive_sha256: 774abaa264028f1aca4b6d14c3db249f8a75bc253b4131c272f6dc8a8c744c49
+
+device: cpu
+seed: 0
+dataset: coco8.yaml
+dataset_split: val
+sample_indices: [0, 1, 2, 3]
+image_size: 64
+overlay_alpha: 0.58
+batch_equivalence_sizes: [2, 4]
+
+region_analysis:
+  enabled: true
+  label_format: yolo_detection_normalized_xywh
+  assignment_rule: valid_token_center_inside_any_ground_truth_box
+  exclude_letterbox_padding: true
+
+spatial_profiles:
+  mot:
+    model_config: ultralytics/cfg/models/26/yolo26-master-mot-n.yaml
+    router_class: _MoTRouter
+    expert_labels: [local, window, deformable]
+  moa:
+    model_config: ultralytics/cfg/models/26/yolo26-master-moa-n.yaml
+    router_class: _MoARouter
+    expert_labels: [local, regional, global]
+
+non_spatial_profiles:
+  moe:
+    model_config: ultralytics/cfg/models/26/yolo26-master-n.yaml
+  latent:
+    model_config: ultralytics/cfg/models/26/yolo26-master-latent-n.yaml
+  molora:
+    audit: isolated_official_router_contract
+
+source_fingerprints:
+  ultralytics/nn/modules/mot/router.py: 0fab250d4b472c979e28c76258768ce9c6e414fdc016dd3a29559ddcefd75fc1
+  ultralytics/nn/modules/moa/router.py: ad753404db8b740c909b38d4f74dc4912527ce931ea76f48609ae7dbeb8f517f
+  ultralytics/nn/modules/latent_mixture.py: 7ee5b0516a20709c9bc96b8c966da13447ca527c8cba7c7051f41aaf61f52b51
+  ultralytics/nn/modules/moe/gated.py: 5e73e35fa6c53ee45381b934771585314e68e66fb3e6f66786a6ce68af8f4727
+  ultralytics/nn/peft/molora/router.py: a8c5c924d76b6906bb8e8c44fe35995798741df1db269a931174c908d4c7db4c
+  ultralytics/cfg/models/26/yolo26-master-mot-n.yaml: 739aca4279cd2ae7813f4b0b5a16211efd68c74a1beaacc71d2431101dca6fda
+  ultralytics/cfg/models/26/yolo26-master-moa-n.yaml: 20a57222cd4a51b11b39d51ca959a2d250e46c5e42b4ecf9fe6a9808e3147310
+  ultralytics/cfg/models/26/yolo26-master-n.yaml: 135ae1f18197f42039dbd67d4e6104cd531c7d9d65ede77c8edb4d0afa11a223
+  ultralytics/cfg/models/26/yolo26-master-latent-n.yaml: 08307e7ca5e7aa68cb41f4a39d2eb0901e8cd20a9f3784edd2dd96ab0da11219

--- a/tools/e3_routing/configs/frozen/p2/robustness.yaml
+++ b/tools/e3_routing/configs/frozen/p2/robustness.yaml
@@ -1,0 +1,30 @@
+run_id: p2r-20260905-cpu-resolution-flip-v4
+require_committed_source: true
+
+runtime_root: ../YOLO-Master-main-07d3303
+official_locked_base_ref: acce839c7e895d6b179de7f7093fa879e237cc7b
+official_runtime_ref: 07d330325b5a26b75aabfc75389f9bcbc0d40245
+official_runtime_tree: e4a900338bd6679d5ad9f8673e466b250ba2c711
+
+device: cpu
+seeds: [0, 1, 2]
+dataset: coco8.yaml
+dataset_split: val
+sample_indices: [0, 1, 2, 3]
+resolutions: [64, 128, 256]
+reference_resolution: 64
+transformations: [identity, horizontal_flip]
+
+spatial_profiles:
+  mot:
+    model_config: ultralytics/cfg/models/26/yolo26-master-mot-n.yaml
+    router_class: _MoTRouter
+  moa:
+    model_config: ultralytics/cfg/models/26/yolo26-master-moa-n.yaml
+    router_class: _MoARouter
+
+source_fingerprints:
+  ultralytics/nn/modules/mot/router.py: 0fab250d4b472c979e28c76258768ce9c6e414fdc016dd3a29559ddcefd75fc1
+  ultralytics/nn/modules/moa/router.py: ad753404db8b740c909b38d4f74dc4912527ce931ea76f48609ae7dbeb8f517f
+  ultralytics/cfg/models/26/yolo26-master-mot-n.yaml: 739aca4279cd2ae7813f4b0b5a16211efd68c74a1beaacc71d2431101dca6fda
+  ultralytics/cfg/models/26/yolo26-master-moa-n.yaml: 20a57222cd4a51b11b39d51ca959a2d250e46c5e42b4ecf9fe6a9808e3147310

--- a/tools/e3_routing/configs/p0/p0.yaml
+++ b/tools/e3_routing/configs/p0/p0.yaml
@@ -1,0 +1,31 @@
+run_id: p0-20260831-cpu-multisample
+schema_version: e3.routing/v1.0.0
+
+# Run against the containing YOLO-Master checkout.
+runtime_root: ../..
+official_locked_base_ref: acce839c7e895d6b179de7f7093fa879e237cc7b
+official_runtime_ref: 7bfbfd374a6b44720f98366e088f3a962e16321d
+official_runtime_tree: cfdc006e9da0f0daa6ead7aa66af742983ea14bc
+official_source_archive_url: https://codeload.github.com/Tencent/YOLO-Master/zip/7bfbfd374a6b44720f98366e088f3a962e16321d
+official_source_archive_sha256: null  # live Git checkout is bound by commit/tree; frozen evidence keeps its archive hash
+
+device: cpu
+seed: 0
+dataset: coco8.yaml
+dataset_split: val
+sample_indices: [0, 1, 2, 3]
+image_size: 64
+primary_batch_size: 1
+boundary_batch_sizes: [2, 4]
+repeat_primary_passes: 2
+batch_consistency_tolerance: 0.00001
+selection_policy: leaf_routed_modules
+moe_snapshot_interval: 1
+
+profiles:
+  moe:
+    model_config: ultralytics/cfg/models/26/yolo26-master-n.yaml
+  mot:
+    model_config: ultralytics/cfg/models/26/yolo26-master-mot-n.yaml
+  latent:
+    model_config: ultralytics/cfg/models/26/yolo26-master-latent-n.yaml

--- a/tools/e3_routing/configs/p1/p1.yaml
+++ b/tools/e3_routing/configs/p1/p1.yaml
@@ -1,0 +1,28 @@
+run_id: p1-20260901-cpu-split
+
+runtime_root: ../..
+p0_repo_root: .
+official_runtime_ref: 7bfbfd374a6b44720f98366e088f3a962e16321d
+official_runtime_tree: cfdc006e9da0f0daa6ead7aa66af742983ea14bc
+
+device: cpu
+seed: 0
+dataset: coco8.yaml
+dataset_split: val
+sample_indices: [0, 1]
+image_size: 64
+batch_size: 2
+warmup_pairs: 5
+measured_pairs: 30
+bootstrap_resamples: 5000
+target_slowdown_percent: 10.0
+loss_match_rtol: 0.000001
+loss_match_atol: 0.000001
+
+profiles:
+  moe:
+    model_config: ultralytics/cfg/models/26/yolo26-master-n.yaml
+  mot:
+    model_config: ultralytics/cfg/models/26/yolo26-master-mot-n.yaml
+  latent:
+    model_config: ultralytics/cfg/models/26/yolo26-master-latent-n.yaml

--- a/tools/e3_routing/configs/p1/p1_engine_crosscheck.yaml
+++ b/tools/e3_routing/configs/p1/p1_engine_crosscheck.yaml
@@ -1,0 +1,38 @@
+run_id: p1e-20260903-cpu-trainer-v3
+
+runtime_root: ../..
+p0_repo_root: .
+official_runtime_ref: 7bfbfd374a6b44720f98366e088f3a962e16321d
+official_runtime_tree: cfdc006e9da0f0daa6ead7aa66af742983ea14bc
+runtime_identity_policy: base_ancestor
+runtime_input_sha256:
+  ultralytics/engine/trainer.py: d1aa2e8d56371e24014cd934d83b86eccef57d086038b0b365def40ef5c3c7a9
+  ultralytics/models/yolo/detect/train.py: 257f81fcbce922e9032f6d3908378f6e1d1b0648169d72f4a37f1448d2afb81e
+  ultralytics/nn/modules/routing_protocol.py: fb1182314dd74fbc2295a33fef927e9f7333b4e2906688e5c0ecd4f9a00340b3
+  ultralytics/cfg/models/26/yolo26-master-n.yaml: 135ae1f18197f42039dbd67d4e6104cd531c7d9d65ede77c8edb4d0afa11a223
+  ultralytics/cfg/models/26/yolo26-master-mot-n.yaml: 739aca4279cd2ae7813f4b0b5a16211efd68c74a1beaacc71d2431101dca6fda
+  ultralytics/cfg/models/26/yolo26-master-latent-n.yaml: 08307e7ca5e7aa68cb41f4a39d2eb0901e8cd20a9f3784edd2dd96ab0da11219
+
+device: cpu
+seed: 2300
+dataset: coco8.yaml
+image_size: 64
+batch_size: 2
+epochs: 5
+warmup_pairs: 2
+measured_pairs: 6
+target_slowdown_percent: 10.0
+
+optimizer:
+  name: SGD
+  learning_rate: 0.001
+  momentum: 0.9
+  weight_decay: 0.0005
+
+profiles:
+  moe:
+    model_config: ultralytics/cfg/models/26/yolo26-master-n.yaml
+  mot:
+    model_config: ultralytics/cfg/models/26/yolo26-master-mot-n.yaml
+  latent:
+    model_config: ultralytics/cfg/models/26/yolo26-master-latent-n.yaml

--- a/tools/e3_routing/configs/p1/p1_strengthened.yaml
+++ b/tools/e3_routing/configs/p1/p1_strengthened.yaml
@@ -1,0 +1,43 @@
+run_id: p1s-20260901-cpu-fullstep-v1
+
+runtime_root: ../..
+p0_repo_root: .
+official_runtime_ref: 7bfbfd374a6b44720f98366e088f3a962e16321d
+official_runtime_tree: cfdc006e9da0f0daa6ead7aa66af742983ea14bc
+
+device: cpu
+seed: 0
+dataset: coco8.yaml
+dataset_split: val
+sample_batches:
+  - [0, 1]
+  - [2, 3]
+image_size: 64
+batch_size: 2
+warmup_pairs: 6
+bootstrap_resamples: 10000
+target_slowdown_percent: 10.0
+loss_match_rtol: 0.000001
+loss_match_atol: 0.000001
+gradient_match_rtol: 0.00001
+gradient_match_atol: 0.00001
+gradient_clip_norm: 10.0
+writer_flush_each_step: true
+
+optimizer:
+  name: SGD
+  learning_rate: 0.001
+  momentum: 0.9
+  weight_decay: 0.0005
+  router_lr_scale: 0.5
+
+profiles:
+  moe:
+    model_config: ultralytics/cfg/models/26/yolo26-master-n.yaml
+    measured_pairs: 30
+  mot:
+    model_config: ultralytics/cfg/models/26/yolo26-master-mot-n.yaml
+    measured_pairs: 48
+  latent:
+    model_config: ultralytics/cfg/models/26/yolo26-master-latent-n.yaml
+    measured_pairs: 30

--- a/tools/e3_routing/configs/p2/appearance.yaml
+++ b/tools/e3_routing/configs/p2/appearance.yaml
@@ -1,0 +1,35 @@
+run_id: p2a-20260905-cpu-appearance-v2
+require_committed_source: true
+
+runtime_root: ../..
+official_locked_base_ref: acce839c7e895d6b179de7f7093fa879e237cc7b
+official_runtime_ref: 7bfbfd374a6b44720f98366e088f3a962e16321d
+official_runtime_tree: cfdc006e9da0f0daa6ead7aa66af742983ea14bc
+
+device: cpu
+seeds: [0, 1, 2]
+dataset: coco8.yaml
+dataset_split: val
+sample_indices: [0, 1, 2, 3]
+resolution: 128
+transformations:
+  - {name: identity, kind: identity}
+  - {name: brightness_090, kind: brightness, factor: 0.9}
+  - {name: brightness_110, kind: brightness, factor: 1.1}
+  - {name: contrast_090, kind: contrast, factor: 0.9}
+  - {name: contrast_110, kind: contrast, factor: 1.1}
+  - {name: gaussian_blur_075, kind: gaussian_blur, radius: 0.75}
+
+spatial_profiles:
+  mot:
+    model_config: ultralytics/cfg/models/26/yolo26-master-mot-n.yaml
+    router_class: _MoTRouter
+  moa:
+    model_config: ultralytics/cfg/models/26/yolo26-master-moa-n.yaml
+    router_class: _MoARouter
+
+source_fingerprints:
+  ultralytics/nn/modules/mot/router.py: 0fab250d4b472c979e28c76258768ce9c6e414fdc016dd3a29559ddcefd75fc1
+  ultralytics/nn/modules/moa/router.py: ad753404db8b740c909b38d4f74dc4912527ce931ea76f48609ae7dbeb8f517f
+  ultralytics/cfg/models/26/yolo26-master-mot-n.yaml: 739aca4279cd2ae7813f4b0b5a16211efd68c74a1beaacc71d2431101dca6fda
+  ultralytics/cfg/models/26/yolo26-master-moa-n.yaml: 20a57222cd4a51b11b39d51ca959a2d250e46c5e42b4ecf9fe6a9808e3147310

--- a/tools/e3_routing/configs/p2/blur_residual.yaml
+++ b/tools/e3_routing/configs/p2/blur_residual.yaml
@@ -1,0 +1,23 @@
+run_id: p2x-20260908-blur-residual-v1
+require_committed_source: true
+holdout_run_dir: artifacts/p2/p2h-20260907-dose-holdout-v1
+expected_holdout_run_id: p2h-20260907-dose-holdout-v1
+expected_holdout_manifest_sha256: 1beeb20bf31d2ad153ecfde466cbd8f66e9e45dd322f13c6c66e57eae82b2b2e
+image_source_run_dir: artifacts/p2/p2q-20260906-dose-response-v1
+expected_image_source_manifest_sha256: c1917ad0d254b01d33ce9883c33d7d085c3147633915c2cab6213dde95ecaafe
+expected_selected_image_and_label_set_sha256: 80020696759bd2b6a6e68bb645c9c748e90c4b6425489563a746f72fbd161c4f
+expected_image_count: 32
+canvas_size: 128
+family: gaussian_blur
+endpoint: probability_mae
+features:
+  - letterbox_content_fraction
+  - luminance_mean_0_255
+  - edge_total_variation_0_1
+bootstrap_draws: 10000
+bootstrap_seed: 20260908
+permutation_draws: 20000
+permutation_seed: 20261908
+alpha: 0.05
+top_k: 6
+max_evidence_bytes: 8388608

--- a/tools/e3_routing/configs/p2/dose_holdout.yaml
+++ b/tools/e3_routing/configs/p2/dose_holdout.yaml
@@ -1,0 +1,24 @@
+run_id: p2h-20260907-dose-holdout-v1
+require_committed_source: true
+parent_run_dir: artifacts/p2/p2q-20260906-dose-response-v1
+expected_parent_run_id: p2q-20260906-dose-response-v1
+expected_parent_manifest_sha256: c1917ad0d254b01d33ce9883c33d7d085c3147633915c2cab6213dde95ecaafe
+expected_image_count: 32
+expected_seeds: [0, 1, 2]
+bootstrap_draws: 10000
+bootstrap_seed: 20260907
+max_evidence_bytes: 8388608
+
+families:
+  - name: brightness
+    low_transform: brightness_095
+    middle_transform: brightness_090
+    high_transform: brightness_080
+  - name: contrast
+    low_transform: contrast_095
+    middle_transform: contrast_090
+    high_transform: contrast_080
+  - name: gaussian_blur
+    low_transform: gaussian_blur_025
+    middle_transform: gaussian_blur_075
+    high_transform: gaussian_blur_150

--- a/tools/e3_routing/configs/p2/dose_response.yaml
+++ b/tools/e3_routing/configs/p2/dose_response.yaml
@@ -1,0 +1,59 @@
+run_id: p2q-20260906-dose-response-v1
+require_committed_source: true
+study_kind: dose_response
+
+runtime_root: ../..
+official_locked_base_ref: acce839c7e895d6b179de7f7093fa879e237cc7b
+official_runtime_ref: 7bfbfd374a6b44720f98366e088f3a962e16321d
+official_runtime_tree: cfdc006e9da0f0daa6ead7aa66af742983ea14bc
+
+device: cpu
+family: moa
+target_module: model.16.m.0.router
+seeds: [0, 1, 2]
+dataset: coco128.yaml
+dataset_split: val
+expected_dataset_image_count: 128
+selected_image_count: 32
+selection_salt: e3-p2-coco128-image-v1
+resolution: 128
+transformations:
+  - {name: identity, kind: identity}
+  - {name: brightness_095, kind: brightness, factor: 0.95}
+  - {name: brightness_090, kind: brightness, factor: 0.9}
+  - {name: brightness_080, kind: brightness, factor: 0.8}
+  - {name: contrast_095, kind: contrast, factor: 0.95}
+  - {name: contrast_090, kind: contrast, factor: 0.9}
+  - {name: contrast_080, kind: contrast, factor: 0.8}
+  - {name: gaussian_blur_025, kind: gaussian_blur, radius: 0.25}
+  - {name: gaussian_blur_075, kind: gaussian_blur, radius: 0.75}
+  - {name: gaussian_blur_150, kind: gaussian_blur, radius: 1.5}
+
+dose_response_families:
+  - name: brightness
+    conditions:
+      - {transform: brightness_095, severity: 1, label: "0.95"}
+      - {transform: brightness_090, severity: 2, label: "0.90"}
+      - {transform: brightness_080, severity: 3, label: "0.80"}
+  - name: contrast
+    conditions:
+      - {transform: contrast_095, severity: 1, label: "0.95"}
+      - {transform: contrast_090, severity: 2, label: "0.90"}
+      - {transform: contrast_080, severity: 3, label: "0.80"}
+  - name: gaussian_blur
+    conditions:
+      - {transform: gaussian_blur_025, severity: 1, label: "0.25"}
+      - {transform: gaussian_blur_075, severity: 2, label: "0.75"}
+      - {transform: gaussian_blur_150, severity: 3, label: "1.50"}
+
+profile:
+  model_config: ultralytics/cfg/models/26/yolo26-master-moa-n.yaml
+  router_class: _MoARouter
+
+bootstrap_draws: 10000
+bootstrap_seed: 20260906
+max_evidence_bytes: 67108864
+
+source_fingerprints:
+  ultralytics/nn/modules/moa/router.py: ad753404db8b740c909b38d4f74dc4912527ce931ea76f48609ae7dbeb8f517f
+  ultralytics/cfg/models/26/yolo26-master-moa-n.yaml: 20a57222cd4a51b11b39d51ca959a2d250e46c5e42b4ecf9fe6a9808e3147310

--- a/tools/e3_routing/configs/p2/image_driver.yaml
+++ b/tools/e3_routing/configs/p2/image_driver.yaml
@@ -1,0 +1,19 @@
+run_id: p2i-20260905-image-driver-v1
+require_committed_source: true
+
+parent_run_dir: artifacts/p2/p2s-20260905-coco128-32-v1
+expected_parent_run_id: p2s-20260905-coco128-32-v1
+expected_parent_manifest_sha256: 42d85cb411ef3776bc03b857025dcb77304b5530c4b4b2b4218d0d773d8d45c1
+
+expected_image_count: 32
+expected_seeds: [0, 1, 2]
+candidate_transformations:
+  - brightness_090
+  - contrast_090
+  - gaussian_blur_075
+endpoints:
+  - probability_mae
+  - dominant_switch_fraction
+
+bootstrap_draws: 10000
+bootstrap_seed: 20260905

--- a/tools/e3_routing/configs/p2/image_scale.yaml
+++ b/tools/e3_routing/configs/p2/image_scale.yaml
@@ -1,0 +1,35 @@
+run_id: p2s-20260905-coco128-32-v1
+require_committed_source: true
+
+runtime_root: ../..
+official_locked_base_ref: acce839c7e895d6b179de7f7093fa879e237cc7b
+official_runtime_ref: 7bfbfd374a6b44720f98366e088f3a962e16321d
+official_runtime_tree: cfdc006e9da0f0daa6ead7aa66af742983ea14bc
+
+device: cpu
+family: moa
+target_module: model.16.m.0.router
+seeds: [0, 1, 2]
+dataset: coco128.yaml
+dataset_split: val
+expected_dataset_image_count: 128
+selected_image_count: 32
+selection_salt: e3-p2-coco128-image-v1
+resolution: 128
+transformations:
+  - {name: identity, kind: identity}
+  - {name: brightness_090, kind: brightness, factor: 0.9}
+  - {name: contrast_090, kind: contrast, factor: 0.9}
+  - {name: gaussian_blur_075, kind: gaussian_blur, radius: 0.75}
+
+profile:
+  model_config: ultralytics/cfg/models/26/yolo26-master-moa-n.yaml
+  router_class: _MoARouter
+
+bootstrap_draws: 10000
+bootstrap_seed: 20260905
+max_evidence_bytes: 67108864
+
+source_fingerprints:
+  ultralytics/nn/modules/moa/router.py: ad753404db8b740c909b38d4f74dc4912527ce931ea76f48609ae7dbeb8f517f
+  ultralytics/cfg/models/26/yolo26-master-moa-n.yaml: 20a57222cd4a51b11b39d51ca959a2d250e46c5e42b4ecf9fe6a9808e3147310

--- a/tools/e3_routing/configs/p2/layer_drilldown.yaml
+++ b/tools/e3_routing/configs/p2/layer_drilldown.yaml
@@ -1,0 +1,16 @@
+run_id: p2d-20260905-layer16-attribution-v2
+require_committed_source: true
+
+parent_run_dir: artifacts/p2/p2a-20260905-cpu-appearance-v2
+expected_parent_run_id: p2a-20260905-cpu-appearance-v2
+expected_parent_manifest_sha256: 7df8fbaf1d10d61d268559ff688cc81a67ab5c3e428b8deb45f1ea2904dd5d21
+
+family: moa
+target_module: model.16.m.0.router
+candidate_transformations:
+  - brightness_090
+  - brightness_110
+  - contrast_090
+  - contrast_110
+  - gaussian_blur_075
+margin_bin_count: 10

--- a/tools/e3_routing/configs/p2/output_coupling.yaml
+++ b/tools/e3_routing/configs/p2/output_coupling.yaml
@@ -1,0 +1,37 @@
+run_id: p2o-20260906-output-coupling-v2
+require_committed_source: true
+study_kind: output_coupling
+record_detector_outputs: true
+
+runtime_root: ../..
+official_locked_base_ref: acce839c7e895d6b179de7f7093fa879e237cc7b
+official_runtime_ref: 7bfbfd374a6b44720f98366e088f3a962e16321d
+official_runtime_tree: cfdc006e9da0f0daa6ead7aa66af742983ea14bc
+
+device: cpu
+family: moa
+target_module: model.16.m.0.router
+seeds: [0, 1, 2]
+dataset: coco128.yaml
+dataset_split: val
+expected_dataset_image_count: 128
+selected_image_count: 32
+selection_salt: e3-p2-coco128-image-v1
+resolution: 128
+transformations:
+  - {name: identity, kind: identity}
+  - {name: brightness_080, kind: brightness, factor: 0.8}
+  - {name: contrast_080, kind: contrast, factor: 0.8}
+  - {name: gaussian_blur_150, kind: gaussian_blur, radius: 1.5}
+
+profile:
+  model_config: ultralytics/cfg/models/26/yolo26-master-moa-n.yaml
+  router_class: _MoARouter
+
+bootstrap_draws: 10000
+bootstrap_seed: 20260906
+max_evidence_bytes: 67108864
+
+source_fingerprints:
+  ultralytics/nn/modules/moa/router.py: ad753404db8b740c909b38d4f74dc4912527ce931ea76f48609ae7dbeb8f517f
+  ultralytics/cfg/models/26/yolo26-master-moa-n.yaml: 20a57222cd4a51b11b39d51ca959a2d250e46c5e42b4ecf9fe6a9808e3147310

--- a/tools/e3_routing/configs/p2/p2.yaml
+++ b/tools/e3_routing/configs/p2/p2.yaml
@@ -1,0 +1,54 @@
+run_id: p2-20260904-cpu-five-family-v3
+schema_version: e3.spatial-routing/v1.0.0
+require_committed_source: true
+
+runtime_root: ../..
+official_locked_base_ref: acce839c7e895d6b179de7f7093fa879e237cc7b
+official_runtime_ref: 7bfbfd374a6b44720f98366e088f3a962e16321d
+official_runtime_tree: cfdc006e9da0f0daa6ead7aa66af742983ea14bc
+official_source_archive_url: https://codeload.github.com/Tencent/YOLO-Master/zip/7bfbfd374a6b44720f98366e088f3a962e16321d
+official_source_archive_sha256: null  # live Git checkout is bound by commit/tree; frozen evidence keeps its archive hash
+
+device: cpu
+seed: 0
+dataset: coco8.yaml
+dataset_split: val
+sample_indices: [0, 1, 2, 3]
+image_size: 64
+overlay_alpha: 0.58
+batch_equivalence_sizes: [2, 4]
+
+region_analysis:
+  enabled: true
+  label_format: yolo_detection_normalized_xywh
+  assignment_rule: valid_token_center_inside_any_ground_truth_box
+  exclude_letterbox_padding: true
+
+spatial_profiles:
+  mot:
+    model_config: ultralytics/cfg/models/26/yolo26-master-mot-n.yaml
+    router_class: _MoTRouter
+    expert_labels: [local, window, deformable]
+  moa:
+    model_config: ultralytics/cfg/models/26/yolo26-master-moa-n.yaml
+    router_class: _MoARouter
+    expert_labels: [local, regional, global]
+
+non_spatial_profiles:
+  moe:
+    model_config: ultralytics/cfg/models/26/yolo26-master-n.yaml
+  latent:
+    model_config: ultralytics/cfg/models/26/yolo26-master-latent-n.yaml
+  molora:
+    audit: isolated_official_router_contract
+
+source_fingerprints:
+  ultralytics/nn/modules/mot/router.py: 0fab250d4b472c979e28c76258768ce9c6e414fdc016dd3a29559ddcefd75fc1
+  ultralytics/nn/modules/moa/router.py: ad753404db8b740c909b38d4f74dc4912527ce931ea76f48609ae7dbeb8f517f
+  ultralytics/nn/modules/latent_mixture.py: 7ee5b0516a20709c9bc96b8c966da13447ca527c8cba7c7051f41aaf61f52b51
+  ultralytics/nn/modules/moe/gated.py: 5e73e35fa6c53ee45381b934771585314e68e66fb3e6f66786a6ce68af8f4727
+  ultralytics/nn/peft/molora/router.py: a8c5c924d76b6906bb8e8c44fe35995798741df1db269a931174c908d4c7db4c
+  ultralytics/cfg/models/26/yolo26-master-mot-n.yaml: 739aca4279cd2ae7813f4b0b5a16211efd68c74a1beaacc71d2431101dca6fda
+  ultralytics/cfg/models/26/yolo26-master-moa-n.yaml: 20a57222cd4a51b11b39d51ca959a2d250e46c5e42b4ecf9fe6a9808e3147310
+  ultralytics/cfg/models/26/yolo26-master-n.yaml: 135ae1f18197f42039dbd67d4e6104cd531c7d9d65ede77c8edb4d0afa11a223
+  ultralytics/cfg/models/26/yolo26-master-latent-n.yaml: 08307e7ca5e7aa68cb41f4a39d2eb0901e8cd20a9f3784edd2dd96ab0da11219

--- a/tools/e3_routing/configs/p2/robustness.yaml
+++ b/tools/e3_routing/configs/p2/robustness.yaml
@@ -1,0 +1,30 @@
+run_id: p2r-20260905-cpu-resolution-flip-v4
+require_committed_source: true
+
+runtime_root: ../..
+official_locked_base_ref: acce839c7e895d6b179de7f7093fa879e237cc7b
+official_runtime_ref: 7bfbfd374a6b44720f98366e088f3a962e16321d
+official_runtime_tree: cfdc006e9da0f0daa6ead7aa66af742983ea14bc
+
+device: cpu
+seeds: [0, 1, 2]
+dataset: coco8.yaml
+dataset_split: val
+sample_indices: [0, 1, 2, 3]
+resolutions: [64, 128, 256]
+reference_resolution: 64
+transformations: [identity, horizontal_flip]
+
+spatial_profiles:
+  mot:
+    model_config: ultralytics/cfg/models/26/yolo26-master-mot-n.yaml
+    router_class: _MoTRouter
+  moa:
+    model_config: ultralytics/cfg/models/26/yolo26-master-moa-n.yaml
+    router_class: _MoARouter
+
+source_fingerprints:
+  ultralytics/nn/modules/mot/router.py: 0fab250d4b472c979e28c76258768ce9c6e414fdc016dd3a29559ddcefd75fc1
+  ultralytics/nn/modules/moa/router.py: ad753404db8b740c909b38d4f74dc4912527ce931ea76f48609ae7dbeb8f517f
+  ultralytics/cfg/models/26/yolo26-master-mot-n.yaml: 739aca4279cd2ae7813f4b0b5a16211efd68c74a1beaacc71d2431101dca6fda
+  ultralytics/cfg/models/26/yolo26-master-moa-n.yaml: 20a57222cd4a51b11b39d51ca959a2d250e46c5e42b4ecf9fe6a9808e3147310

--- a/tools/e3_routing/docs/LATEST_MAIN_VERIFICATION.md
+++ b/tools/e3_routing/docs/LATEST_MAIN_VERIFICATION.md
@@ -1,0 +1,36 @@
+# Latest-main compatibility verification
+
+## Source identity
+
+- Upstream commit: `7bfbfd374a6b44720f98366e088f3a962e16321d`
+- Upstream tree: `cfdc006e9da0f0daa6ead7aa66af742983ea14bc`
+- Live-checkout identity: Git commit/tree plus critical-file SHA-256; no codeload hash is claimed for this refresh.
+- The refresh is 30 commits ahead of `3bd0a602...`; 74 paths changed.
+- The nine P2-pinned router/model files are byte-identical to the formal `07d3303` runtime.
+- Of the changed paths, only `ultralytics/nn/modules/mot/block.py` is in the E3 routing execution area; the change
+  replaces tuple-dimension `Tensor.any` with a Torch 1.8-compatible equivalent and does not alter the router contract.
+- `ultralytics/engine/trainer.py` changed; the active P1 engine config was refreshed to SHA256
+  `d1aa2e8d56371e24014cd934d83b86eccef57d086038b0b365def40ef5c3c7a9`.
+
+## Checks run on the latest-main contribution checkout
+
+| Gate | Result |
+| --- | --- |
+| Combined phase and CLI-contract tests | 113 passed |
+| Ruff on `src`, `tests`, `scripts` | PASS |
+| Upstream default-config and master-model tests | 13 passed, one expected MoA head-adjustment warning |
+| Five-family real-forward smoke | PASS; P0 modules 6/4/3; MoT/MoA spatial modules 4/4; hook delta 0 |
+| Full P0 | PASS; 52 primary + 52 repeat events; batch 2/4 max load delta 0 |
+| P1 dashboard over latest-main P0 events | PASS; HTTP 200; 52 events; three families |
+| Full P2 committed-source release gate | PASS; five families; 32 spatial captures; 240 arrays; 192 demo views |
+
+A preliminary codeload compatibility run used a local-only config with `require_committed_source=false`, because a
+ZIP archive has no Git metadata. The final release gate then ran full P2 from the contribution branch with the active
+`require_committed_source=true` configuration. It passed with a clean committed implementation and all 9 source
+fingerprints matched; every data, spatial, equivalence, geometry and manifest gate remained enabled.
+
+## Correct interpretation
+
+This verification establishes compatibility with the named upstream commit. It does not relabel the larger formal
+P1/P2 numerical experiments, which remain attached to the frozen runtime and their original manifests. Rebase and
+rerun this compatibility gate if upstream main moves again before the PR is opened.

--- a/tools/e3_routing/docs/P0.md
+++ b/tools/e3_routing/docs/P0.md
@@ -1,0 +1,38 @@
+# P0: unified routing schema and static evidence
+
+## Design
+
+P0 observes real routed modules through removable forward hooks and normalizes MoE, MoT and Latent outputs into
+`e3.routing/v1.0.0`. Leaf-level discovery avoids counting both a wrapper and its routed child. Adapters preserve
+the source snapshot, distinguish observed, derived and unavailable values, and never replace model outputs.
+
+The common event contract reports expert load, entropy in nats, normalized entropy, load Gini, dominant-expert
+share, mixing-weight availability, auxiliary-loss availability and run/sample context. This unifies telemetry
+without pretending that the three routing mechanisms have identical semantics.
+
+## Acceptance evidence
+
+The formal CPU/coco8 run used all four validation images and covered six MoE, four MoT and three Latent modules.
+It produced 52 schema-valid primary events and an independently reconstructed 52-event repeat. All 52 stable
+fingerprints matched. Rebatching the same inputs at batch sizes 2 and 4 changed aggregate expert load by at most
+`0`, against a preregistered tolerance of `1e-5`.
+
+| Check | Result |
+| --- | ---: |
+| Routed families | 3 |
+| Routed modules | 13 |
+| Primary events | 52 |
+| Repeat matches | 52 / 52 |
+| Batch 2/4 max load delta | 0 |
+| P0 tests | 16 passed |
+
+## Reproduce
+
+From `tools/e3_routing`, run P0 with `configs/p0/p0.yaml`. The runner refuses to overwrite a non-empty evidence
+directory and writes resolved configuration, input hashes, raw JSONL, aggregate statistics, repeat and batch
+comparisons, plots, environment metadata, logs and a SHA-256 manifest under ignored `artifacts/p0/`.
+
+## Boundary
+
+The run uses randomly initialized models on a small CPU dataset. It validates collection, normalization,
+repeatability and batching behavior; it does not claim trained routing quality or model accuracy.

--- a/tools/e3_routing/docs/P1.md
+++ b/tools/e3_routing/docs/P1.md
@@ -1,0 +1,39 @@
+# P1: live dashboard and measured observer overhead
+
+## Design
+
+P1 consumes the P0 JSONL contract through a read-only dashboard bound to `127.0.0.1`. The API exposes the valid
+source count, active window size and truncation state, tolerates only an incomplete final line during concurrent
+writes, and fails on earlier corruption. It displays family, module, entropy, Gini, dominant share and recent
+events for MoE, MoT and Latent.
+
+The formal overhead gate compares three initially identical trajectories: capture off, capture in memory, and
+capture plus JSONL write/flush. Each timed full step includes real detection loss, backward, gradient clipping,
+grouped SGD and the requested observer work. Six condition permutations balance order effects. Loss components,
+gradients, model state and optimizer state must remain equivalent.
+
+## Acceptance evidence
+
+| Family | Formal pairs | Median slowdown | 95% bootstrap CI | Verdict |
+| --- | ---: | ---: | ---: | --- |
+| MoE | 30 | 2.113% | [-2.514%, 8.361%] | PASS / STRONG |
+| MoT | 48 | -0.050% | [-6.374%, 9.451%] | PASS / STRONG |
+| Latent | 30 | -5.741% | [-16.195%, 1.570%] | PASS / STRONG |
+
+All three medians and all 95% confidence-interval upper bounds are below the 10% gate. The 108 formal pairs kept
+loss, gradients, model state and optimizer state equivalent. Negative estimates are treated as CPU scheduling
+noise, not observer speedups. A separate official `DetectionTrainer` integration cross-check produced 1,040
+events and an HTTP 200 dashboard response; its short epoch timing is descriptive and does not replace the formal
+verdict.
+
+## Current-main source policy
+
+Frozen evidence uses an exact source identity. The active integration configuration uses an explicit
+`base_ancestor` policy: the recorded upstream commit must be an ancestor of the contribution branch, while every
+runtime input file must still match its pinned SHA-256. This permits an honest tool commit on top of upstream
+without weakening the runtime-file gate.
+
+## Boundary
+
+The verdict is specific to CPU, coco8, image size 64 and the registered full-step protocol. It is not a GPU or
+large-dataset throughput claim.

--- a/tools/e3_routing/docs/P2.md
+++ b/tools/e3_routing/docs/P2.md
@@ -1,0 +1,38 @@
+# P2: truthful spatial routing lens
+
+## Design
+
+P2 captures router-child outputs before public block snapshots average away spatial axes. A family is eligible for
+an original-image overlay only when the observed tensor is a finite, normalized `[B,E,H,W]` probability grid with
+valid logits and, where applicable, aligned Top-K indices. Exact letterbox geometry is recorded and reversed before
+mapping fixed-scale probability, entropy, margin and dominant-expert views onto the archived original image.
+
+The feasibility audit finds true spatial contracts for MoT and MoA. MoE, Latent and MoLoRA are reported as
+`UNSUPPORTED` because the observed tensors expose sample/expert decisions or singleton spatial axes. The tool never
+reshapes these vectors into visually plausible but semantically false token heatmaps.
+
+## Acceptance evidence
+
+| Check | Result |
+| --- | ---: |
+| Families audited | 5 |
+| Spatially supported | MoT, MoA |
+| Spatial captures | 32 |
+| Raw arrays | 240 |
+| Selectable demo views | 192 |
+| Hooked/unhooked output max delta | 0 |
+| Batch 2/4 probability max delta | 0 |
+| Maximum MoA logit delta | `1.24e-10` |
+| P2 tests | 73 passed |
+
+The extended analysis covers 32 images, three seeds and three perturbation families at three strengths. It retains
+a preregistered controlled null result instead of overstating random-initialization patterns. The static demo uses
+archived assets only, binds to localhost, exposes feasibility decisions and metadata, and supports paired original
+and overlay export. The included real-UI video is 1:55.
+
+[Open the manifest-bound P2 overview in the evidence repository](https://github.com/Ricky-7-Yan/YOLO-Master-E3-P2/blob/main/artifacts/p2/p2-20260904-cpu-region-analysis-v7/routing-overview.png)
+
+## Boundary
+
+The evidence validates coordinate correctness, capture semantics, determinism, batch identity and diagnostic
+behavior. It does not establish learned semantic specialization or causal effects on detector predictions.

--- a/tools/e3_routing/docs/REPRODUCIBILITY.md
+++ b/tools/e3_routing/docs/REPRODUCIBILITY.md
@@ -1,0 +1,37 @@
+# Reproducibility and version policy
+
+## Two gates, two meanings
+
+The configurations under `configs/frozen/` are frozen to YOLO-Master commit
+`07d330325b5a26b75aabfc75389f9bcbc0d40245` and archive SHA256
+`774abaa264028f1aca4b6d14c3db249f8a75bc253b4131c272f6dc8a8c744c49`. Their numerical results must not be
+silently relabelled as results from another source revision.
+
+The independent `scripts/latest_main_smoke.py` gate answers a different question: whether the contribution still
+loads the current repository models, preserves outputs and observes the same spatial/non-spatial contracts. Its
+output records the actual source commit and tree. Run it again after every rebase.
+
+## Formal reproduction
+
+The original phase repositories preserve resolved configs, logs, inputs, raw events, reports and manifests. To
+reproduce the archived numbers, use `configs/frozen/`, place the frozen source at the configured `runtime_root`,
+or update only that path to an independently verified checkout of the same commit. Do not change the reference,
+tree or source fingerprints. The phase-level active configs target the containing current-main checkout instead.
+
+## Latest-main gate
+
+From the repository root:
+
+```bat
+cd tools\e3_routing
+set PYTHONPATH=%CD%\src
+python scripts\latest_main_smoke.py --repo-root ..\.. --output artifacts\latest-main-smoke.json
+```
+
+PASS requires:
+
+1. real forward evidence for MoE, MoT and Latent P0 telemetry;
+2. unchanged hooked model outputs;
+3. valid `[B,E,H,W]` records for MoT and MoA;
+4. explicit non-spatial decisions for MoE, Latent and MoLoRA;
+5. recorded current commit and tree.

--- a/tools/e3_routing/docs/RESULTS.md
+++ b/tools/e3_routing/docs/RESULTS.md
@@ -1,0 +1,44 @@
+# E3 result summary
+
+## P0 — unified structured routing events
+
+The formal four-image coco8 validation run covered six MoE, four MoT and three Latent modules. It emitted 52
+schema-valid events; an independent repeat matched all 52 stable fingerprints. Batch sizes 2 and 4 produced a
+maximum aggregate expert-load difference of 0 relative to batch size 1. These checks establish telemetry and
+aggregation correctness, not learned routing quality.
+
+## P1 — live view and overhead
+
+| Family | Pairs | Median slowdown | 95% bootstrap CI | Result |
+| --- | ---: | ---: | ---: | --- |
+| MoE | 30 | 2.113% | [-2.514%, 8.361%] | PASS / STRONG |
+| MoT | 48 | -0.050% | [-6.374%, 9.451%] | PASS / STRONG |
+| Latent | 30 | -5.741% | [-16.195%, 1.570%] | PASS / STRONG |
+
+All medians and CI upper bounds are below the 10% gate. The 108 pairs include detection loss, backward, gradient
+clipping, grouped SGD and JSONL write/flush; loss, gradients, model state and optimizer state remain equivalent.
+The separate Trainer integration layer produced 1,040 events and HTTP 200, but its very short CPU epoch timing is
+explicitly descriptive rather than verdict-eligible.
+
+## P2 — truthful spatial routing lens
+
+The five-family audit supports original-image overlays only for MoT and MoA. The primary run generated 32 true
+spatial captures, 240 raw arrays and 192 selectable views. Hooks changed model output by 0; single-versus-batch
+probabilities differed by 0 and the maximum logit difference was `1.24e-10`.
+
+The extended evidence covers 32 images and three seeds. Three perturbation families at three strengths generated
+3,840 captures; seed-averaged probability response was non-decreasing for 32/32 images in every family. Held-middle
+span-normalized median errors were 0.115% for brightness, 0.161% for contrast and 2.647% for blur. A preregistered
+blur follow-up found no Holm-significant association for content fraction, luminance or edge total variation; the
+smallest adjusted p-value was 0.318. This is retained as a controlled null result.
+
+## Integrity summary
+
+- Tests: P0 16, P1 19, P2 73; 108 total, all passing in the phase repositories.
+- Formal manifests: seven key runs, 395 entries, independently recomputed with zero mismatch.
+- Combined contribution suite: 113 tests, all passing.
+- Demo video prepared for PR attachment: 1:55, SHA256
+  `6a686af4f3d2e307a8c4b08d862c80da29a2dceab364988df670692a36e4149f`.
+- Latest-main compatibility: upstream `7bfbfd374a6b44720f98366e088f3a962e16321d`; five-family smoke PASS;
+  full P0 52/52 replay and batch gate PASS; full P2 32 captures/192 demo views PASS; 13 upstream model/config
+  regression tests PASS.

--- a/tools/e3_routing/pyproject.toml
+++ b/tools/e3_routing/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "yolo-master-e3-routing-tools"
+version = "1.0.0"
+description = "Unified routing telemetry, live monitoring, and truthful spatial overlays for YOLO-Master"
+requires-python = ">=3.9"
+dependencies = [
+  "jsonschema>=4.18",
+  "matplotlib>=3.5",
+  "numpy>=1.23",
+  "Pillow>=9.0",
+  "PyYAML>=6.0",
+]
+
+[project.optional-dependencies]
+test = ["pytest>=7.0", "ruff>=0.5"]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+testpaths = ["tests"]
+pythonpath = ["src"]
+
+[tool.ruff]
+line-length = 120
+target-version = "py39"

--- a/tools/e3_routing/run_smoke.cmd
+++ b/tools/e3_routing/run_smoke.cmd
@@ -1,0 +1,8 @@
+@echo off
+setlocal
+cd /d "%~dp0"
+set "PYTHONUTF8=1"
+set "PYTHONIOENCODING=utf-8"
+set "PYTHONPATH=%~dp0src;%PYTHONPATH%"
+python scripts\latest_main_smoke.py --repo-root "%~dp0..\.." %*
+exit /b %ERRORLEVEL%

--- a/tools/e3_routing/run_tests.cmd
+++ b/tools/e3_routing/run_tests.cmd
@@ -1,0 +1,10 @@
+@echo off
+setlocal
+cd /d "%~dp0"
+set "PYTHONUTF8=1"
+set "PYTHONIOENCODING=utf-8"
+set "PYTHONPATH=%~dp0src;%PYTHONPATH%"
+python -m pytest tests -q
+if errorlevel 1 exit /b %ERRORLEVEL%
+python -m ruff check src tests scripts
+exit /b %ERRORLEVEL%

--- a/tools/e3_routing/schemas/routing-event.schema.json
+++ b/tools/e3_routing/schemas/routing-event.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Ricky-7-Yan/YOLO-Master-E3-P0/schemas/routing-event.schema.json",
+  "title": "YOLO-Master E3 unified routing event",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "run_id", "sequence", "captured_at", "family", "module", "routing", "aux_loss", "runtime", "provenance", "source_snapshot"],
+  "properties": {
+    "schema_version": {"const": "e3.routing/v1.0.0"},
+    "run_id": {"type": "string", "minLength": 1},
+    "sequence": {"type": "integer", "minimum": 0},
+    "captured_at": {"type": "string"},
+    "family": {"enum": ["moe", "mot", "latent"]},
+    "module": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "type", "python_module"],
+      "properties": {
+        "name": {"type": "string"},
+        "type": {"type": "string"},
+        "python_module": {"type": "string"}
+      }
+    },
+    "routing": {
+      "type": "object",
+      "required": ["num_experts", "top_k", "granularity", "expert_load", "expert_load_sum", "entropy_nats", "entropy_normalized", "load_gini", "dominant_expert_share", "mixing_weights"],
+      "properties": {
+        "num_experts": {"type": "integer", "minimum": 1},
+        "top_k": {"type": "integer", "minimum": 1},
+        "granularity": {"type": "string"},
+        "expert_load": {"type": "array", "minItems": 1, "items": {"type": "number", "minimum": 0}},
+        "expert_load_sum": {"type": "number", "minimum": 0.999999, "maximum": 1.000001},
+        "entropy_nats": {"type": "number", "minimum": 0},
+        "entropy_normalized": {"type": "number", "minimum": 0, "maximum": 1.000001},
+        "load_gini": {"type": "number", "minimum": 0, "maximum": 1},
+        "dominant_expert_share": {"type": "number", "minimum": 0, "maximum": 1},
+        "mixing_weights": {"$ref": "#/$defs/observedField"}
+      }
+    },
+    "aux_loss": {
+      "allOf": [{"$ref": "#/$defs/observedField"}],
+      "properties": {
+        "finite": {"type": ["boolean", "null"]},
+        "mode": {"const": "eval_observation"}
+      },
+      "required": ["finite", "mode"]
+    },
+    "runtime": {"type": "object"},
+    "provenance": {"type": "object"},
+    "source_snapshot": {"type": "object"}
+  },
+  "$defs": {
+    "observedField": {
+      "type": "object",
+      "required": ["state", "source", "value"],
+      "properties": {
+        "state": {"enum": ["observed", "derived", "unavailable"]},
+        "source": {"type": ["string", "null"]},
+        "value": {}
+      }
+    }
+  }
+}

--- a/tools/e3_routing/scripts/latest_main_smoke.py
+++ b/tools/e3_routing/scripts/latest_main_smoke.py
@@ -1,0 +1,158 @@
+"""Run a small five-family compatibility gate against the containing YOLO-Master checkout."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+TOOL_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _git_value(root: Path, *args: str) -> str | None:
+    result = subprocess.run(
+        ["git", "-C", str(root), *args], capture_output=True, check=False, text=True, encoding="utf-8"
+    )
+    return result.stdout.strip() or None if result.returncode == 0 else None
+
+
+def _tensor_shapes(records: list[Any]) -> list[list[int]]:
+    return sorted({tuple(int(item) for item in record.weights.shape) for record in records})
+
+
+def _source_identity(root: Path) -> tuple[str | None, str]:
+    commit = _git_value(root, "rev-parse", "HEAD")
+    if commit:
+        return commit, "git"
+    match = re.search(r"-([0-9a-f]{40})$", root.name)
+    return (match.group(1), "codeload-directory") if match else (None, "unresolved")
+
+
+def run(repo_root: Path, image_size: int, seed: int) -> dict[str, Any]:
+    """Execute P0 telemetry plus the P2 spatial/non-spatial contract on one deterministic input."""
+
+    repo_root = repo_root.resolve()
+    if not (repo_root / "ultralytics").is_dir():
+        raise FileNotFoundError(f"YOLO-Master checkout not found: {repo_root}")
+    sys.path.insert(0, str(TOOL_ROOT / "src"))
+    sys.path.insert(0, str(repo_root))
+
+    import torch
+    from ultralytics import YOLO
+
+    from e3_p0.collector import RoutingCollector
+    from e3_p2.capture import SpatialRouterCollector, max_output_delta
+    from e3_p2.runner import _audit_latent, _audit_moe, _audit_molora
+
+    torch.manual_seed(seed)
+    torch.set_num_threads(1)
+    tensor = torch.linspace(-1.0, 1.0, steps=3 * image_size * image_size).reshape(1, 3, image_size, image_size)
+    model_configs = {
+        "moe": "ultralytics/cfg/models/26/yolo26-master-n.yaml",
+        "mot": "ultralytics/cfg/models/26/yolo26-master-mot-n.yaml",
+        "latent": "ultralytics/cfg/models/26/yolo26-master-latent-n.yaml",
+        "moa": "ultralytics/cfg/models/26/yolo26-master-moa-n.yaml",
+    }
+
+    p0: dict[str, Any] = {}
+    for family in ("moe", "mot", "latent"):
+        wrapper = YOLO(repo_root / model_configs[family])
+        model = wrapper.model.eval()
+        with torch.inference_mode():
+            reference = model(tensor)
+        collector = RoutingCollector(family=family, run_id="latest-main-smoke")
+        collector.set_context(phase="compatibility", batch_size=1, sample_indices=[0])
+        names = collector.register(model)
+        try:
+            with torch.inference_mode():
+                observed = model(tensor)
+        finally:
+            collector.remove()
+        delta = max_output_delta(reference, observed)
+        if not names or not collector.events:
+            raise RuntimeError(f"{family} produced no routed telemetry")
+        if delta > 1e-8:
+            raise RuntimeError(f"{family} observer changed model output: {delta}")
+        p0[family] = {"modules": len(names), "events": len(collector.events), "hook_output_delta": delta}
+        del model, wrapper
+
+    spatial: dict[str, Any] = {}
+    for family, router_class in (("mot", "_MoTRouter"), ("moa", "_MoARouter")):
+        wrapper = YOLO(repo_root / model_configs[family])
+        model = wrapper.model.eval()
+        with torch.inference_mode():
+            reference = model(tensor)
+        collector = SpatialRouterCollector(family=family, router_class=router_class)
+        names = collector.register(model)
+        try:
+            with torch.inference_mode():
+                observed = model(tensor)
+        finally:
+            collector.remove()
+        delta = max_output_delta(reference, observed)
+        if not collector.records:
+            raise RuntimeError(f"{family} produced no spatial routing records")
+        if delta > 1e-8:
+            raise RuntimeError(f"{family} spatial hook changed model output: {delta}")
+        spatial[family] = {
+            "modules": len(names),
+            "records": len(collector.records),
+            "weight_shapes": _tensor_shapes(collector.records),
+            "hook_output_delta": delta,
+        }
+        del model, wrapper
+
+    unsupported = {
+        "moe": _audit_moe(repo_root, tensor, torch, YOLO),
+        "latent": _audit_latent(repo_root, tensor, torch, YOLO),
+        "molora": _audit_molora(torch),
+    }
+    if any(item["status"] != "UNSUPPORTED" for item in unsupported.values()):
+        raise RuntimeError("non-spatial family contract changed")
+
+    source_commit, source_identity_mode = _source_identity(repo_root)
+    return {
+        "status": "PASS",
+        "repo_root": str(repo_root),
+        "source_commit": source_commit,
+        "source_tree": _git_value(repo_root, "rev-parse", "HEAD^{tree}"),
+        "source_identity_mode": source_identity_mode,
+        "image_size": image_size,
+        "seed": seed,
+        "p0": p0,
+        "p2_spatial": spatial,
+        "p2_explicit_unsupported": {
+            family: {
+                "status": item["status"],
+                "evidence_kind": item["evidence_kind"],
+                "spatial_shape_count": item["spatial_shape_count"],
+            }
+            for family, item in unsupported.items()
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[3])
+    parser.add_argument("--image-size", type=int, default=64)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    if args.image_size < 32:
+        parser.error("--image-size must be >= 32")
+    result = run(args.repo_root, args.image_size, args.seed)
+    payload = json.dumps(result, indent=2, ensure_ascii=False)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload + "\n", encoding="utf-8")
+    print(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/e3_routing/src/e3_p0/__init__.py
+++ b/tools/e3_routing/src/e3_p0/__init__.py
@@ -1,0 +1,12 @@
+"""E3 P0 unified routing diagnostics."""
+
+from .adapters import SCHEMA_VERSION, adapt_snapshot, routing_metrics
+from .collector import RoutingCollector, discover_routed_modules
+
+__all__ = (
+    "SCHEMA_VERSION",
+    "RoutingCollector",
+    "adapt_snapshot",
+    "discover_routed_modules",
+    "routing_metrics",
+)

--- a/tools/e3_routing/src/e3_p0/__main__.py
+++ b/tools/e3_routing/src/e3_p0/__main__.py
@@ -1,0 +1,6 @@
+"""Command-line entry point."""
+
+from .runner import parse_args, run
+
+args = parse_args()
+run(args.config.resolve(), run_id=args.run_id, update_latest=not args.no_update_latest)

--- a/tools/e3_routing/src/e3_p0/adapters.py
+++ b/tools/e3_routing/src/e3_p0/adapters.py
@@ -1,0 +1,163 @@
+"""Normalize heterogeneous YOLO-Master routing snapshots into one schema."""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime
+from typing import Any
+
+import numpy as np
+
+SCHEMA_VERSION = "e3.routing/v1.0.0"
+ADAPTER_VERSION = "0.1.0"
+SUPPORTED_FAMILIES = frozenset({"moe", "mot", "latent"})
+
+
+def to_jsonable(value: Any) -> Any:
+    """Detach tensor-like values and recursively convert them to JSON values."""
+
+    if hasattr(value, "detach") and hasattr(value, "cpu"):
+        value = value.detach().cpu()
+        if getattr(value, "ndim", 0) == 0:
+            return value.item()
+        return value.tolist()
+    if isinstance(value, dict):
+        return {str(key): to_jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [to_jsonable(item) for item in value]
+    if isinstance(value, (np.floating, np.integer)):
+        return value.item()
+    return value
+
+
+def _finite_vector(value: Any) -> np.ndarray:
+    vector = np.asarray(to_jsonable(value), dtype=np.float64).reshape(-1)
+    return np.nan_to_num(vector, nan=0.0, posinf=0.0, neginf=0.0)
+
+
+def routing_metrics(expert_usage: Any) -> dict[str, Any]:
+    """Compute normalized load, entropy and concentration from expert usage."""
+
+    usage = np.clip(_finite_vector(expert_usage), 0.0, None)
+    total = float(usage.sum())
+    load = usage / total if total > 0.0 else np.zeros_like(usage)
+    positive = load[load > 0.0]
+    entropy = float(-(positive * np.log(positive)).sum()) if positive.size else 0.0
+    max_entropy = math.log(load.size) if load.size > 1 else 0.0
+    normalized_entropy = entropy / max_entropy if max_entropy > 0.0 else 0.0
+    if total > 0.0 and usage.size:
+        ordered = np.sort(usage)
+        index = np.arange(1, ordered.size + 1, dtype=np.float64)
+        gini = 2.0 * np.sum(index * ordered) / (ordered.size * ordered.sum())
+        gini -= (ordered.size + 1.0) / ordered.size
+        gini = float(np.clip(gini, 0.0, 1.0))
+    else:
+        gini = 0.0
+    return {
+        "expert_load": load.tolist(),
+        "expert_load_sum": float(load.sum()),
+        "entropy_nats": entropy,
+        "entropy_normalized": normalized_entropy,
+        "load_gini": gini,
+        "dominant_expert_share": float(load.max()) if load.size else 0.0,
+    }
+
+
+def _field_state(snapshot: dict[str, Any], names: tuple[str, ...], *, fallback: Any = None) -> dict[str, Any]:
+    for name in names:
+        if name in snapshot and snapshot[name] is not None:
+            return {"state": "observed", "source": name, "value": to_jsonable(snapshot[name])}
+    if fallback is not None:
+        return {"state": "derived", "source": "expert_load", "value": to_jsonable(fallback)}
+    return {"state": "unavailable", "source": None, "value": None}
+
+
+def infer_family(module: Any) -> str | None:
+    """Infer one supported family from module metadata without class-name allowlists."""
+
+    declared = str(getattr(module, "_routing_aux_kind", "")).lower()
+    module_path = module.__class__.__module__.lower()
+    class_name = module.__class__.__name__.lower()
+    if declared in SUPPORTED_FAMILIES:
+        return declared
+    if "latent_mixture" in module_path or "latent" in class_name:
+        return "latent"
+    if ".mot." in module_path or class_name.endswith("mot") or "motblock" in class_name:
+        return "mot"
+    if ".moe." in module_path or "moe" in class_name:
+        return "moe"
+    return None
+
+
+def adapt_snapshot(
+    *,
+    family: str,
+    run_id: str,
+    sequence: int,
+    module_name: str,
+    module: Any,
+    snapshot: dict[str, Any],
+    input_shape: list[int] | None,
+    output_shapes: list[list[int]],
+    runtime_context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Create one schema-valid event from a detached source snapshot."""
+
+    if family not in SUPPORTED_FAMILIES:
+        raise ValueError(f"Unsupported routing family: {family}")
+    usage_source = "expert_usage" if snapshot.get("expert_usage") is not None else "mean_router_probs"
+    usage = snapshot.get(usage_source)
+    if usage is None:
+        raise ValueError(f"{module_name} snapshot has no expert usage vector")
+    metrics = routing_metrics(usage)
+    num_experts = int(snapshot.get("num_experts", getattr(module, "num_experts", len(metrics["expert_load"]))))
+    top_k = int(snapshot.get("top_k", getattr(module, "top_k", 0)))
+    if num_experts != len(metrics["expert_load"]):
+        raise ValueError(
+            f"{module_name} num_experts={num_experts} differs from load length={len(metrics['expert_load'])}"
+        )
+    mixing = _field_state(snapshot, ("mean_topk_weight", "mean_router_probs", "value_fusion_weights"), fallback=metrics["expert_load"])
+    aux = _field_state(snapshot, ("aux_loss",))
+    aux_value = aux["value"]
+    aux_number = float(aux_value) if isinstance(aux_value, (int, float)) else None
+    aux.update(finite=math.isfinite(aux_number) if aux_number is not None else None, mode="eval_observation")
+    granularity = {
+        "moe": "module-defined token/spatial routing",
+        "mot": "spatial-token routing",
+        "latent": str(snapshot.get("routing_axis", "image/scale routing")),
+    }[family]
+    runtime = {
+        "training": bool(getattr(module, "training", False)),
+        "input_shape": input_shape,
+        "output_shapes": output_shapes,
+    }
+    if runtime_context:
+        runtime.update(to_jsonable(runtime_context))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "sequence": int(sequence),
+        "captured_at": datetime.now().astimezone().isoformat(timespec="seconds"),
+        "family": family,
+        "module": {
+            "name": module_name,
+            "type": module.__class__.__name__,
+            "python_module": module.__class__.__module__,
+        },
+        "routing": {
+            "num_experts": num_experts,
+            "top_k": top_k,
+            "granularity": granularity,
+            **metrics,
+            "mixing_weights": mixing,
+        },
+        "aux_loss": aux,
+        "runtime": runtime,
+        "provenance": {
+            "adapter_version": ADAPTER_VERSION,
+            "selection_policy": "leaf_routed_modules",
+            "usage_source": usage_source,
+            "source_snapshot_keys": sorted(snapshot),
+        },
+        "source_snapshot": to_jsonable(snapshot),
+    }

--- a/tools/e3_routing/src/e3_p0/aggregation.py
+++ b/tools/e3_routing/src/e3_p0/aggregation.py
@@ -1,0 +1,161 @@
+"""Dataset-level aggregation and reproducibility checks for routing events."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import defaultdict
+from typing import Any
+
+import numpy as np
+
+from .adapters import routing_metrics
+
+
+def _event_weight(event: dict[str, Any]) -> float:
+    runtime = event.get("runtime", {})
+    batch_size = runtime.get("batch_size")
+    if batch_size is None:
+        shape = runtime.get("input_shape") or []
+        batch_size = shape[0] if shape else 1
+    return float(batch_size)
+
+
+def aggregate_events(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Aggregate per-forward loads by family/module with batch-size weighting."""
+
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for event in events:
+        grouped[(event["family"], event["module"]["name"])].append(event)
+
+    aggregates = []
+    for (family, module_name), group in sorted(grouped.items()):
+        loads = np.asarray([event["routing"]["expert_load"] for event in group], dtype=np.float64)
+        weights = np.asarray([_event_weight(event) for event in group], dtype=np.float64)
+        mean_load = np.average(loads, axis=0, weights=weights)
+        variance = np.average((loads - mean_load) ** 2, axis=0, weights=weights)
+        metrics = routing_metrics(mean_load)
+        metric_stats = {}
+        for name in ("entropy_normalized", "load_gini", "dominant_expert_share"):
+            values = np.asarray([event["routing"][name] for event in group], dtype=np.float64)
+            metric_stats[name] = {
+                "mean": float(np.average(values, weights=weights)),
+                "std": float(np.sqrt(np.average((values - np.average(values, weights=weights)) ** 2, weights=weights))),
+                "min": float(values.min()),
+                "max": float(values.max()),
+            }
+        aggregates.append(
+            {
+                "family": family,
+                "module": module_name,
+                "num_experts": len(mean_load),
+                "forward_observations": len(group),
+                "sample_observations": int(weights.sum()),
+                "expert_load_mean": mean_load.tolist(),
+                "expert_load_std": np.sqrt(variance).tolist(),
+                "aggregate_metrics": metrics,
+                "per_forward_metric_stats": metric_stats,
+                "mixing_weight_states": sorted({event["routing"]["mixing_weights"]["state"] for event in group}),
+                "aux_loss_states": sorted({event["aux_loss"]["state"] for event in group}),
+            }
+        )
+    return aggregates
+
+
+def _stable_payload(event: dict[str, Any]) -> dict[str, Any]:
+    runtime = dict(event.get("runtime", {}))
+    runtime.pop("pass_name", None)
+    return {
+        "family": event["family"],
+        "module": event["module"],
+        "routing": event["routing"],
+        "aux_loss": event["aux_loss"],
+        "runtime": runtime,
+        "provenance": event["provenance"],
+        "source_snapshot": event["source_snapshot"],
+    }
+
+
+def event_fingerprint(event: dict[str, Any]) -> str:
+    """Hash deterministic event content while excluding run/time/sequence metadata."""
+
+    encoded = json.dumps(_stable_payload(event), sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def compare_repeated_runs(reference: list[dict[str, Any]], repeated: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compare two same-order passes using canonical event fingerprints."""
+
+    if len(reference) != len(repeated):
+        return {
+            "status": "FAIL",
+            "reference_events": len(reference),
+            "repeated_events": len(repeated),
+            "matching_events": 0,
+            "mismatches": [{"reason": "event_count_mismatch"}],
+        }
+    mismatches = []
+    for index, (left, right) in enumerate(zip(reference, repeated)):
+        left_hash = event_fingerprint(left)
+        right_hash = event_fingerprint(right)
+        if left_hash != right_hash:
+            mismatches.append(
+                {
+                    "index": index,
+                    "family": left["family"],
+                    "module": left["module"]["name"],
+                    "sample_indices": left.get("runtime", {}).get("sample_indices"),
+                    "reference_sha256": left_hash,
+                    "repeated_sha256": right_hash,
+                }
+            )
+    return {
+        "status": "PASS" if not mismatches else "FAIL",
+        "reference_events": len(reference),
+        "repeated_events": len(repeated),
+        "matching_events": len(reference) - len(mismatches),
+        "mismatches": mismatches,
+    }
+
+
+def compare_batch_aggregates(
+    reference: list[dict[str, Any]],
+    candidate: list[dict[str, Any]],
+    *,
+    candidate_batch_size: int,
+    tolerance: float,
+) -> dict[str, Any]:
+    """Compare module-level mean expert loads against the batch=1 reference."""
+
+    left = {(item["family"], item["module"]): item for item in aggregate_events(reference)}
+    right = {(item["family"], item["module"]): item for item in aggregate_events(candidate)}
+    rows = []
+    for key in sorted(left):
+        if key not in right:
+            rows.append({"family": key[0], "module": key[1], "status": "MISSING", "max_abs_load_delta": None})
+            continue
+        left_load = np.asarray(left[key]["expert_load_mean"], dtype=np.float64)
+        right_load = np.asarray(right[key]["expert_load_mean"], dtype=np.float64)
+        delta = float(np.max(np.abs(left_load - right_load)))
+        rows.append(
+            {
+                "family": key[0],
+                "module": key[1],
+                "status": "PASS" if delta <= tolerance else "FAIL",
+                "max_abs_load_delta": delta,
+            }
+        )
+    missing_reference = sorted(set(right).difference(left))
+    rows.extend(
+        {"family": family, "module": module, "status": "UNEXPECTED", "max_abs_load_delta": None}
+        for family, module in missing_reference
+    )
+    numeric = [row["max_abs_load_delta"] for row in rows if row["max_abs_load_delta"] is not None]
+    return {
+        "status": "PASS" if rows and all(row["status"] == "PASS" for row in rows) else "FAIL",
+        "reference_batch_size": 1,
+        "candidate_batch_size": candidate_batch_size,
+        "tolerance": tolerance,
+        "max_abs_load_delta": max(numeric, default=None),
+        "modules": rows,
+    }

--- a/tools/e3_routing/src/e3_p0/collector.py
+++ b/tools/e3_routing/src/e3_p0/collector.py
@@ -1,0 +1,184 @@
+"""Forward-hook collector for routed modules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from .adapters import adapt_snapshot, infer_family
+
+
+def _shapes(value: Any) -> list[list[int]]:
+    shapes: list[list[int]] = []
+    if hasattr(value, "shape"):
+        shapes.append([int(item) for item in value.shape])
+    elif isinstance(value, dict):
+        for child in value.values():
+            shapes.extend(_shapes(child))
+    elif isinstance(value, (list, tuple)):
+        for child in value:
+            shapes.extend(_shapes(child))
+    return shapes
+
+
+def _default_is_routed(module: Any) -> bool:
+    try:
+        num_experts = int(module.num_experts)
+        top_k = int(module.top_k)
+    except (AttributeError, TypeError, ValueError):
+        return False
+    return num_experts > 0 and 0 < top_k <= num_experts and isinstance(
+        getattr(module, "last_routing_snapshot", None), dict
+    )
+
+
+def _snapshot_for_hook(module: Any, family: str, route_cache: dict[int, dict[str, Any]]) -> dict[str, Any]:
+    """Return the official snapshot or an explicitly labelled eval-safe MoE buffer view."""
+
+    snapshot = getattr(module, "last_routing_snapshot", {})
+    if isinstance(snapshot, dict) and snapshot:
+        return dict(snapshot)
+    cached = route_cache.pop(id(module), None)
+    if cached:
+        return cached
+    # OptimizedMOEImproved deliberately publishes last_routing_snapshot only in
+    # training mode. Its eval forward still updates these detached diagnostic
+    # buffers, so use them without changing model mode or core forward code.
+    if family == "moe":
+        usage = getattr(module, "expert_usage_counts", None)
+        if hasattr(usage, "numel") and usage.numel() > 0 and float(usage.detach().sum()) > 0.0:
+            balance = getattr(module, "load_balancing_loss", None)
+            return {
+                "num_experts": int(module.num_experts),
+                "top_k": int(module.top_k),
+                "expert_usage": usage.detach(),
+                "mean_router_probs": usage.detach(),
+                "aux_loss": balance.detach() if hasattr(balance, "detach") else balance,
+                "diagnostic_transport": "official_eval_runtime_buffers",
+                "diagnostic_transport_fields": ["expert_usage_counts", "load_balancing_loss"],
+            }
+    return {}
+
+
+def _moe_route_snapshot(module: Any, router_output: Any) -> dict[str, Any]:
+    """Normalize an OptimizedMOEImproved eval-router return without retaining tensors."""
+
+    if not isinstance(router_output, (list, tuple)) or len(router_output) < 2:
+        return {}
+    weights, indices = router_output[:2]
+    if not all(hasattr(item, "detach") for item in (weights, indices)):
+        return {}
+    flat_indices = indices.detach().reshape(-1).to(dtype=getattr(indices, "dtype", None))
+    try:
+        import torch
+
+        flat_indices = flat_indices.to(torch.long)
+        counts = torch.bincount(flat_indices, minlength=int(module.num_experts)).float()
+        usage = counts / counts.sum().clamp_min(1.0)
+    except (ImportError, RuntimeError, TypeError, ValueError):
+        return {}
+    flat_weights = weights.detach().float().reshape(-1, int(module.top_k))
+    return {
+        "num_experts": int(module.num_experts),
+        "top_k": int(module.top_k),
+        "expert_usage": usage.cpu(),
+        "mean_topk_weight": flat_weights.mean(dim=0).cpu(),
+        "diagnostic_transport": "nested_router_forward_hook",
+        "diagnostic_transport_fields": ["routing_indices", "routing_weights"],
+    }
+
+
+def discover_routed_modules(
+    model: Any,
+    family: str,
+    *,
+    predicate: Callable[[Any], bool] | None = None,
+    leaf_only: bool = True,
+) -> list[tuple[str, Any]]:
+    """Return deterministic family-matched routed modules, optionally only leaf producers."""
+
+    predicate = predicate or _default_is_routed
+    candidates = [(name, module) for name, module in model.named_modules() if predicate(module) and infer_family(module) == family]
+    if not leaf_only:
+        return candidates
+    candidate_ids = {id(module) for _, module in candidates}
+    selected: list[tuple[str, Any]] = []
+    for name, module in candidates:
+        has_routed_child = any(id(child) in candidate_ids for child in module.modules() if child is not module)
+        if not has_routed_child:
+            selected.append((name, module))
+    return selected
+
+
+@dataclass
+class RoutingCollector:
+    """Collect normalized events without changing forward arguments or return values."""
+
+    family: str
+    run_id: str
+    events: list[dict[str, Any]] = field(default_factory=list)
+    handles: list[Any] = field(default_factory=list)
+    registered_names: list[str] = field(default_factory=list)
+    route_cache: dict[int, dict[str, Any]] = field(default_factory=dict)
+    runtime_context: dict[str, Any] = field(default_factory=dict)
+    event_callback: Callable[[dict[str, Any]], None] | None = None
+    max_events: int | None = None
+
+    def set_context(self, **context: Any) -> None:
+        """Attach explicit batch/sample provenance to subsequently captured events."""
+
+        self.runtime_context = dict(context)
+
+    def register(self, model: Any, *, predicate: Callable[[Any], bool] | None = None) -> list[str]:
+        if self.handles:
+            raise RuntimeError("Collector is already registered")
+        modules = discover_routed_modules(model, self.family, predicate=predicate, leaf_only=True)
+        for module_name, module in modules:
+            if self.family == "moe" and hasattr(module, "routing"):
+
+                def capture_route(
+                    current_router: Any,
+                    inputs: Any,
+                    output: Any,
+                    *,
+                    owner: Any = module,
+                ) -> None:
+                    del current_router, inputs
+                    snapshot = _moe_route_snapshot(owner, output)
+                    if snapshot:
+                        self.route_cache[id(owner)] = snapshot
+
+                self.handles.append(module.routing.register_forward_hook(capture_route))
+
+            def capture(current_module: Any, inputs: Any, output: Any, *, name: str = module_name) -> None:
+                snapshot = _snapshot_for_hook(current_module, self.family, self.route_cache)
+                if not snapshot:
+                    return
+                input_shapes = _shapes(inputs)
+                input_shape = input_shapes[0] if input_shapes else None
+                event = adapt_snapshot(
+                    family=self.family,
+                    run_id=self.run_id,
+                    sequence=len(self.events),
+                    module_name=name,
+                    module=current_module,
+                    snapshot=snapshot,
+                    input_shape=input_shape,
+                    output_shapes=_shapes(output),
+                    runtime_context=self.runtime_context,
+                )
+                self.events.append(event)
+                if self.max_events is not None and len(self.events) > self.max_events:
+                    del self.events[: len(self.events) - self.max_events]
+                if self.event_callback is not None:
+                    self.event_callback(event)
+
+            self.handles.append(module.register_forward_hook(capture))
+            self.registered_names.append(module_name)
+        return list(self.registered_names)
+
+    def remove(self) -> None:
+        for handle in self.handles:
+            handle.remove()
+        self.handles.clear()
+        self.route_cache.clear()

--- a/tools/e3_routing/src/e3_p0/io_utils.py
+++ b/tools/e3_routing/src/e3_p0/io_utils.py
@@ -1,0 +1,91 @@
+"""Reproducibility and artifact helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import platform
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.write_text(json.dumps(value, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def write_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8", newline="\n") as stream:
+        for record in records:
+            stream.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def git_identity(root: Path) -> dict[str, Any]:
+    def run(*args: str) -> str | None:
+        try:
+            return subprocess.run(
+                ["git", *args], cwd=root, check=True, capture_output=True, text=True, encoding="utf-8"
+            ).stdout.strip()
+        except (OSError, subprocess.CalledProcessError):
+            return None
+
+    return {
+        "head": run("rev-parse", "HEAD"),
+        "tree": run("show", "-s", "--format=%T", "HEAD"),
+        "status_short": run("status", "--short"),
+    }
+
+
+def environment(
+    torch_module: Any,
+    source_root: Path,
+    tool_root: Path,
+    configured_ref: str,
+    configured_tree: str,
+) -> dict[str, Any]:
+    import matplotlib
+    import PIL
+    import ultralytics
+
+    return {
+        "captured_at": datetime.now().astimezone().isoformat(timespec="seconds"),
+        "platform": platform.platform(),
+        "python": sys.version,
+        "python_executable": sys.executable,
+        "torch": torch_module.__version__,
+        "ultralytics": ultralytics.__version__,
+        "matplotlib": matplotlib.__version__,
+        "pillow": PIL.__version__,
+        "cuda_available": bool(torch_module.cuda.is_available()),
+        "torch_num_threads": int(torch_module.get_num_threads()),
+        "source_root": str(source_root),
+        "configured_official_ref": configured_ref,
+        "configured_official_tree": configured_tree,
+        "source_git": git_identity(source_root),
+        "tool_git": git_identity(tool_root),
+    }
+
+
+def write_manifest(run_dir: Path) -> list[dict[str, Any]]:
+    entries = []
+    for path in sorted(run_dir.rglob("*")):
+        if path.is_file() and path.name != "manifest.sha256.json":
+            entries.append(
+                {
+                    "path": path.relative_to(run_dir).as_posix(),
+                    "bytes": path.stat().st_size,
+                    "sha256": sha256_file(path),
+                }
+            )
+    write_json(run_dir / "manifest.sha256.json", entries)
+    return entries

--- a/tools/e3_routing/src/e3_p0/plotting.py
+++ b/tools/e3_routing/src/e3_p0/plotting.py
@@ -1,0 +1,182 @@
+"""Static evidence plots for the P0 artifact bundle."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from .aggregation import aggregate_events
+
+
+def _load_matrix(events: list[dict[str, Any]]) -> tuple[np.ndarray, list[str]]:
+    width = max(len(event["routing"]["expert_load"]) for event in events)
+    matrix = np.full((len(events), width), np.nan, dtype=np.float64)
+    labels = []
+    for row, event in enumerate(events):
+        load = event["routing"]["expert_load"]
+        matrix[row, : len(load)] = load
+        labels.append(event["module"]["name"])
+    return matrix, labels
+
+
+def save_family_plot(family: str, events: list[dict[str, Any]], path: Path, subtitle: str) -> None:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    aggregates = aggregate_events(events)
+    width = max(len(item["expert_load_mean"]) for item in aggregates)
+    matrix = np.full((len(aggregates), width), np.nan, dtype=np.float64)
+    for row, item in enumerate(aggregates):
+        matrix[row, : len(item["expert_load_mean"])] = item["expert_load_mean"]
+    labels = [item["module"] for item in aggregates]
+    entropies = [item["per_forward_metric_stats"]["entropy_normalized"]["mean"] for item in aggregates]
+    entropy_std = [item["per_forward_metric_stats"]["entropy_normalized"]["std"] for item in aggregates]
+    ginis = [item["per_forward_metric_stats"]["load_gini"]["mean"] for item in aggregates]
+    gini_std = [item["per_forward_metric_stats"]["load_gini"]["std"] for item in aggregates]
+    height = max(4.8, 0.55 * len(labels) + 2.5)
+    fig, axes = plt.subplots(1, 2, figsize=(13, height), constrained_layout=True)
+    image = axes[0].imshow(matrix, aspect="auto", cmap="Blues", vmin=0.0, vmax=max(0.5, float(np.nanmax(matrix))))
+    axes[0].set_title(f"{family.upper()} expert load")
+    axes[0].set_xlabel("Expert index")
+    axes[0].set_ylabel("Leaf routed module")
+    axes[0].set_xticks(range(matrix.shape[1]), [f"E{i}" for i in range(matrix.shape[1])])
+    axes[0].set_yticks(range(len(labels)), labels)
+    fig.colorbar(image, ax=axes[0], label="Normalized load share")
+
+    positions = np.arange(len(labels))
+    axes[1].barh(
+        positions - 0.18,
+        entropies,
+        height=0.34,
+        xerr=entropy_std,
+        label="Normalized entropy (mean ± std)",
+        color="#2F6FAE",
+    )
+    axes[1].barh(
+        positions + 0.18,
+        ginis,
+        height=0.34,
+        xerr=gini_std,
+        label="Load Gini (mean ± std)",
+        color="#E19A35",
+    )
+    axes[1].set_yticks(positions, labels)
+    axes[1].set_xlim(0.0, 1.0)
+    axes[1].set_xlabel("Metric value")
+    axes[1].set_title("Balance diagnostics")
+    axes[1].grid(axis="x", linewidth=0.7, color="#D8DEE6")
+    axes[1].legend(loc="lower right")
+    fig.suptitle(f"E3 P0 unified routing view — {family.upper()}\n{subtitle}", fontsize=13)
+    fig.savefig(path, dpi=180)
+    plt.close(fig)
+
+
+def save_cross_family_plot(all_events: dict[str, list[dict[str, Any]]], path: Path, subtitle: str) -> None:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    families = list(all_events)
+    aggregates = {name: aggregate_events(all_events[name]) for name in families}
+    entropy_mean = [
+        np.mean([item["aggregate_metrics"]["entropy_normalized"] for item in aggregates[name]]) for name in families
+    ]
+    gini_mean = [np.mean([item["aggregate_metrics"]["load_gini"] for item in aggregates[name]]) for name in families]
+    dominant_mean = [
+        np.mean([item["aggregate_metrics"]["dominant_expert_share"] for item in aggregates[name]])
+        for name in families
+    ]
+    positions = np.arange(len(families))
+    width = 0.24
+    fig, ax = plt.subplots(figsize=(9.5, 5.6), constrained_layout=True)
+    ax.bar(positions - width, entropy_mean, width, label="Mean normalized entropy", color="#2F6FAE")
+    ax.bar(positions, gini_mean, width, label="Mean load Gini", color="#E19A35")
+    ax.bar(positions + width, dominant_mean, width, label="Mean dominant share", color="#50A47B")
+    ax.set_xticks(positions, [family.upper() for family in families])
+    ax.set_ylim(0.0, 1.05)
+    ax.set_ylabel("Metric value")
+    ax.set_title(f"E3 P0 cross-family routing summary\n{subtitle}")
+    ax.grid(axis="y", linewidth=0.7, color="#D8DEE6")
+    ax.legend(loc="upper right")
+    fig.savefig(path, dpi=180)
+    plt.close(fig)
+
+
+def save_sample_variation_plot(all_events: dict[str, list[dict[str, Any]]], path: Path, subtitle: str) -> None:
+    """Plot per-sample normalized entropy for every routed module."""
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    families = list(all_events)
+    fig, axes = plt.subplots(len(families), 1, figsize=(12, 3.7 * len(families)), constrained_layout=True)
+    axes = np.atleast_1d(axes)
+    for axis, family in zip(axes, families):
+        modules = sorted({event["module"]["name"] for event in all_events[family]})
+        for module in modules:
+            selected = [event for event in all_events[family] if event["module"]["name"] == module]
+            selected.sort(key=lambda event: event["runtime"]["sample_indices"])
+            x = [event["runtime"]["sample_indices"][0] for event in selected]
+            y = [event["routing"]["entropy_normalized"] for event in selected]
+            axis.plot(x, y, marker="o", linewidth=1.5, label=module)
+        axis.set_ylim(-0.03, 1.03)
+        axis.set_xticks(sorted({index for event in all_events[family] for index in event["runtime"]["sample_indices"]}))
+        axis.set_ylabel("Normalized entropy")
+        axis.set_title(f"{family.upper()} per-sample routing variation")
+        axis.grid(linewidth=0.7, color="#D8DEE6")
+        axis.legend(fontsize=7, loc="best")
+    axes[-1].set_xlabel("coco8 val sample index")
+    fig.suptitle(f"E3 P0 per-sample routing evidence\n{subtitle}", fontsize=13)
+    fig.savefig(path, dpi=180)
+    plt.close(fig)
+
+
+def save_batch_consistency_plot(comparisons: list[dict[str, Any]], path: Path) -> None:
+    """Plot maximum load deltas for each tested batch size and family."""
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    rows = []
+    for comparison in comparisons:
+        batch_size = comparison["candidate_batch_size"]
+        for family in sorted({item["family"] for item in comparison["modules"]}):
+            values = [
+                item["max_abs_load_delta"]
+                for item in comparison["modules"]
+                if item["family"] == family and item["max_abs_load_delta"] is not None
+            ]
+            rows.append((batch_size, family, max(values, default=0.0)))
+    labels = [f"B{batch_size}-{family.upper()}" for batch_size, family, _ in rows]
+    values = [value for _, _, value in rows]
+    tolerance = comparisons[0]["tolerance"] if comparisons else 1e-5
+    fig, ax = plt.subplots(figsize=(10, 5.2), constrained_layout=True)
+    bars = ax.bar(labels, values, color="#2F6FAE")
+    ax.axhline(tolerance, color="#C83E4D", linestyle="--", label=f"Tolerance {tolerance:g}")
+    upper = max(tolerance * 1.25, max(values, default=0.0) * 1.15)
+    ax.set_ylim(0.0, upper)
+    for bar, value in zip(bars, values):
+        ax.annotate(
+            f"{value:.1e}",
+            (bar.get_x() + bar.get_width() / 2, value),
+            xytext=(0, 5),
+            textcoords="offset points",
+            ha="center",
+            va="bottom",
+            fontsize=8,
+        )
+    ax.set_ylabel("Maximum absolute expert-load delta")
+    ax.set_title("E3 P0 batch-size consistency against batch=1")
+    ax.grid(axis="y", linewidth=0.7, color="#D8DEE6")
+    ax.legend()
+    fig.savefig(path, dpi=180)
+    plt.close(fig)

--- a/tools/e3_routing/src/e3_p0/runner.py
+++ b/tools/e3_routing/src/e3_p0/runner.py
@@ -1,0 +1,471 @@
+"""Run the real MoE/MoT/Latent P0 evidence workflow on a fixed coco8 sample set."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import random
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import yaml
+from PIL import Image
+
+from .aggregation import aggregate_events, compare_batch_aggregates, compare_repeated_runs
+from .collector import RoutingCollector
+from .io_utils import environment, sha256_file, write_json, write_jsonl, write_manifest
+from .plotting import (
+    save_batch_consistency_plot,
+    save_cross_family_plot,
+    save_family_plot,
+    save_sample_variation_plot,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+RUN_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
+
+
+def _load_config(config_path: Path, run_id_override: str | None = None) -> dict[str, Any]:
+    """Load config and apply a path-safe run id override."""
+
+    loaded = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise TypeError(f"Config must contain a mapping: {config_path}")
+    config = dict(loaded)
+    run_id = str(run_id_override if run_id_override is not None else config.get("run_id", "")).strip()
+    if not RUN_ID_PATTERN.fullmatch(run_id):
+        raise ValueError(
+            "run_id must be 1-128 characters and contain only letters, digits, '.', '_' or '-' "
+            "without path separators"
+        )
+    config["run_id"] = run_id
+    indices = config.get("sample_indices")
+    if indices is None and "sample_index" in config:
+        indices = [config["sample_index"]]
+    if not isinstance(indices, list) or not indices:
+        raise ValueError("sample_indices must be a non-empty list")
+    config["sample_indices"] = [int(index) for index in indices]
+    if len(set(config["sample_indices"])) != len(config["sample_indices"]):
+        raise ValueError("sample_indices must not contain duplicates")
+    primary_batch_size = int(config.get("primary_batch_size", 1))
+    boundary_batch_sizes = [int(value) for value in config.get("boundary_batch_sizes", [])]
+    if primary_batch_size != 1:
+        raise ValueError("primary_batch_size must remain 1 so per-sample evidence is retained")
+    if any(value < 1 for value in boundary_batch_sizes):
+        raise ValueError("boundary_batch_sizes must contain positive integers")
+    config["primary_batch_size"] = primary_batch_size
+    config["boundary_batch_sizes"] = sorted(set(boundary_batch_sizes))
+    if int(config.get("repeat_primary_passes", 2)) < 2:
+        raise ValueError("repeat_primary_passes must be at least 2")
+    return config
+
+
+def _logger(path: Path) -> logging.Logger:
+    logger = logging.getLogger("e3_p0")
+    logger.handlers.clear()
+    logger.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
+    console = logging.StreamHandler(sys.stdout)
+    file_handler = logging.FileHandler(path, encoding="utf-8", mode="w")
+    console.setFormatter(formatter)
+    file_handler.setFormatter(formatter)
+    logger.addHandler(console)
+    logger.addHandler(file_handler)
+    return logger
+
+
+def _resolve_images(dataset_name: str, split: str, sample_indices: list[int]) -> tuple[list[Path], dict[str, Any]]:
+    from ultralytics.data.utils import check_det_dataset
+
+    dataset = check_det_dataset(dataset_name, autodownload=True)
+    roots = dataset[split] if isinstance(dataset[split], list) else [dataset[split]]
+    extensions = {".bmp", ".jpeg", ".jpg", ".png", ".tif", ".tiff", ".webp"}
+    images: list[Path] = []
+    for item in roots:
+        root = Path(item)
+        if root.is_file() and root.suffix.lower() == ".txt":
+            images.extend(Path(line.strip()) for line in root.read_text(encoding="utf-8").splitlines() if line.strip())
+        elif root.is_file():
+            images.append(root)
+        elif root.is_dir():
+            images.extend(path for path in root.rglob("*") if path.suffix.lower() in extensions)
+    images = sorted(path.resolve() for path in images)
+    if not images:
+        raise FileNotFoundError(f"No image found for dataset={dataset_name!r}, split={split!r}")
+    invalid = [index for index in sample_indices if not 0 <= index < len(images)]
+    if invalid:
+        raise IndexError(f"sample_indices={invalid} outside [0, {len(images) - 1}]")
+    return [images[index] for index in sample_indices], {
+        "dataset_root": str(dataset.get("path")),
+        "split_image_count": len(images),
+        "selected_indices": sample_indices,
+    }
+
+
+def _load_tensor(path: Path, image_size: int, torch_module: Any) -> tuple[Any, dict[str, Any]]:
+    image = Image.open(path).convert("RGB")
+    original = list(image.size)
+    resized = image.resize((image_size, image_size), Image.Resampling.BILINEAR)
+    array = np.asarray(resized, dtype=np.float32).transpose(2, 0, 1) / 255.0
+    return torch_module.from_numpy(array).contiguous(), {
+        "path": str(path),
+        "name": path.name,
+        "sha256": sha256_file(path),
+        "original_size_wh": original,
+        "input_size_wh": [image_size, image_size],
+        "normalization": "RGB uint8 / 255.0",
+    }
+
+
+def _validate_events(events: list[dict[str, Any]]) -> None:
+    try:
+        import jsonschema
+    except ImportError as exc:
+        raise RuntimeError("jsonschema is required for P0 contract validation") from exc
+    schema = json.loads((PROJECT_ROOT / "schemas" / "routing-event.schema.json").read_text(encoding="utf-8"))
+    validator = jsonschema.Draft202012Validator(schema)
+    errors = []
+    for index, event in enumerate(events):
+        errors.extend(f"event[{index}] {error.message}" for error in validator.iter_errors(event))
+    if errors:
+        raise RuntimeError("Schema validation failed:\n" + "\n".join(errors))
+
+
+def _batched_indices(count: int, batch_size: int) -> list[list[int]]:
+    return [list(range(start, min(start + batch_size, count))) for start in range(0, count, batch_size)]
+
+
+def _collect_pass(
+    *,
+    model: Any,
+    family: str,
+    run_id: str,
+    tensors: list[Any],
+    input_meta: list[dict[str, Any]],
+    sample_indices: list[int],
+    batch_size: int,
+    pass_name: str,
+    device: str,
+    predicate: Any,
+    torch_module: Any,
+) -> tuple[list[dict[str, Any]], list[str], list[float], str]:
+    collector = RoutingCollector(family=family, run_id=run_id)
+    registered = collector.register(model, predicate=predicate)
+    if not registered:
+        raise RuntimeError(f"No routed modules discovered for family={family}")
+    durations = []
+    output_type = "unknown"
+    try:
+        for batch_index, positions in enumerate(_batched_indices(len(tensors), batch_size)):
+            batch = torch_module.stack([tensors[position] for position in positions], dim=0).to(device)
+            selected_indices = [sample_indices[position] for position in positions]
+            collector.set_context(
+                pass_name=pass_name,
+                batch_index=batch_index,
+                batch_size=len(positions),
+                sample_indices=selected_indices,
+                input_ids=[input_meta[position]["sha256"][:16] for position in positions],
+            )
+            started = time.perf_counter()
+            with torch_module.inference_mode():
+                output = model(batch)
+            durations.append((time.perf_counter() - started) * 1000.0)
+            output_type = type(output).__name__
+            del batch, output
+    finally:
+        collector.remove()
+    if collector.handles:
+        raise RuntimeError(f"Hook leak detected for family={family} pass={pass_name}")
+    if not collector.events:
+        raise RuntimeError(f"No routing events captured for family={family} pass={pass_name}")
+    _validate_events(collector.events)
+    return collector.events, registered, durations, output_type
+
+
+def _input_set_sha256(input_meta: list[dict[str, Any]]) -> str:
+    payload = "\n".join(f"{item['sample_index']}:{item['sha256']}" for item in input_meta).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def run(config_path: Path, *, run_id: str | None = None, update_latest: bool = True) -> Path:
+    config = _load_config(config_path, run_id)
+    run_dir = PROJECT_ROOT / "artifacts" / "p0" / str(config["run_id"])
+    if run_dir.exists() and any(run_dir.iterdir()):
+        raise FileExistsError(f"Refusing to overwrite non-empty evidence directory: {run_dir}")
+    run_dir.mkdir(parents=True, exist_ok=True)
+    logger = _logger(run_dir / "full.log")
+    (run_dir / "config.resolved.yaml").write_text(
+        yaml.safe_dump(config, sort_keys=False, allow_unicode=True), encoding="utf-8"
+    )
+    (run_dir / "command.txt").write_text("run_p0.cmd\n", encoding="utf-8")
+
+    source_root = (PROJECT_ROOT / config["runtime_root"]).resolve()
+    if not source_root.is_dir():
+        raise FileNotFoundError(f"runtime_root does not exist: {source_root}")
+    sys.path.insert(0, str(source_root))
+    os.environ["MOE_SNAPSHOT_INTERVAL"] = str(int(config.get("moe_snapshot_interval", 1)))
+    os.chdir(PROJECT_ROOT)
+
+    import torch
+    from ultralytics import YOLO
+    from ultralytics.nn.modules.routing_protocol import is_routed_module
+
+    seed = int(config["seed"])
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    logger.info("scope=E3 P0 real three-family multi-sample evidence run")
+    logger.info("source_ref=%s source_tree=%s", config["official_runtime_ref"], config["official_runtime_tree"])
+    logger.info("device=%s seed=%d selection_policy=%s", config["device"], seed, config["selection_policy"])
+
+    paths, dataset_meta = _resolve_images(config["dataset"], config["dataset_split"], config["sample_indices"])
+    tensors = []
+    inputs = []
+    for sample_index, path in zip(config["sample_indices"], paths):
+        tensor, metadata = _load_tensor(path, int(config["image_size"]), torch)
+        metadata["sample_index"] = sample_index
+        tensors.append(tensor)
+        inputs.append(metadata)
+        logger.info("input_index=%d input=%s sha256=%s", sample_index, path, metadata["sha256"])
+    input_record = {
+        **dataset_meta,
+        "dataset": config["dataset"],
+        "split": config["dataset_split"],
+        "selected_image_count": len(inputs),
+        "input_set_sha256": _input_set_sha256(inputs),
+        "images": inputs,
+    }
+    write_json(run_dir / "input.json", input_record)
+
+    primary_events: dict[str, list[dict[str, Any]]] = {}
+    repeat_events: dict[str, list[dict[str, Any]]] = {}
+    boundary_events: dict[int, dict[str, list[dict[str, Any]]]] = {
+        batch_size: {} for batch_size in config["boundary_batch_sizes"]
+    }
+    family_summaries: dict[str, Any] = {}
+    reproducibility: dict[str, Any] = {}
+    subtitle = (
+        f"coco8 val indices {config['sample_indices']}, random initialization, CPU, "
+        f"seed={seed}, imgsz={config['image_size']}"
+    )
+
+    for family, profile in config["profiles"].items():
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
+        model_config = source_root / profile["model_config"]
+        wrapper = YOLO(model_config)
+        model = wrapper.model.to(config["device"]).eval()
+        primary, registered, primary_durations, output_type = _collect_pass(
+            model=model,
+            family=family,
+            run_id=config["run_id"],
+            tensors=tensors,
+            input_meta=inputs,
+            sample_indices=config["sample_indices"],
+            batch_size=config["primary_batch_size"],
+            pass_name="primary",
+            device=config["device"],
+            predicate=is_routed_module,
+            torch_module=torch,
+        )
+        repeated, repeat_registered, repeat_durations, _ = _collect_pass(
+            model=model,
+            family=family,
+            run_id=config["run_id"],
+            tensors=tensors,
+            input_meta=inputs,
+            sample_indices=config["sample_indices"],
+            batch_size=config["primary_batch_size"],
+            pass_name="repeat-2",
+            device=config["device"],
+            predicate=is_routed_module,
+            torch_module=torch,
+        )
+        if registered != repeat_registered:
+            raise RuntimeError(f"Routed module discovery changed between repeated passes for family={family}")
+        repeat_result = compare_repeated_runs(primary, repeated)
+        reproducibility[family] = repeat_result
+        if repeat_result["status"] != "PASS":
+            raise RuntimeError(f"Deterministic repeat failed for family={family}: {repeat_result['mismatches'][:1]}")
+
+        primary_events[family] = primary
+        repeat_events[family] = repeated
+        write_jsonl(run_dir / f"routing-{family}.jsonl", primary)
+        write_jsonl(run_dir / f"routing-repeat-{family}.jsonl", repeated)
+        save_family_plot(family, primary, run_dir / f"routing-{family}.png", subtitle)
+
+        for batch_size in config["boundary_batch_sizes"]:
+            candidate, candidate_registered, _, _ = _collect_pass(
+                model=model,
+                family=family,
+                run_id=config["run_id"],
+                tensors=tensors,
+                input_meta=inputs,
+                sample_indices=config["sample_indices"],
+                batch_size=batch_size,
+                pass_name=f"batch-{batch_size}",
+                device=config["device"],
+                predicate=is_routed_module,
+                torch_module=torch,
+            )
+            if registered != candidate_registered:
+                raise RuntimeError(f"Routed module discovery changed for family={family} batch_size={batch_size}")
+            boundary_events[batch_size][family] = candidate
+            write_jsonl(run_dir / f"routing-batch{batch_size}-{family}.jsonl", candidate)
+
+        parameters = sum(parameter.numel() for parameter in model.parameters())
+        aggregates = aggregate_events(primary)
+        family_summaries[family] = {
+            "status": "PASS",
+            "model_config": profile["model_config"],
+            "model_parameters": parameters,
+            "registered_modules": registered,
+            "routed_module_count": len(registered),
+            "selected_image_count": len(inputs),
+            "primary_forward_count": len(primary_durations),
+            "primary_captured_events": len(primary),
+            "repeat_captured_events": len(repeated),
+            "hooks_removed": True,
+            "output_type": output_type,
+            "primary_forward_ms_observation_only": primary_durations,
+            "repeat_forward_ms_observation_only": repeat_durations,
+            "entropy_normalized_range": [
+                min(item["per_forward_metric_stats"]["entropy_normalized"]["min"] for item in aggregates),
+                max(item["per_forward_metric_stats"]["entropy_normalized"]["max"] for item in aggregates),
+            ],
+            "load_gini_range": [
+                min(item["per_forward_metric_stats"]["load_gini"]["min"] for item in aggregates),
+                max(item["per_forward_metric_stats"]["load_gini"]["max"] for item in aggregates),
+            ],
+            "deterministic_repeat": repeat_result["status"],
+        }
+        logger.info(
+            "family=%s modules=%d images=%d primary_events=%d repeat_match=%s params=%d",
+            family,
+            len(registered),
+            len(inputs),
+            len(primary),
+            repeat_result["status"],
+            parameters,
+        )
+        del model, wrapper
+
+    combined = [event for family in config["profiles"] for event in primary_events[family]]
+    repeated_combined = [event for family in config["profiles"] for event in repeat_events[family]]
+    _validate_events(combined)
+    _validate_events(repeated_combined)
+    write_jsonl(run_dir / "routing-all.jsonl", combined)
+    write_jsonl(run_dir / "routing-repeat-all.jsonl", repeated_combined)
+    aggregates = aggregate_events(combined)
+    write_json(run_dir / "routing-aggregate.json", aggregates)
+    save_cross_family_plot(primary_events, run_dir / "routing-cross-family.png", subtitle)
+    save_sample_variation_plot(primary_events, run_dir / "routing-sample-variation.png", subtitle)
+
+    tolerance = float(config["batch_consistency_tolerance"])
+    batch_comparisons = []
+    for batch_size in config["boundary_batch_sizes"]:
+        candidate_combined = [event for family in config["profiles"] for event in boundary_events[batch_size][family]]
+        comparison = compare_batch_aggregates(
+            combined,
+            candidate_combined,
+            candidate_batch_size=batch_size,
+            tolerance=tolerance,
+        )
+        batch_comparisons.append(comparison)
+        if comparison["status"] != "PASS":
+            raise RuntimeError(
+                f"Batch consistency failed for batch_size={batch_size}: max_delta={comparison['max_abs_load_delta']}"
+            )
+    write_json(run_dir / "reproducibility.json", reproducibility)
+    write_json(run_dir / "batch-consistency.json", batch_comparisons)
+    save_batch_consistency_plot(batch_comparisons, run_dir / "routing-batch-consistency.png")
+    write_json(
+        run_dir / "environment.json",
+        environment(torch, source_root, PROJECT_ROOT, config["official_runtime_ref"], config["official_runtime_tree"]),
+    )
+    summary = {
+        "status": "PASS",
+        "scope": "E3 P0 multi-sample unified routing evidence for real MoE/MoT/Latent forwards",
+        "run_id": config["run_id"],
+        "schema_version": config["schema_version"],
+        "official_locked_base_ref": config["official_locked_base_ref"],
+        "official_runtime_ref": config["official_runtime_ref"],
+        "official_runtime_tree": config["official_runtime_tree"],
+        "official_source_archive_url": config["official_source_archive_url"],
+        "official_source_archive_sha256": config["official_source_archive_sha256"],
+        "input": input_record,
+        "coverage": {
+            "selected_images": len(inputs),
+            "sample_indices": config["sample_indices"],
+            "primary_batch_size": config["primary_batch_size"],
+            "boundary_batch_sizes": config["boundary_batch_sizes"],
+            "primary_passes": config["repeat_primary_passes"],
+        },
+        "families": family_summaries,
+        "total_events": len(combined),
+        "total_repeat_events": len(repeated_combined),
+        "aggregate_module_records": len(aggregates),
+        "schema_validation": "PASS",
+        "deterministic_repetition": {
+            "status": "PASS",
+            "matching_events": sum(item["matching_events"] for item in reproducibility.values()),
+            "compared_events": sum(item["reference_events"] for item in reproducibility.values()),
+        },
+        "batch_consistency": {
+            "status": "PASS",
+            "tolerance": tolerance,
+            "comparisons": [
+                {
+                    "candidate_batch_size": item["candidate_batch_size"],
+                    "max_abs_load_delta": item["max_abs_load_delta"],
+                }
+                for item in batch_comparisons
+            ],
+        },
+        "limitations": [
+            "Models are randomly initialized; routing distributions are pipeline evidence, not trained-quality claims.",
+            "The four coco8 validation images improve coverage but do not support population-level specialization claims.",
+            "Forward durations remain observations only and are not the P1 paired training-overhead benchmark.",
+            "P0 covers MoE, MoT and Latent; realtime panels and image overlays remain P1/P2 work.",
+        ],
+    }
+    write_json(run_dir / "summary.json", summary)
+    write_manifest(run_dir)
+    if update_latest:
+        (PROJECT_ROOT / "artifacts" / "p0" / "LATEST.txt").write_text(config["run_id"] + "\n", encoding="utf-8")
+    logger.info(
+        "result=PASS primary_events=%d repeat_events=%d batch_consistency=PASS artifacts=%s",
+        len(combined),
+        len(repeated_combined),
+        run_dir,
+    )
+    write_manifest(run_dir)
+    return run_dir
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=PROJECT_ROOT / "configs" / "p0" / "p0.yaml")
+    parser.add_argument(
+        "--run-id",
+        help="Path-safe output id. Overrides config run_id; existing non-empty output directories are never overwritten.",
+    )
+    parser.add_argument(
+        "--no-update-latest",
+        action="store_true",
+        help="Do not change artifacts/p0/LATEST.txt. Use this for local reproduction runs.",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    run(args.config.resolve(), run_id=args.run_id, update_latest=not args.no_update_latest)

--- a/tools/e3_routing/src/e3_p1/__init__.py
+++ b/tools/e3_routing/src/e3_p1/__init__.py
@@ -1,0 +1,3 @@
+"""P1 realtime routing dashboard and paired observer-overhead benchmark."""
+
+__version__ = "0.1.0"

--- a/tools/e3_routing/src/e3_p1/__main__.py
+++ b/tools/e3_routing/src/e3_p1/__main__.py
@@ -1,0 +1,6 @@
+"""Command-line entry point for the E3 P1 benchmark."""
+
+from .benchmark import parse_args, run
+
+args = parse_args()
+run(args.config.resolve(), run_id=args.run_id, update_latest=not args.no_update_latest)

--- a/tools/e3_routing/src/e3_p1/benchmark.py
+++ b/tools/e3_routing/src/e3_p1/benchmark.py
@@ -1,0 +1,431 @@
+"""Run the P1 paired training-path observer benchmark and dashboard smoke test."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import random
+import re
+import shutil
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import yaml
+
+from e3_p0.collector import RoutingCollector
+from e3_p0.io_utils import environment, sha256_file, write_json, write_jsonl, write_manifest
+from e3_p0.runner import _load_tensor, _resolve_images, _validate_events
+
+from .dashboard import build_snapshot, load_jsonl, render_dashboard_html, smoke_test_server
+from .plotting import save_benchmark_plot
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+RUN_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
+
+
+def _load_config(config_path: Path, run_id_override: str | None = None) -> dict[str, Any]:
+    loaded = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise TypeError(f"Config must contain a mapping: {config_path}")
+    config = dict(loaded)
+    run_id = str(run_id_override if run_id_override is not None else config.get("run_id", "")).strip()
+    if not RUN_ID_PATTERN.fullmatch(run_id):
+        raise ValueError("run_id must be path-safe and contain at most 128 letters, digits, dots, underscores, or hyphens")
+    config["run_id"] = run_id
+    for name in ("batch_size", "warmup_pairs", "measured_pairs", "bootstrap_resamples"):
+        config[name] = int(config[name])
+        if config[name] <= 0:
+            raise ValueError(f"{name} must be positive")
+    if config["measured_pairs"] < 5:
+        raise ValueError("measured_pairs must be at least 5")
+    config["sample_indices"] = [int(value) for value in config["sample_indices"]]
+    if len(config["sample_indices"]) != config["batch_size"]:
+        raise ValueError("P1 sample_indices count must equal batch_size for a fixed paired input")
+    return config
+
+
+def _logger(path: Path) -> logging.Logger:
+    logger = logging.getLogger("e3_p1")
+    logger.handlers.clear()
+    logger.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
+    console = logging.StreamHandler(sys.stdout)
+    file_handler = logging.FileHandler(path, encoding="utf-8", mode="w")
+    console.setFormatter(formatter)
+    file_handler.setFormatter(formatter)
+    logger.addHandler(console)
+    logger.addHandler(file_handler)
+    return logger
+
+
+def _tensor_leaves(value: Any, seen: set[int] | None = None) -> list[Any]:
+    seen = seen or set()
+    leaves = []
+    if hasattr(value, "requires_grad") and hasattr(value, "dtype"):
+        if id(value) not in seen and bool(value.requires_grad) and bool(value.dtype.is_floating_point):
+            seen.add(id(value))
+            leaves.append(value)
+    elif isinstance(value, dict):
+        for child in value.values():
+            leaves.extend(_tensor_leaves(child, seen))
+    elif isinstance(value, (list, tuple)):
+        for child in value:
+            leaves.extend(_tensor_leaves(child, seen))
+    return leaves
+
+
+def _surrogate_training_loss(output: Any) -> Any:
+    tensors = _tensor_leaves(output)
+    if not tensors:
+        raise RuntimeError("Model train forward exposed no differentiable floating tensors")
+    return sum(tensor.float().square().mean() for tensor in tensors)
+
+
+def _state_sha256(model: Any) -> str:
+    digest = hashlib.sha256()
+
+    def update(value: Any) -> None:
+        if hasattr(value, "detach") and hasattr(value, "shape"):
+            tensor = value.detach().cpu().contiguous()
+            digest.update(b"tensor")
+            digest.update(str(tensor.dtype).encode("ascii"))
+            digest.update(str(tuple(tensor.shape)).encode("ascii"))
+            digest.update(tensor.numpy().tobytes())
+        elif isinstance(value, dict):
+            digest.update(b"dict")
+            for key, child in sorted(value.items(), key=lambda item: str(item[0])):
+                digest.update(str(key).encode("utf-8"))
+                update(child)
+        elif isinstance(value, (list, tuple)):
+            digest.update(type(value).__name__.encode("ascii"))
+            for child in value:
+                update(child)
+        else:
+            digest.update(json.dumps(value, sort_keys=True, default=str, ensure_ascii=False).encode("utf-8"))
+
+    for name, value in sorted(model.state_dict().items()):
+        digest.update(name.encode("utf-8"))
+        update(value)
+    return digest.hexdigest()
+
+
+def _measure_step(model: Any, sample: Any, *, seed: int, torch_module: Any) -> tuple[float, float]:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch_module.manual_seed(seed)
+    model.zero_grad(set_to_none=True)
+    if sample.device.type == "cuda":
+        torch_module.cuda.synchronize(sample.device)
+    started = time.perf_counter()
+    output = model(sample)
+    loss = _surrogate_training_loss(output)
+    loss.backward()
+    if sample.device.type == "cuda":
+        torch_module.cuda.synchronize(sample.device)
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    return elapsed_ms, float(loss.detach().cpu())
+
+
+def _stats(values: list[float]) -> dict[str, float]:
+    array = np.asarray(values, dtype=np.float64)
+    return {
+        "mean": float(array.mean()),
+        "median": float(np.median(array)),
+        "std": float(array.std(ddof=1)) if len(array) > 1 else 0.0,
+        "min": float(array.min()),
+        "max": float(array.max()),
+    }
+
+
+def _bootstrap_median_ci(values: list[float], *, resamples: int, seed: int) -> list[float]:
+    array = np.asarray(values, dtype=np.float64)
+    rng = np.random.default_rng(seed)
+    sampled = rng.choice(array, size=(resamples, len(array)), replace=True)
+    medians = np.median(sampled, axis=1)
+    return [float(np.quantile(medians, 0.025)), float(np.quantile(medians, 0.975))]
+
+
+def _benchmark_family(
+    *,
+    family: str,
+    profile: dict[str, Any],
+    config: dict[str, Any],
+    source_root: Path,
+    sample: Any,
+    logger: logging.Logger,
+    torch_module: Any,
+    yolo_class: Any,
+    predicate: Any,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    seed = int(config["seed"])
+    model_config = source_root / profile["model_config"]
+    random.seed(seed)
+    np.random.seed(seed)
+    torch_module.manual_seed(seed)
+    model_off = yolo_class(model_config).model.to(config["device"]).train()
+    random.seed(seed)
+    np.random.seed(seed)
+    torch_module.manual_seed(seed)
+    model_on = yolo_class(model_config).model.to(config["device"]).train()
+    off_hash = _state_sha256(model_off)
+    on_hash = _state_sha256(model_on)
+    if off_hash != on_hash:
+        raise RuntimeError(f"Initial model state differs between paired conditions for family={family}")
+
+    collector = RoutingCollector(family=family, run_id=config["run_id"], max_events=256)
+    registered = collector.register(model_on, predicate=predicate)
+    if not registered:
+        raise RuntimeError(f"No routed modules discovered for P1 family={family}")
+
+    loss_rtol = float(config["loss_match_rtol"])
+    loss_atol = float(config["loss_match_atol"])
+    rows = []
+    try:
+        for phase, count in (("warmup", config["warmup_pairs"]), ("measured", config["measured_pairs"])):
+            for pair_index in range(count):
+                absolute_index = pair_index if phase == "warmup" else config["warmup_pairs"] + pair_index
+                pair_seed = seed + 1000 + absolute_index
+                order = ["off", "on"] if absolute_index % 2 == 0 else ["on", "off"]
+                timings = {}
+                losses = {}
+                events_before = len(collector.events)
+                for condition in order:
+                    if condition == "on":
+                        collector.set_context(
+                            phase=phase,
+                            pair_index=pair_index,
+                            batch_size=config["batch_size"],
+                            sample_indices=config["sample_indices"],
+                            mode="train_forward_backward",
+                        )
+                        timings[condition], losses[condition] = _measure_step(
+                            model_on, sample, seed=pair_seed, torch_module=torch_module
+                        )
+                    else:
+                        timings[condition], losses[condition] = _measure_step(
+                            model_off, sample, seed=pair_seed, torch_module=torch_module
+                        )
+                new_events = collector.events[events_before:]
+                if len(new_events) != len(registered):
+                    raise RuntimeError(
+                        f"Expected {len(registered)} observer events, got {len(new_events)} for family={family}"
+                    )
+                if phase == "measured" and pair_index == 0:
+                    _validate_events(new_events)
+                loss_match = bool(np.isclose(losses["off"], losses["on"], rtol=loss_rtol, atol=loss_atol))
+                if not loss_match:
+                    raise RuntimeError(
+                        f"Observer changed surrogate loss for family={family}: off={losses['off']} on={losses['on']}"
+                    )
+                if phase == "measured":
+                    slowdown = (timings["on"] - timings["off"]) / timings["off"] * 100.0
+                    rows.append(
+                        {
+                            "family": family,
+                            "pair_index": pair_index,
+                            "execution_order": order,
+                            "pair_seed": pair_seed,
+                            "off_ms": timings["off"],
+                            "on_ms": timings["on"],
+                            "paired_slowdown_percent": slowdown,
+                            "off_loss": losses["off"],
+                            "on_loss": losses["on"],
+                            "loss_match": loss_match,
+                            "captured_events": len(new_events),
+                        }
+                    )
+                collector.events.clear()
+    finally:
+        collector.remove()
+
+    off_values = [row["off_ms"] for row in rows]
+    on_values = [row["on_ms"] for row in rows]
+    slowdowns = [row["paired_slowdown_percent"] for row in rows]
+    target = float(config["target_slowdown_percent"])
+    slowdown_stats = _stats(slowdowns)
+    slowdown_stats["bootstrap_95_ci"] = _bootstrap_median_ci(
+        slowdowns, resamples=config["bootstrap_resamples"], seed=seed + len(family)
+    )
+    status = "PASS" if slowdown_stats["median"] < target else "FAIL"
+    summary = {
+        "status": status,
+        "model_config": profile["model_config"],
+        "model_parameters": sum(parameter.numel() for parameter in model_off.parameters()),
+        "paired_model_state_sha256": off_hash,
+        "registered_modules": registered,
+        "measured_pairs": len(rows),
+        "order_balance": {
+            "off_then_on": sum(row["execution_order"] == ["off", "on"] for row in rows),
+            "on_then_off": sum(row["execution_order"] == ["on", "off"] for row in rows),
+        },
+        "off_ms": _stats(off_values),
+        "on_ms": _stats(on_values),
+        "paired_slowdown_percent": slowdown_stats,
+        "target_slowdown_percent": target,
+        "target_rule": "PASS when the preregistered median paired slowdown is below the target",
+        "loss_equivalence": "PASS",
+        "hooks_removed": not collector.handles,
+        "benchmark_scope": "real train-mode model forward + differentiable surrogate backward; optimizer step excluded",
+    }
+    logger.info(
+        "family=%s status=%s median_slowdown=%.3f%% ci95=[%.3f, %.3f] pairs=%d",
+        family,
+        status,
+        slowdown_stats["median"],
+        slowdown_stats["bootstrap_95_ci"][0],
+        slowdown_stats["bootstrap_95_ci"][1],
+        len(rows),
+    )
+    del model_off, model_on
+    return summary, rows
+
+
+def run(config_path: Path, *, run_id: str | None = None, update_latest: bool = True) -> Path:
+    config = _load_config(config_path, run_id)
+    run_dir = PROJECT_ROOT / "artifacts" / "p1" / config["run_id"]
+    if run_dir.exists() and any(run_dir.iterdir()):
+        raise FileExistsError(f"Refusing to overwrite non-empty P1 evidence directory: {run_dir}")
+    run_dir.mkdir(parents=True, exist_ok=True)
+    logger = _logger(run_dir / "full.log")
+    (run_dir / "config.resolved.yaml").write_text(
+        yaml.safe_dump(config, sort_keys=False, allow_unicode=True), encoding="utf-8"
+    )
+    (run_dir / "command.txt").write_text("run_p1_benchmark.cmd\n", encoding="utf-8")
+
+    source_root = (PROJECT_ROOT / config["runtime_root"]).resolve()
+    p0_repo_root = (PROJECT_ROOT / config["p0_repo_root"]).resolve()
+    if not (p0_repo_root / "artifacts" / "p0" / "LATEST.txt").is_file():
+        raise FileNotFoundError(f"P0 evidence repository is missing or incomplete: {p0_repo_root}")
+    sys.path.insert(0, str(source_root))
+    os.chdir(PROJECT_ROOT)
+    import torch
+    from ultralytics import YOLO
+    from ultralytics.nn.modules.routing_protocol import is_routed_module
+
+    paths, dataset_meta = _resolve_images(config["dataset"], config["dataset_split"], config["sample_indices"])
+    tensors = []
+    input_records = []
+    for sample_index, path in zip(config["sample_indices"], paths):
+        tensor, metadata = _load_tensor(path, int(config["image_size"]), torch)
+        metadata["sample_index"] = sample_index
+        tensors.append(tensor)
+        input_records.append(metadata)
+    sample = torch.stack(tensors, dim=0).to(config["device"])
+    write_json(
+        run_dir / "input.json",
+        {
+            **dataset_meta,
+            "dataset": config["dataset"],
+            "split": config["dataset_split"],
+            "batch_size": config["batch_size"],
+            "images": input_records,
+        },
+    )
+
+    logger.info(
+        "scope=E3 P1 paired train-path observer benchmark device=%s batch=%d imgsz=%d warmup=%d measured=%d",
+        config["device"],
+        config["batch_size"],
+        config["image_size"],
+        config["warmup_pairs"],
+        config["measured_pairs"],
+    )
+    family_summaries = {}
+    all_rows = []
+    for family, profile in config["profiles"].items():
+        summary, rows = _benchmark_family(
+            family=family,
+            profile=profile,
+            config=config,
+            source_root=source_root,
+            sample=sample,
+            logger=logger,
+            torch_module=torch,
+            yolo_class=YOLO,
+            predicate=is_routed_module,
+        )
+        family_summaries[family] = summary
+        all_rows.extend(rows)
+    write_jsonl(run_dir / "benchmark-pairs.jsonl", all_rows)
+    save_benchmark_plot(family_summaries, run_dir / "observer-overhead.png", float(config["target_slowdown_percent"]))
+
+    p0_run_id = (p0_repo_root / "artifacts" / "p0" / "LATEST.txt").read_text(encoding="utf-8").strip()
+    p0_events = p0_repo_root / "artifacts" / "p0" / p0_run_id / "routing-all.jsonl"
+    dashboard_events = run_dir / "dashboard-events.jsonl"
+    shutil.copy2(p0_events, dashboard_events)
+    dashboard_snapshot = build_snapshot(load_jsonl(dashboard_events))
+    write_json(run_dir / "dashboard-snapshot.json", dashboard_snapshot)
+    (run_dir / "dashboard.html").write_text(render_dashboard_html(), encoding="utf-8")
+    dashboard_smoke = smoke_test_server(dashboard_events)
+    write_json(run_dir / "dashboard-smoke.json", dashboard_smoke)
+    if dashboard_smoke["status"] != "PASS":
+        raise RuntimeError(f"Dashboard HTTP smoke failed: {dashboard_smoke}")
+    write_json(
+        run_dir / "dashboard-source.json",
+        {
+            "source_p0_run_id": p0_run_id,
+            "source_repository": "Ricky-7-Yan/YOLO-Master-E3-P0",
+            "source_relative_path_from_p1": Path(os.path.relpath(p0_events, PROJECT_ROOT)).as_posix(),
+            "source_sha256": sha256_file(p0_events),
+            "copied_event_count": dashboard_snapshot["event_count"],
+            "families": sorted(dashboard_snapshot["families"]),
+        },
+    )
+    write_json(
+        run_dir / "environment.json",
+        environment(torch, source_root, PROJECT_ROOT, config["official_runtime_ref"], config["official_runtime_tree"]),
+    )
+    overall_status = "PASS" if all(item["status"] == "PASS" for item in family_summaries.values()) else "FAIL"
+    summary = {
+        "status": overall_status,
+        "scope": "E3 P1 realtime dashboard + paired train-path observer-overhead benchmark",
+        "run_id": config["run_id"],
+        "official_runtime_ref": config["official_runtime_ref"],
+        "official_runtime_tree": config["official_runtime_tree"],
+        "families": family_summaries,
+        "dashboard": dashboard_smoke,
+        "target_slowdown_percent": float(config["target_slowdown_percent"]),
+        "methodology": {
+            "paired_conditions": "identical independently instantiated model states; hook off vs hook on",
+            "order": "alternating AB/BA to reduce order bias",
+            "warmup_pairs": config["warmup_pairs"],
+            "measured_pairs": config["measured_pairs"],
+            "timed_region": "real model train-mode forward plus differentiable surrogate backward",
+            "excluded": "model construction, hook registration/removal, optimizer step, disk serialization, dashboard HTTP",
+            "primary_statistic": "median of per-pair slowdown percentages",
+            "uncertainty": "deterministic-seed bootstrap 95% interval for the paired median",
+        },
+        "limitations": [
+            "This is a training-path microbenchmark, not a full detector epoch benchmark with labels and optimizer updates.",
+            "CPU scheduling noise remains visible; paired AB/BA ordering and bootstrap intervals reduce but do not eliminate it.",
+            "The dashboard is local and read-only; authentication and remote multi-user deployment are outside P1 scope.",
+        ],
+    }
+    write_json(run_dir / "summary.json", summary)
+    write_manifest(run_dir)
+    if update_latest:
+        latest = PROJECT_ROOT / "artifacts" / "p1" / "LATEST.txt"
+        latest.parent.mkdir(parents=True, exist_ok=True)
+        latest.write_text(config["run_id"] + "\n", encoding="utf-8")
+    logger.info("result=%s dashboard=%s artifacts=%s", overall_status, dashboard_smoke["status"], run_dir)
+    write_manifest(run_dir)
+    return run_dir
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=PROJECT_ROOT / "configs" / "p1" / "p1.yaml")
+    parser.add_argument("--run-id")
+    parser.add_argument("--no-update-latest", action="store_true")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    run(args.config.resolve(), run_id=args.run_id, update_latest=not args.no_update_latest)

--- a/tools/e3_routing/src/e3_p1/dashboard.py
+++ b/tools/e3_routing/src/e3_p1/dashboard.py
@@ -1,0 +1,233 @@
+"""Dependency-free local realtime dashboard for E3 routing JSONL streams."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import threading
+import urllib.request
+import webbrowser
+from datetime import datetime
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+from e3_p0.aggregation import aggregate_events
+
+
+def load_jsonl_window(path: Path, *, limit: int = 1000) -> tuple[list[dict[str, Any]], int]:
+    """Read the newest JSON objects and return both the window and valid source count.
+
+    A partial final line is expected while a writer is active and is ignored. Corruption in
+    any earlier non-empty line is surfaced instead of silently removing evidence.
+    """
+
+    if not path.is_file():
+        return [], 0
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+    lines = [(number, line) for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1) if line.strip()]
+    records: list[dict[str, Any]] = []
+    for index, (line_number, line) in enumerate(lines):
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as exc:
+            if index == len(lines) - 1:
+                break
+            raise ValueError(f"Invalid JSONL before final line at {path}:{line_number}") from exc
+        if isinstance(value, dict):
+            records.append(value)
+    return records[-limit:], len(records)
+
+
+def load_jsonl(path: Path, *, limit: int = 1000) -> list[dict[str, Any]]:
+    """Read the newest valid JSON objects without failing on a partial final line."""
+
+    records, _ = load_jsonl_window(path, limit=limit)
+    return records
+
+
+def build_snapshot(
+    events: list[dict[str, Any]], *, source_event_count: int | None = None, window_limit: int | None = None
+) -> dict[str, Any]:
+    """Build one compact dashboard API payload from routing events."""
+
+    aggregates = aggregate_events(events) if events else []
+    families = {}
+    for family in sorted({event.get("family", "unknown") for event in events}):
+        family_events = [event for event in events if event.get("family") == family]
+        family_aggregates = [item for item in aggregates if item["family"] == family]
+        families[family] = {
+            "events": len(family_events),
+            "modules": len(family_aggregates),
+            "mean_entropy": (
+                sum(item["aggregate_metrics"]["entropy_normalized"] for item in family_aggregates)
+                / len(family_aggregates)
+                if family_aggregates
+                else None
+            ),
+            "mean_gini": (
+                sum(item["aggregate_metrics"]["load_gini"] for item in family_aggregates) / len(family_aggregates)
+                if family_aggregates
+                else None
+            ),
+        }
+    source_count = len(events) if source_event_count is None else source_event_count
+    if source_count < len(events):
+        raise ValueError("source_event_count cannot be smaller than the returned event window")
+    return {
+        "generated_at": datetime.now().astimezone().isoformat(timespec="seconds"),
+        "event_count": len(events),
+        "source_event_count": source_count,
+        "window_limit": window_limit,
+        "truncated": source_count > len(events),
+        "families": families,
+        "aggregates": aggregates,
+        "recent_events": [
+            {
+                "family": event.get("family"),
+                "module": event.get("module", {}).get("name"),
+                "entropy": event.get("routing", {}).get("entropy_normalized"),
+                "gini": event.get("routing", {}).get("load_gini"),
+                "sample_indices": event.get("runtime", {}).get("sample_indices"),
+            }
+            for event in events[-12:]
+        ],
+    }
+
+
+def render_dashboard_html(refresh_ms: int = 1000) -> str:
+    """Return the self-contained dashboard shell served by the local HTTP endpoint."""
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>YOLO-Master E3 Routing Dashboard</title>
+<style>
+:root{{--bg:#08111f;--panel:#101d31;--line:#263a55;--text:#e8f0fa;--muted:#91a4bb;--blue:#4da3ff;--gold:#ffbd59}}
+*{{box-sizing:border-box}} body{{margin:0;background:radial-gradient(circle at top,#152944,var(--bg) 48%);color:var(--text);font:14px Inter,Segoe UI,sans-serif}}
+main{{max-width:1280px;margin:auto;padding:28px}} h1{{font-size:28px;margin:0 0 6px}} .sub{{color:var(--muted);margin-bottom:22px}}
+.cards{{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;margin-bottom:18px}} .card,.panel{{background:rgba(16,29,49,.92);border:1px solid var(--line);border-radius:14px;padding:16px;box-shadow:0 12px 36px #0005}}
+.value{{font-size:28px;font-weight:700;color:var(--blue)}} .label{{color:var(--muted);margin-top:4px}} .grid{{display:grid;grid-template-columns:1.25fr .75fr;gap:16px}}
+table{{width:100%;border-collapse:collapse}} th,td{{padding:9px;border-bottom:1px solid var(--line);text-align:left}} th{{color:var(--muted);font-weight:600}} .bar{{height:8px;background:#223653;border-radius:8px;overflow:hidden;min-width:120px}} .fill{{height:100%;background:linear-gradient(90deg,var(--blue),#72e2ae)}}
+.status{{display:inline-flex;align-items:center;gap:7px;color:#72e2ae}} .dot{{width:8px;height:8px;border-radius:50%;background:#72e2ae;box-shadow:0 0 10px #72e2ae}}
+@media(max-width:850px){{.grid{{grid-template-columns:1fr}}}}
+</style></head>
+<body><main><h1>YOLO-Master E3 Routing Dashboard</h1><div class="sub"><span class="status"><i class="dot"></i>live</span> · refresh {refresh_ms} ms · local read-only observer</div>
+<section id="cards" class="cards"></section><section class="grid"><div class="panel"><h2>Module routing aggregates</h2><table><thead><tr><th>Family</th><th>Module</th><th>Entropy</th><th>Gini</th><th>Dominant</th></tr></thead><tbody id="modules"></tbody></table></div>
+<div class="panel"><h2>Recent events</h2><table><thead><tr><th>Family</th><th>Module</th><th>Samples</th></tr></thead><tbody id="recent"></tbody></table></div></section></main>
+<script>
+const fmt=v=>v==null?'—':Number(v).toFixed(3); const esc=s=>String(s??'').replace(/[&<>\"]/g,c=>({{'&':'&amp;','<':'&lt;','>':'&gt;','\"':'&quot;'}}[c]));
+async function refresh(){{const r=await fetch('/api/snapshot',{{cache:'no-store'}});const d=await r.json();
+const eventLabel=d.truncated?`Events in window · ${{d.source_event_count}} total`:'Events in stream';
+document.querySelector('#cards').innerHTML=`<div class="card"><div class="value">${{d.event_count}}</div><div class="label">${{eventLabel}}</div></div>`+Object.entries(d.families).map(([n,v])=>`<div class="card"><div class="value">${{n.toUpperCase()}}</div><div class="label">${{v.modules}} modules · H ${{fmt(v.mean_entropy)}} · G ${{fmt(v.mean_gini)}}</div></div>`).join('');
+document.querySelector('#modules').innerHTML=d.aggregates.map(x=>`<tr><td>${{esc(x.family.toUpperCase())}}</td><td>${{esc(x.module)}}</td><td><div class="bar"><div class="fill" style="width:${{100*x.aggregate_metrics.entropy_normalized}}%"></div></div>${{fmt(x.aggregate_metrics.entropy_normalized)}}</td><td>${{fmt(x.aggregate_metrics.load_gini)}}</td><td>${{fmt(x.aggregate_metrics.dominant_expert_share)}}</td></tr>`).join('');
+document.querySelector('#recent').innerHTML=d.recent_events.slice().reverse().map(x=>`<tr><td>${{esc((x.family||'').toUpperCase())}}</td><td>${{esc(x.module)}}</td><td>${{esc((x.sample_indices||[]).join(','))}}</td></tr>`).join('');}}
+refresh();setInterval(refresh,{refresh_ms});
+</script></body></html>"""
+
+
+class DashboardServer(ThreadingHTTPServer):
+    """HTTP server carrying an explicit JSONL source path."""
+
+    def __init__(self, address: tuple[str, int], source: Path, refresh_ms: int = 1000):
+        self.source = source
+        self.refresh_ms = refresh_ms
+        super().__init__(address, DashboardHandler)
+
+
+class DashboardHandler(BaseHTTPRequestHandler):
+    """Serve dashboard, health, and live snapshot endpoints."""
+
+    server: DashboardServer
+
+    def _send(self, body: bytes, content_type: str, status: HTTPStatus = HTTPStatus.OK) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:
+        if self.path == "/":
+            self._send(render_dashboard_html(self.server.refresh_ms).encode("utf-8"), "text/html; charset=utf-8")
+            return
+        if self.path == "/healthz":
+            self._send(b'{"status":"ok"}\n', "application/json")
+            return
+        if self.path == "/api/snapshot":
+            events, source_event_count = load_jsonl_window(self.server.source)
+            snapshot = build_snapshot(events, source_event_count=source_event_count, window_limit=1000)
+            body = json.dumps(snapshot, ensure_ascii=False).encode("utf-8")
+            self._send(body, "application/json; charset=utf-8")
+            return
+        self._send(b"not found\n", "text/plain; charset=utf-8", HTTPStatus.NOT_FOUND)
+
+    def log_message(self, format: str, *args: Any) -> None:
+        del format, args
+
+
+def smoke_test_server(source: Path) -> dict[str, Any]:
+    """Start the real HTTP server on an ephemeral port and verify all endpoints."""
+
+    server = DashboardServer(("127.0.0.1", 0), source)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base = f"http://127.0.0.1:{server.server_port}"
+    try:
+        with urllib.request.urlopen(base + "/healthz", timeout=5) as response:
+            health_status = response.status
+        with urllib.request.urlopen(base + "/", timeout=5) as response:
+            html = response.read().decode("utf-8")
+        with urllib.request.urlopen(base + "/api/snapshot", timeout=5) as response:
+            snapshot = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+    return {
+        "status": "PASS" if health_status == 200 and "Routing Dashboard" in html else "FAIL",
+        "health_status": health_status,
+        "html_contains_dashboard": "YOLO-Master E3 Routing Dashboard" in html,
+        "api_event_count": snapshot["event_count"],
+        "api_source_event_count": snapshot["source_event_count"],
+        "api_window_limit": snapshot["window_limit"],
+        "api_truncated": snapshot["truncated"],
+        "api_families": sorted(snapshot["families"]),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--events", type=Path, required=True, help="Routing JSONL file read on every refresh.")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--refresh-ms", type=int, default=1000)
+    parser.add_argument("--open", action="store_true", help="Open the local dashboard in the default browser.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    source = args.events.resolve()
+    if not source.is_file():
+        raise FileNotFoundError(f"Routing event stream does not exist: {source}")
+    server = DashboardServer((args.host, args.port), source, args.refresh_ms)
+    url = f"http://{args.host}:{args.port}/"
+    print(f"E3 dashboard source: {source}")
+    print(f"E3 dashboard URL: {url}")
+    if args.open:
+        webbrowser.open(url)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/e3_routing/src/e3_p1/engine_crosscheck.py
+++ b/tools/e3_routing/src/e3_p1/engine_crosscheck.py
@@ -1,0 +1,695 @@
+"""Cross-check the P1 observer inside the real Ultralytics DetectionTrainer lifecycle."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import logging
+import os
+import random
+import re
+import shutil
+import subprocess
+import sys
+import time
+import traceback
+from pathlib import Path
+from typing import Any, TextIO
+
+import numpy as np
+import yaml
+
+from e3_p0.collector import RoutingCollector
+from e3_p0.io_utils import environment, git_identity, sha256_file, write_json, write_jsonl, write_manifest
+
+from .dashboard import build_snapshot, load_jsonl, render_dashboard_html, smoke_test_server
+from .plotting import save_engine_crosscheck_plot
+from .strengthened import _validate_event_stream, _writer_callback
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+RUN_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
+CONDITIONS = ("off", "capture_jsonl")
+LATENT_TRANSIENT_FIELDS = ("_last_routing_logits", "_last_routing_probs", "_last_routing_summary")
+
+
+def _load_engine_config(config_path: Path, run_id_override: str | None = None) -> dict[str, Any]:
+    loaded = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise TypeError(f"Config must contain a mapping: {config_path}")
+    config = dict(loaded)
+    run_id = str(run_id_override if run_id_override is not None else config.get("run_id", "")).strip()
+    if not RUN_ID_PATTERN.fullmatch(run_id):
+        raise ValueError("run_id must be path-safe and contain at most 128 letters, digits, dots, underscores, or hyphens")
+    config["run_id"] = run_id
+    for name in ("batch_size", "image_size", "epochs", "warmup_pairs", "measured_pairs"):
+        config[name] = int(config[name])
+        if config[name] < 0 or name in {"batch_size", "image_size", "measured_pairs"} and config[name] == 0:
+            raise ValueError(f"{name} must be positive (warmup_pairs may be zero)")
+    if config["measured_pairs"] % 2:
+        raise ValueError("measured_pairs must be even for balanced AB/BA ordering")
+    if not isinstance(config.get("profiles"), dict) or len(config["profiles"]) < 1:
+        raise ValueError("profiles must contain at least one routing family")
+    return config
+
+
+def _condition_order(pair_index: int) -> list[str]:
+    return list(CONDITIONS if pair_index % 2 == 0 else reversed(CONDITIONS))
+
+
+def _hash_value(value: Any) -> str:
+    """Return a stable recursive SHA-256 for tensors and JSON-like containers."""
+
+    digest = hashlib.sha256()
+
+    def update(child: Any) -> None:
+        if hasattr(child, "detach") and hasattr(child, "shape"):
+            tensor = child.detach().cpu().contiguous()
+            digest.update(b"tensor")
+            digest.update(str(tensor.dtype).encode("ascii"))
+            digest.update(str(tuple(tensor.shape)).encode("ascii"))
+            digest.update(tensor.numpy().tobytes())
+        elif isinstance(child, dict):
+            digest.update(b"dict")
+            for key, item in sorted(child.items(), key=lambda pair: str(pair[0])):
+                digest.update(str(key).encode("utf-8"))
+                update(item)
+        elif isinstance(child, (list, tuple)):
+            digest.update(type(child).__name__.encode("ascii"))
+            for item in child:
+                update(item)
+        else:
+            digest.update(json.dumps(child, sort_keys=True, default=str, ensure_ascii=False).encode("utf-8"))
+
+    update(value)
+    return digest.hexdigest()
+
+
+def _state_sha256(stateful: Any) -> str:
+    return _hash_value(stateful.state_dict())
+
+
+def _clear_nonleaf_latent_transients(model: Any) -> list[dict[str, Any]]:
+    """Clear constructor-time Latent snapshots that prevent ModelEMA deepcopy."""
+
+    cleared = []
+    for module_name, module in model.named_modules():
+        for field in LATENT_TRANSIENT_FIELDS:
+            value = getattr(module, field, None)
+            if hasattr(value, "is_leaf") and not bool(value.is_leaf):
+                cleared.append(
+                    {
+                        "module": module_name,
+                        "type": type(module).__name__,
+                        "field": field,
+                        "shape": list(value.shape),
+                        "state_dict_member": field in module.state_dict(),
+                    }
+                )
+                setattr(module, field, None)
+    return cleared
+
+
+def _logger(path: Path) -> logging.Logger:
+    logger = logging.getLogger("e3_p1_engine_crosscheck")
+    logger.handlers.clear()
+    logger.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
+    console = logging.StreamHandler(sys.stdout)
+    file_handler = logging.FileHandler(path, encoding="utf-8", mode="w")
+    console.setFormatter(formatter)
+    file_handler.setFormatter(formatter)
+    logger.addHandler(console)
+    logger.addHandler(file_handler)
+    return logger
+
+
+def _read_metrics_csv(path: Path) -> dict[str, str]:
+    if not path.is_file():
+        return {}
+    with path.open("r", encoding="utf-8-sig", newline="") as stream:
+        rows = list(csv.DictReader(stream))
+    return {str(key).strip(): str(value).strip() for key, value in rows[-1].items()} if rows else {}
+
+
+def _verify_runtime_inputs(source_root: Path, config: dict[str, Any]) -> dict[str, Any]:
+    """Verify a Git checkout by identity or an extracted snapshot by preregistered file hashes."""
+
+    identity = git_identity(source_root)
+    expected_files = config.get("runtime_input_sha256")
+    if not isinstance(expected_files, dict) or not expected_files:
+        raise ValueError("runtime_input_sha256 must preregister the Trainer and routed-model source files")
+    records = []
+    for relative_path, expected_hash in expected_files.items():
+        path = source_root / relative_path
+        if not path.is_file():
+            raise FileNotFoundError(f"Preregistered runtime input is missing: {relative_path}")
+        actual_hash = sha256_file(path)
+        if actual_hash != expected_hash:
+            raise RuntimeError(f"Runtime input hash differs for {relative_path}")
+        records.append({"path": relative_path, "sha256": actual_hash, "status": "MATCH"})
+    identity_policy = config.get("runtime_identity_policy", "exact")
+    if identity_policy not in {"exact", "base_ancestor"}:
+        raise ValueError("runtime_identity_policy must be exact or base_ancestor")
+    if identity["head"] is not None and identity_policy == "exact":
+        if identity["head"] != config["official_runtime_ref"]:
+            raise RuntimeError("Official runtime commit differs from the preregistered ref")
+        if identity["tree"] != config["official_runtime_tree"]:
+            raise RuntimeError("Official runtime tree differs from the preregistered tree")
+    elif identity["head"] is not None:
+        ancestry = subprocess.run(
+            ["git", "-C", str(source_root), "merge-base", "--is-ancestor", config["official_runtime_ref"], "HEAD"],
+            capture_output=True,
+            check=False,
+            text=True,
+            encoding="utf-8",
+        )
+        if ancestry.returncode != 0:
+            raise RuntimeError("Configured runtime base is not an ancestor of the integration checkout")
+    mode = "extracted_snapshot_file_hashes"
+    if identity["head"] is not None:
+        mode = "git_identity_and_file_hashes" if identity_policy == "exact" else "git_base_ancestor_and_file_hashes"
+    return {
+        "status": "PASS",
+        "mode": mode,
+        "identity_policy": identity_policy,
+        "configured_ref": config["official_runtime_ref"],
+        "configured_tree": config["official_runtime_tree"],
+        "git_identity": identity,
+        "files": records,
+    }
+
+
+class _TrainerObserver:
+    """Own callback state for exactly one trainer execution."""
+
+    def __init__(
+        self,
+        *,
+        family: str,
+        condition: str,
+        pair_index: int,
+        phase: str,
+        run_id: str,
+        writer_path: Path | None,
+        predicate: Any,
+    ) -> None:
+        self.family = family
+        self.condition = condition
+        self.pair_index = pair_index
+        self.phase = phase
+        self.run_id = run_id
+        self.writer_path = writer_path
+        self.predicate = predicate
+        self.collector: RoutingCollector | None = None
+        self.writer: TextIO | None = None
+        self.registered_modules: list[str] = []
+        self.batch_records: list[dict[str, Any]] = []
+        self.epoch_started: float | None = None
+        self.epoch_windows_ms: list[float] = []
+        self.initial_model_sha256: str | None = None
+        self.initial_optimizer_sha256: str | None = None
+        self.final_model_sha256: str | None = None
+        self.final_optimizer_sha256: str | None = None
+        self.final_ema_sha256: str | None = None
+        self.loss_items: list[float] = []
+
+    def install(self, trainer: Any) -> None:
+        trainer.add_callback("on_train_start", self.on_train_start)
+        trainer.add_callback("on_train_epoch_start", self.on_train_epoch_start)
+        trainer.add_callback("on_train_batch_start", self.on_train_batch_start)
+        trainer.add_callback("on_train_batch_end", self.on_train_batch_end)
+        trainer.add_callback("on_train_epoch_end", self.on_train_epoch_end)
+        trainer.add_callback("on_train_end", self.on_train_end)
+        trainer.add_callback("teardown", self.teardown)
+
+    def on_train_start(self, trainer: Any) -> None:
+        self.initial_model_sha256 = _state_sha256(trainer.model)
+        self.initial_optimizer_sha256 = _state_sha256(trainer.optimizer)
+        if self.condition == "capture_jsonl":
+            if self.writer_path is None:
+                raise RuntimeError("capture_jsonl requires a writer path")
+            self.writer = self.writer_path.open("w", encoding="utf-8", newline="\n")
+            self.collector = RoutingCollector(
+                family=self.family,
+                run_id=self.run_id,
+                max_events=4096,
+                event_callback=_writer_callback(self.writer),
+            )
+            self.registered_modules = self.collector.register(trainer.model, predicate=self.predicate)
+            if not self.registered_modules:
+                raise RuntimeError(f"No routed modules discovered for family={self.family}")
+
+    def on_train_epoch_start(self, trainer: Any) -> None:
+        del trainer
+        self.epoch_started = time.perf_counter()
+
+    def on_train_batch_start(self, trainer: Any) -> None:
+        batch = trainer.batch
+        batch_index = len(self.batch_records)
+        files = [str(value) for value in batch.get("im_file", [])]
+        payload = {
+            "img": batch.get("img"),
+            "cls": batch.get("cls"),
+            "bboxes": batch.get("bboxes"),
+            "batch_idx": batch.get("batch_idx"),
+            "im_file": files,
+        }
+        self.batch_records.append(
+            {
+                "batch_index": batch_index,
+                "im_file": files,
+                "batch_size": int(batch["img"].shape[0]),
+                "target_count": int(batch.get("cls", []).shape[0]) if hasattr(batch.get("cls"), "shape") else 0,
+                "raw_batch_sha256": _hash_value(payload),
+            }
+        )
+        if self.collector is not None:
+            self.collector.set_context(
+                phase=self.phase,
+                engine="ultralytics.models.yolo.detect.DetectionTrainer",
+                condition=self.condition,
+                pair_index=self.pair_index,
+                epoch=int(trainer.epoch),
+                batch_index=batch_index,
+                batch_size=int(batch["img"].shape[0]),
+                sample_paths=files,
+            )
+
+    def on_train_batch_end(self, trainer: Any) -> None:
+        del trainer
+        if self.writer is not None:
+            self.writer.flush()
+
+    def on_train_epoch_end(self, trainer: Any) -> None:
+        del trainer
+        if self.epoch_started is None:
+            raise RuntimeError("epoch timer was not started")
+        self.epoch_windows_ms.append((time.perf_counter() - self.epoch_started) * 1000.0)
+
+    def on_train_end(self, trainer: Any) -> None:
+        self.final_model_sha256 = _state_sha256(trainer.model)
+        self.final_optimizer_sha256 = _state_sha256(trainer.optimizer)
+        self.final_ema_sha256 = _state_sha256(trainer.ema.ema) if trainer.ema is not None else None
+        self.loss_items = [float(value) for value in trainer.tloss.detach().cpu().view(-1)]
+
+    def teardown(self, trainer: Any) -> None:
+        del trainer
+        self.close()
+
+    def close(self) -> None:
+        if self.collector is not None:
+            self.collector.remove()
+        if self.writer is not None and not self.writer.closed:
+            self.writer.flush()
+            self.writer.close()
+
+
+def _assert_pair_equivalence(off: dict[str, Any], observed: dict[str, Any], *, family: str, pair_index: int) -> None:
+    exact_fields = (
+        "initial_model_sha256",
+        "initial_optimizer_sha256",
+        "final_model_sha256",
+        "final_optimizer_sha256",
+        "final_ema_sha256",
+        "optimizer_steps",
+        "batch_count",
+        "epochs_completed",
+        "sanitized_transients",
+    )
+    for field in exact_fields:
+        if off[field] != observed[field]:
+            raise RuntimeError(f"Pair mismatch family={family} pair={pair_index} field={field}")
+    off_batches = [item["raw_batch_sha256"] for item in off["batches"]]
+    observed_batches = [item["raw_batch_sha256"] for item in observed["batches"]]
+    if off_batches != observed_batches:
+        raise RuntimeError(f"Trainer batch stream changed family={family} pair={pair_index}")
+    if not np.allclose(off["loss_items"], observed["loss_items"], rtol=1e-6, atol=1e-6):
+        raise RuntimeError(f"Trainer loss items changed family={family} pair={pair_index}")
+
+
+def _run_condition(
+    *,
+    trainer_class: Any,
+    predicate: Any,
+    source_root: Path,
+    scratch_root: Path,
+    run_dir: Path,
+    config: dict[str, Any],
+    family: str,
+    profile: dict[str, Any],
+    condition: str,
+    pair_index: int,
+    phase: str,
+    seed: int,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    label = f"{family}-{phase}-p{pair_index:02d}-{condition}"
+    writer_path = run_dir / f"events-{label}.jsonl" if condition == "capture_jsonl" else None
+    overrides = {
+        "model": str(source_root / profile["model_config"]),
+        "data": config["dataset"],
+        "epochs": int(config["epochs"]),
+        "batch": int(config["batch_size"]),
+        "imgsz": int(config["image_size"]),
+        "device": config["device"],
+        "workers": 0,
+        "amp": False,
+        "cache": False,
+        "val": False,
+        "plots": False,
+        "save": False,
+        "pretrained": False,
+        "optimizer": config["optimizer"]["name"],
+        "lr0": float(config["optimizer"]["learning_rate"]),
+        "momentum": float(config["optimizer"]["momentum"]),
+        "weight_decay": float(config["optimizer"]["weight_decay"]),
+        "warmup_epochs": 0.0,
+        "close_mosaic": 0,
+        "nbs": int(config["batch_size"]),
+        "mosaic": 0.0,
+        "mixup": 0.0,
+        "copy_paste": 0.0,
+        "degrees": 0.0,
+        "translate": 0.0,
+        "scale": 0.0,
+        "shear": 0.0,
+        "perspective": 0.0,
+        "fliplr": 0.0,
+        "flipud": 0.0,
+        "hsv_h": 0.0,
+        "hsv_s": 0.0,
+        "hsv_v": 0.0,
+        "multi_scale": 0.0,
+        "project": str(scratch_root),
+        "name": label,
+        "exist_ok": False,
+        "verbose": False,
+        "seed": seed,
+        "deterministic": True,
+    }
+    random.seed(seed)
+    np.random.seed(seed)
+    lifecycle_started = time.perf_counter()
+    trainer = trainer_class(overrides=overrides)
+    observer = _TrainerObserver(
+        family=family,
+        condition=condition,
+        pair_index=pair_index,
+        phase=phase,
+        run_id=f"{config['run_id']}-{family}-{phase}-p{pair_index:02d}",
+        writer_path=writer_path,
+        predicate=predicate,
+    )
+    observer.install(trainer)
+    try:
+        trainer.train()
+        full_lifecycle_ms = (time.perf_counter() - lifecycle_started) * 1000.0
+        if len(observer.epoch_windows_ms) != int(config["epochs"]) or observer.final_model_sha256 is None:
+            raise RuntimeError(f"Trainer callbacks did not complete for {label}")
+        events = load_jsonl(writer_path, limit=10000) if writer_path is not None else []
+        expected_events = len(observer.registered_modules) * len(observer.batch_records)
+        event_validation = (
+            _validate_event_stream(events, expected_count=expected_events, label=label)
+            if condition == "capture_jsonl"
+            else {"expected_count": 0, "actual_count": 0, "contiguous_from_zero": True}
+        )
+        row = {
+            "family": family,
+            "phase": phase,
+            "pair_index": pair_index,
+            "condition": condition,
+            "seed": seed,
+            "epoch_window_ms": float(sum(observer.epoch_windows_ms)),
+            "epoch_windows_ms": observer.epoch_windows_ms,
+            "full_lifecycle_ms": full_lifecycle_ms,
+            "batch_count": len(observer.batch_records),
+            "epochs_completed": len(observer.epoch_windows_ms),
+            "optimizer_steps": int(trainer.optimizer_steps),
+            "amp_enabled": bool(trainer.amp),
+            "device": str(trainer.device),
+            "registered_modules": observer.registered_modules,
+            "sanitized_transients": list(getattr(trainer, "evidence_sanitized_transients", [])),
+            "event_validation": event_validation,
+            "initial_model_sha256": observer.initial_model_sha256,
+            "initial_optimizer_sha256": observer.initial_optimizer_sha256,
+            "final_model_sha256": observer.final_model_sha256,
+            "final_optimizer_sha256": observer.final_optimizer_sha256,
+            "final_ema_sha256": observer.final_ema_sha256,
+            "loss_items": observer.loss_items,
+            "batches": observer.batch_records,
+            "metrics": _read_metrics_csv(Path(trainer.csv)),
+        }
+        return row, events
+    finally:
+        observer.close()
+
+
+def _family_summary(rows: list[dict[str, Any]], *, measured_pairs: int) -> dict[str, Any]:
+    measured = [row for row in rows if row["phase"] == "measured"]
+    by_pair: dict[int, dict[str, dict[str, Any]]] = {}
+    for row in measured:
+        by_pair.setdefault(int(row["pair_index"]), {})[str(row["condition"])] = row
+    slowdowns = []
+    lifecycle_slowdowns = []
+    for conditions in by_pair.values():
+        off = conditions["off"]
+        observed = conditions["capture_jsonl"]
+        slowdowns.append((observed["epoch_window_ms"] / off["epoch_window_ms"] - 1.0) * 100.0)
+        lifecycle_slowdowns.append((observed["full_lifecycle_ms"] / off["full_lifecycle_ms"] - 1.0) * 100.0)
+    observed_rows = [row for row in measured if row["condition"] == "capture_jsonl"]
+    return {
+        "measured_pairs": measured_pairs,
+        "ab_pairs": sum(_condition_order(index)[0] == "off" for index in by_pair),
+        "ba_pairs": sum(_condition_order(index)[0] == "capture_jsonl" for index in by_pair),
+        "epoch_window_slowdown_percent": {
+            "values": slowdowns,
+            "median": float(np.median(slowdowns)),
+            "min": float(np.min(slowdowns)),
+            "max": float(np.max(slowdowns)),
+        },
+        "full_lifecycle_slowdown_percent": {
+            "values": lifecycle_slowdowns,
+            "median": float(np.median(lifecycle_slowdowns)),
+            "min": float(np.min(lifecycle_slowdowns)),
+            "max": float(np.max(lifecycle_slowdowns)),
+        },
+        "registered_modules": observed_rows[0]["registered_modules"],
+        "batch_count_per_run": observed_rows[0]["batch_count"],
+        "epochs_per_run": observed_rows[0]["epochs_completed"],
+        "optimizer_steps_per_run": observed_rows[0]["optimizer_steps"],
+        "writer_event_count": sum(row["event_validation"]["actual_count"] for row in observed_rows),
+        "setup_transient_sanitization_count_per_run": len(observed_rows[0]["sanitized_transients"]),
+        "pair_equivalence": "PASS",
+        "purpose": "integration cross-check; not a replacement formal overhead verdict",
+    }
+
+
+def run(
+    config_path: Path,
+    *,
+    run_id: str | None = None,
+    update_latest: bool = True,
+    family: str | None = None,
+    preflight: bool = False,
+) -> Path:
+    config = _load_engine_config(config_path, run_id)
+    if family is not None:
+        if family not in config["profiles"]:
+            raise ValueError(f"Unknown engine profile: {family}")
+        config["profiles"] = {family: config["profiles"][family]}
+    if preflight:
+        config["warmup_pairs"] = 0
+        config["measured_pairs"] = 2
+    config["execution_mode"] = "preflight" if preflight else "integration_crosscheck"
+    run_dir = PROJECT_ROOT / "artifacts" / "p1-engine" / config["run_id"]
+    if run_dir.exists() and any(run_dir.iterdir()):
+        raise FileExistsError(f"Refusing to overwrite non-empty engine evidence directory: {run_dir}")
+    run_dir.mkdir(parents=True, exist_ok=True)
+    scratch_root = run_dir / "_scratch"
+    logger = _logger(run_dir / "full.log")
+    (run_dir / "config.resolved.yaml").write_text(
+        yaml.safe_dump(config, sort_keys=False, allow_unicode=True), encoding="utf-8", newline="\n"
+    )
+    command = "python -m e3_p1.engine_crosscheck --config configs/p1_engine_crosscheck.yaml"
+    if run_id:
+        command += f" --run-id {config['run_id']}"
+    if family:
+        command += f" --family {family}"
+    if preflight:
+        command += " --preflight"
+    if not update_latest:
+        command += " --no-update-latest"
+    (run_dir / "command.txt").write_text(command + "\n", encoding="utf-8", newline="\n")
+
+    source_root = (PROJECT_ROOT / config["runtime_root"]).resolve()
+    try:
+        runtime_verification = _verify_runtime_inputs(source_root, config)
+        write_json(run_dir / "runtime-inputs.json", runtime_verification)
+        sys.path.insert(0, str(source_root))
+        os.chdir(PROJECT_ROOT)
+        import torch
+        from ultralytics.models.yolo.detect import DetectionTrainer
+        from ultralytics.nn.modules.routing_protocol import is_routed_module
+
+        class EvidenceDetectionTrainer(DetectionTrainer):
+            """Use the official train loop while suppressing checkpoint I/O in this evidence harness."""
+
+            def _bootstrap_healthy_checkpoint(self) -> None:
+                return None
+
+            def _refresh_healthy_checkpoint(self) -> bool:
+                return False
+
+            def save_model(self) -> bool:
+                return False
+
+            def get_model(self, cfg: str | None = None, weights: str | None = None, verbose: bool = True) -> Any:
+                model = super().get_model(cfg=cfg, weights=weights, verbose=verbose)
+                self.evidence_sanitized_transients = _clear_nonleaf_latent_transients(model)
+                return model
+
+        write_json(
+            run_dir / "environment.json",
+            environment(torch, source_root, PROJECT_ROOT, config["official_runtime_ref"], config["official_runtime_tree"]),
+        )
+        all_rows = []
+        all_events = []
+        family_summaries = {}
+        total_pairs = int(config["warmup_pairs"]) + int(config["measured_pairs"])
+        for family_name, profile in config["profiles"].items():
+            family_rows = []
+            for absolute_index in range(total_pairs):
+                phase = "warmup" if absolute_index < config["warmup_pairs"] else "measured"
+                pair_index = absolute_index if phase == "warmup" else absolute_index - config["warmup_pairs"]
+                seed = int(config["seed"]) + 1000 * list(config["profiles"]).index(family_name) + pair_index
+                order = _condition_order(absolute_index)
+                pair_rows = {}
+                for position, condition in enumerate(order):
+                    row, events = _run_condition(
+                        trainer_class=EvidenceDetectionTrainer,
+                        predicate=is_routed_module,
+                        source_root=source_root,
+                        scratch_root=scratch_root,
+                        run_dir=run_dir,
+                        config=config,
+                        family=family_name,
+                        profile=profile,
+                        condition=condition,
+                        pair_index=pair_index,
+                        phase=phase,
+                        seed=seed,
+                    )
+                    row["order"] = order
+                    row["position"] = position
+                    pair_rows[condition] = row
+                    family_rows.append(row)
+                    all_rows.append(row)
+                    all_events.extend(events)
+                _assert_pair_equivalence(pair_rows["off"], pair_rows["capture_jsonl"], family=family_name, pair_index=pair_index)
+                logger.info(
+                    "family=%s phase=%s pair=%d order=%s epoch_off_ms=%.3f epoch_on_ms=%.3f equivalent=PASS",
+                    family_name,
+                    phase,
+                    pair_index,
+                    "/".join(order),
+                    pair_rows["off"]["epoch_window_ms"],
+                    pair_rows["capture_jsonl"]["epoch_window_ms"],
+                )
+            family_summaries[family_name] = _family_summary(
+                family_rows, measured_pairs=int(config["measured_pairs"])
+            )
+        write_jsonl(run_dir / "trainer-runs.jsonl", all_rows)
+        write_jsonl(run_dir / "routing-engine-all.jsonl", all_events)
+        snapshot = build_snapshot(all_events)
+        write_json(run_dir / "dashboard-snapshot.json", snapshot)
+        (run_dir / "dashboard.html").write_text(render_dashboard_html(), encoding="utf-8", newline="\n")
+        dashboard_smoke = smoke_test_server(run_dir / "routing-engine-all.jsonl")
+        write_json(run_dir / "dashboard-smoke.json", dashboard_smoke)
+        if dashboard_smoke["status"] != "PASS" or set(dashboard_smoke["api_families"]) != set(config["profiles"]):
+            raise RuntimeError("Dashboard failed to consume the Trainer-generated event stream")
+        save_engine_crosscheck_plot(
+            family_summaries,
+            run_dir / "trainer-epoch-crosscheck.png",
+            float(config["target_slowdown_percent"]),
+        )
+        summary = {
+            "status": "PREFLIGHT_COMPLETE" if preflight else "PASS",
+            "execution_mode": config["execution_mode"],
+            "formal_verdict_eligible": False,
+            "scope": "real Ultralytics DetectionTrainer and coco8 dataloader integration cross-check",
+            "run_id": config["run_id"],
+            "official_runtime_ref": config["official_runtime_ref"],
+            "official_runtime_tree": config["official_runtime_tree"],
+            "runtime_verification": runtime_verification["mode"],
+            "families": family_summaries,
+            "dashboard": dashboard_smoke,
+            "event_count": len(all_events),
+            "methodology": {
+                "conditions": list(CONDITIONS),
+                "order": "balanced AB/BA by pair",
+                "warmup_pairs": int(config["warmup_pairs"]),
+                "measured_pairs": int(config["measured_pairs"]),
+                "timed_epoch_window": "sum of each on_train_epoch_start through on_train_epoch_end window, including dataloader iteration, preprocess, detection loss, backward, optimizer steps, event JSON encoding/write/flush",
+                "full_lifecycle_window": "trainer construction through train completion",
+                "determinism": "same pair seed; stochastic geometric/color augmentation disabled; raw collated batch hashes must match",
+                "equivalence": "initial/final model, optimizer and EMA hashes; raw batch hashes; loss items; optimizer step count",
+                "checkpoint_policy": "checkpoint serialization suppressed in the harness; official dataloader, preprocess, loss, backward, optimizer and callback loop retained",
+                "latent_setup_guard": "clear only non-leaf _last_routing_logits/probs/summary snapshots after model construction so ModelEMA deepcopy can start; records are stored per run",
+            },
+            "interpretation": "Integration evidence only. The preregistered 108-pair strengthened run remains the formal <10% overhead verdict.",
+            "limitations": [
+                "CPU-only, five coco8 train epochs per execution, batch=2, imgsz=64.",
+                "The configured measured pairs are descriptive and intentionally not used for a new confidence-bound verdict.",
+                "Validation, checkpoint serialization, CUDA, AMP and multi-epoch convergence are outside this cross-check.",
+                "The frozen Latent model cannot enter ModelEMA deepcopy without clearing nine constructor-time non-leaf routing snapshot fields; this harness records and applies that setup guard without changing state_dict parameters.",
+            ],
+        }
+        write_json(run_dir / "summary.json", summary)
+        if scratch_root.exists():
+            resolved_scratch = scratch_root.resolve()
+            if run_dir.resolve() not in resolved_scratch.parents:
+                raise RuntimeError("Refusing to remove scratch directory outside the evidence run")
+            shutil.rmtree(resolved_scratch)
+        write_manifest(run_dir)
+        if update_latest:
+            latest = PROJECT_ROOT / "artifacts" / "p1-engine" / "LATEST.txt"
+            latest.parent.mkdir(parents=True, exist_ok=True)
+            latest.write_text(config["run_id"] + "\n", encoding="utf-8", newline="\n")
+        logger.info("result=PASS trainer_runs=%d events=%d artifacts=%s", len(all_rows), len(all_events), run_dir)
+        write_manifest(run_dir)
+        return run_dir
+    except Exception as exc:
+        write_json(
+            run_dir / "failure.json",
+            {
+                "status": "FAIL",
+                "error_type": type(exc).__name__,
+                "message": str(exc),
+                "traceback": traceback.format_exc(),
+            },
+        )
+        logger.exception("engine cross-check failed")
+        write_manifest(run_dir)
+        raise
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=PROJECT_ROOT / "configs" / "p1_engine_crosscheck.yaml")
+    parser.add_argument("--run-id")
+    parser.add_argument("--family")
+    parser.add_argument("--preflight", action="store_true")
+    parser.add_argument("--no-update-latest", action="store_true")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    run(
+        args.config.resolve(),
+        run_id=args.run_id,
+        update_latest=not args.no_update_latest,
+        family=args.family,
+        preflight=args.preflight,
+    )

--- a/tools/e3_routing/src/e3_p1/plotting.py
+++ b/tools/e3_routing/src/e3_p1/plotting.py
@@ -1,0 +1,132 @@
+"""Evidence plots for the P1 paired training-path benchmark."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+def save_benchmark_plot(families: dict[str, dict[str, Any]], path: Path, target_percent: float) -> None:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    names = list(families)
+    figure, axes = plt.subplots(1, 2, figsize=(12.5, 5.2), constrained_layout=True)
+    x = np.arange(len(names))
+    off = [families[name]["off_ms"]["median"] for name in names]
+    on = [families[name]["on_ms"]["median"] for name in names]
+    width = 0.34
+    axes[0].bar(x - width / 2, off, width, label="Hook off", color="#61758A")
+    axes[0].bar(x + width / 2, on, width, label="Hook on", color="#2F6FAE")
+    axes[0].set_xticks(x, [name.upper() for name in names])
+    axes[0].set_ylabel("Median train-path forward+backward (ms)")
+    axes[0].set_title("Paired observer timing")
+    axes[0].grid(axis="y", color="#D8DEE6")
+    axes[0].legend()
+
+    slowdowns = [families[name]["paired_slowdown_percent"]["median"] for name in names]
+    lower = [families[name]["paired_slowdown_percent"]["bootstrap_95_ci"][0] for name in names]
+    upper = [families[name]["paired_slowdown_percent"]["bootstrap_95_ci"][1] for name in names]
+    errors = np.asarray([[value - low for value, low in zip(slowdowns, lower)], [high - value for value, high in zip(slowdowns, upper)]])
+    colors = ["#50A47B" if value < target_percent else "#C83E4D" for value in slowdowns]
+    axes[1].bar(x, slowdowns, yerr=errors, capsize=5, color=colors)
+    axes[1].axhline(target_percent, color="#C83E4D", linestyle="--", label=f"Target < {target_percent:g}%")
+    axes[1].axhline(0.0, color="#61758A", linewidth=0.9)
+    axes[1].set_xticks(x, [name.upper() for name in names])
+    axes[1].set_ylabel("Paired slowdown (%)")
+    axes[1].set_title("Median and bootstrap 95% CI")
+    axes[1].grid(axis="y", color="#D8DEE6")
+    axes[1].legend()
+    figure.suptitle("E3 P1 observer-overhead benchmark · real train-mode forward+backward")
+    figure.savefig(path, dpi=180)
+    plt.close(figure)
+
+
+def save_strengthened_plot(families: dict[str, dict[str, Any]], path: Path, target_percent: float) -> None:
+    """Plot full-step condition timings and layered paired slowdowns."""
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    names = list(families)
+    x = np.arange(len(names))
+    figure, axes = plt.subplots(1, 2, figsize=(13.5, 5.4), constrained_layout=True)
+    width = 0.25
+    condition_styles = (
+        ("off", "Off", "#61758A"),
+        ("capture", "Capture", "#2F6FAE"),
+        ("capture_jsonl", "Capture + JSONL", "#50A47B"),
+    )
+    for offset, (condition, label, color) in zip((-width, 0.0, width), condition_styles):
+        values = [families[name]["condition_ms"][condition]["median"] for name in names]
+        axes[0].bar(x + offset, values, width, label=label, color=color)
+    axes[0].set_xticks(x, [name.upper() for name in names])
+    axes[0].set_ylabel("Median two-batch full-step unit (ms)")
+    axes[0].set_title("Detection loss + backward + optimizer")
+    axes[0].grid(axis="y", color="#D8DEE6")
+    axes[0].legend()
+
+    comparison_styles = (
+        ("capture_vs_off_percent", "Capture vs off", "#2F6FAE", -0.12),
+        ("capture_jsonl_vs_off_percent", "Capture + JSONL vs off", "#50A47B", 0.12),
+    )
+    for key, label, color, offset in comparison_styles:
+        values = [families[name]["comparisons"][key]["median"] for name in names]
+        lower = [families[name]["comparisons"][key]["bootstrap_95_ci"][0] for name in names]
+        upper = [families[name]["comparisons"][key]["bootstrap_95_ci"][1] for name in names]
+        errors = np.asarray(
+            [[value - low for value, low in zip(values, lower)], [high - value for value, high in zip(values, upper)]]
+        )
+        axes[1].errorbar(x + offset, values, yerr=errors, fmt="o", capsize=5, color=color, label=label)
+    axes[1].axhline(target_percent, color="#C83E4D", linestyle="--", label=f"Task target < {target_percent:g}%")
+    axes[1].axhline(0.0, color="#61758A", linewidth=0.9)
+    axes[1].set_xticks(x, [name.upper() for name in names])
+    axes[1].set_ylabel("Paired slowdown (%)")
+    axes[1].set_title("Median and bootstrap 95% CI")
+    axes[1].grid(axis="y", color="#D8DEE6")
+    axes[1].legend()
+    figure.suptitle("E3 P1 strengthened layered observer benchmark")
+    figure.savefig(path, dpi=180)
+    plt.close(figure)
+
+
+def save_engine_crosscheck_plot(families: dict[str, dict[str, Any]], path: Path, target_percent: float) -> None:
+    """Plot descriptive Trainer epoch-window pairs without making a new formal verdict."""
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    names = list(families)
+    x = np.arange(len(names))
+    figure, axes = plt.subplots(1, 2, figsize=(13.5, 5.4), constrained_layout=True)
+    values = [families[name]["epoch_window_slowdown_percent"]["values"] for name in names]
+    axes[0].boxplot(values, tick_labels=[name.upper() for name in names], showmeans=True)
+    for index, samples in enumerate(values, start=1):
+        axes[0].scatter(np.full(len(samples), index), samples, color="#2F6FAE", s=24, zorder=3)
+    axes[0].axhline(target_percent, color="#C83E4D", linestyle="--", label=f"P1 context: {target_percent:g}%")
+    axes[0].axhline(0.0, color="#61758A", linewidth=0.9)
+    axes[0].set_ylabel("Paired epoch-window slowdown (%)")
+    axes[0].set_title("Six Trainer pairs per family (descriptive)")
+    axes[0].grid(axis="y", color="#D8DEE6")
+    axes[0].legend()
+
+    event_counts = [families[name]["writer_event_count"] for name in names]
+    # Event volume is an integrity metric, not a pass/fail result for the descriptive timing panel.
+    axes[1].bar(x, event_counts, color=["#3B82F6", "#14B8A6", "#8B5CF6"])
+    axes[1].set_xticks(x, [name.upper() for name in names])
+    axes[1].set_ylabel("Trainer-generated JSONL events")
+    axes[1].set_title("Writer stream consumed by dashboard HTTP API")
+    axes[1].grid(axis="y", color="#D8DEE6")
+    for index, count in enumerate(event_counts):
+        axes[1].text(index, count, str(count), ha="center", va="bottom")
+    figure.suptitle("E3 P1 · real DetectionTrainer integration cross-check (not the formal verdict)")
+    figure.savefig(path, dpi=180)
+    plt.close(figure)

--- a/tools/e3_routing/src/e3_p1/strengthened.py
+++ b/tools/e3_routing/src/e3_p1/strengthened.py
@@ -1,0 +1,688 @@
+"""Run the strengthened P1 full detection-step paired benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import math
+import os
+import random
+import re
+import sys
+import time
+import traceback
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, TextIO
+
+import numpy as np
+import yaml
+
+from e3_p0.collector import RoutingCollector
+from e3_p0.io_utils import environment, sha256_file, write_json, write_jsonl, write_manifest
+from e3_p0.runner import _load_tensor, _resolve_images, _validate_events
+
+from .benchmark import _bootstrap_median_ci, _state_sha256, _stats
+from .plotting import save_strengthened_plot
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+RUN_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
+CONDITIONS = ("off", "capture", "capture_jsonl")
+CONDITION_ORDERS = (
+    ("off", "capture", "capture_jsonl"),
+    ("off", "capture_jsonl", "capture"),
+    ("capture", "off", "capture_jsonl"),
+    ("capture", "capture_jsonl", "off"),
+    ("capture_jsonl", "off", "capture"),
+    ("capture_jsonl", "capture", "off"),
+)
+
+
+def _load_strengthened_config(config_path: Path, run_id_override: str | None = None) -> dict[str, Any]:
+    loaded = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise TypeError(f"Config must contain a mapping: {config_path}")
+    config = dict(loaded)
+    run_id = str(run_id_override if run_id_override is not None else config.get("run_id", "")).strip()
+    if not RUN_ID_PATTERN.fullmatch(run_id):
+        raise ValueError("run_id must be path-safe and contain at most 128 letters, digits, dots, underscores, or hyphens")
+    config["run_id"] = run_id
+    for name in ("batch_size", "warmup_pairs", "bootstrap_resamples"):
+        config[name] = int(config[name])
+        if config[name] <= 0:
+            raise ValueError(f"{name} must be positive")
+    if config["warmup_pairs"] % len(CONDITION_ORDERS) != 0:
+        raise ValueError("warmup_pairs must be divisible by 6 for balanced three-condition ordering")
+    batches = [[int(value) for value in batch] for batch in config["sample_batches"]]
+    if not batches or any(len(batch) != config["batch_size"] for batch in batches):
+        raise ValueError("every sample_batches entry must contain exactly batch_size indices")
+    if len({value for batch in batches for value in batch}) != sum(len(batch) for batch in batches):
+        raise ValueError("sample_batches must not repeat image indices")
+    config["sample_batches"] = batches
+    if not isinstance(config.get("profiles"), dict) or not config["profiles"]:
+        raise ValueError("profiles must contain at least one routing family")
+    for family, profile in config["profiles"].items():
+        profile["measured_pairs"] = int(profile["measured_pairs"])
+        if profile["measured_pairs"] < 30 or profile["measured_pairs"] % len(CONDITION_ORDERS) != 0:
+            raise ValueError(f"profiles.{family}.measured_pairs must be at least 30 and divisible by 6")
+    return config
+
+
+def _logger(path: Path) -> logging.Logger:
+    logger = logging.getLogger("e3_p1_strengthened")
+    logger.handlers.clear()
+    logger.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
+    console = logging.StreamHandler(sys.stdout)
+    file_handler = logging.FileHandler(path, encoding="utf-8", mode="w")
+    console.setFormatter(formatter)
+    file_handler.setFormatter(formatter)
+    logger.addHandler(console)
+    logger.addHandler(file_handler)
+    return logger
+
+
+def _condition_order(pair_index: int) -> list[str]:
+    return list(CONDITION_ORDERS[pair_index % len(CONDITION_ORDERS)])
+
+
+def _label_path(image_path: Path) -> Path:
+    parts = list(image_path.parts)
+    positions = [index for index, part in enumerate(parts) if part.lower() == "images"]
+    if not positions:
+        raise ValueError(f"Image path has no 'images' component: {image_path}")
+    parts[positions[-1]] = "labels"
+    return Path(*parts).with_suffix(".txt")
+
+
+def _load_yolo_labels(label_path: Path, *, num_classes: int) -> np.ndarray:
+    if not label_path.is_file():
+        raise FileNotFoundError(f"YOLO label file not found: {label_path}")
+    rows = []
+    for line_number, raw in enumerate(label_path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not raw.strip():
+            continue
+        values = [float(value) for value in raw.split()]
+        if len(values) != 5:
+            raise ValueError(f"Expected 5 YOLO label fields at {label_path}:{line_number}")
+        class_id, *box = values
+        if class_id != int(class_id) or not 0 <= int(class_id) < num_classes:
+            raise ValueError(f"Invalid class id at {label_path}:{line_number}: {class_id}")
+        if any(not 0.0 <= value <= 1.0 for value in box):
+            raise ValueError(f"YOLO box must be normalized to [0, 1] at {label_path}:{line_number}")
+        rows.append(values)
+    return np.asarray(rows, dtype=np.float32).reshape(-1, 5)
+
+
+def _build_detection_batches(
+    config: dict[str, Any], *, torch_module: Any, num_classes: int
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    flat_indices = [index for batch in config["sample_batches"] for index in batch]
+    paths, dataset_meta = _resolve_images(config["dataset"], config["dataset_split"], flat_indices)
+    by_index = dict(zip(flat_indices, paths))
+    batches = []
+    input_records = []
+    for batch_number, indices in enumerate(config["sample_batches"]):
+        images = []
+        classes = []
+        boxes = []
+        batch_indices = []
+        for within_batch, sample_index in enumerate(indices):
+            image_path = by_index[sample_index]
+            image, metadata = _load_tensor(image_path, int(config["image_size"]), torch_module)
+            label_path = _label_path(image_path)
+            labels = _load_yolo_labels(label_path, num_classes=num_classes)
+            metadata.update(
+                {
+                    "sample_index": sample_index,
+                    "batch_number": batch_number,
+                    "label_path": str(label_path),
+                    "label_sha256": sha256_file(label_path),
+                    "target_count": len(labels),
+                }
+            )
+            input_records.append(metadata)
+            images.append(image)
+            if len(labels):
+                classes.append(torch_module.from_numpy(labels[:, :1]))
+                boxes.append(torch_module.from_numpy(labels[:, 1:]))
+                batch_indices.append(torch_module.full((len(labels),), within_batch, dtype=torch_module.long))
+        device = config["device"]
+        batch = {
+            "img": torch_module.stack(images, dim=0).to(device),
+            "cls": torch_module.cat(classes, dim=0).to(device) if classes else torch_module.empty((0, 1), device=device),
+            "bboxes": torch_module.cat(boxes, dim=0).to(device) if boxes else torch_module.empty((0, 4), device=device),
+            "batch_idx": (
+                torch_module.cat(batch_indices, dim=0).to(device)
+                if batch_indices
+                else torch_module.empty((0,), dtype=torch_module.long, device=device)
+            ),
+        }
+        batches.append(batch)
+    return batches, {
+        **dataset_meta,
+        "dataset": config["dataset"],
+        "split": config["dataset_split"],
+        "sample_batches": config["sample_batches"],
+        "batch_size": config["batch_size"],
+        "images": input_records,
+    }
+
+
+def _official_optimizer(model: Any, config: dict[str, Any], base_trainer_class: Any) -> Any:
+    optimizer_config = config["optimizer"]
+    proxy = SimpleNamespace(
+        args=SimpleNamespace(
+            moe_router_lr_scale=float(optimizer_config["router_lr_scale"]),
+            lora_lr_mult=1.0,
+            warmup_bias_lr=0.0,
+        ),
+        data={"nc": int(model.yaml["nc"])},
+        adapter_controller=None,
+    )
+    return base_trainer_class.build_optimizer(
+        proxy,
+        model,
+        name=str(optimizer_config["name"]),
+        lr=float(optimizer_config["learning_rate"]),
+        momentum=float(optimizer_config["momentum"]),
+        decay=float(optimizer_config["weight_decay"]),
+        iterations=1000,
+    )
+
+
+def _finite_scalar(value: float, *, name: str) -> float:
+    if not math.isfinite(value):
+        raise RuntimeError(f"Non-finite {name}: {value}")
+    return value
+
+
+def _full_detection_step(
+    model: Any,
+    optimizer: Any,
+    batch: dict[str, Any],
+    *,
+    seed: int,
+    torch_module: Any,
+    gradient_clip_norm: float,
+    post_step: Any | None = None,
+) -> dict[str, Any]:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch_module.manual_seed(seed)
+    if batch["img"].device.type == "cuda":
+        torch_module.cuda.synchronize(batch["img"].device)
+    started = time.perf_counter()
+    optimizer.zero_grad(set_to_none=True)
+    losses, loss_items = model.loss(batch)
+    total_loss = losses.sum()
+    total_loss.backward()
+    gradient_norm = torch_module.nn.utils.clip_grad_norm_(model.parameters(), max_norm=gradient_clip_norm)
+    optimizer.step()
+    if post_step is not None:
+        post_step()
+    if batch["img"].device.type == "cuda":
+        torch_module.cuda.synchronize(batch["img"].device)
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    result = {
+        "elapsed_ms": _finite_scalar(float(elapsed_ms), name="elapsed_ms"),
+        "loss_total": _finite_scalar(float(total_loss.detach().cpu()), name="loss_total"),
+        "loss_components": [_finite_scalar(float(value), name="loss_component") for value in loss_items.cpu().view(-1)],
+        "gradient_norm_preclip": _finite_scalar(float(gradient_norm.detach().cpu()), name="gradient_norm"),
+    }
+    return result
+
+
+def _assert_step_equivalence(
+    reference: list[dict[str, Any]],
+    candidate: list[dict[str, Any]],
+    *,
+    family: str,
+    condition: str,
+    config: dict[str, Any],
+) -> None:
+    if len(reference) != len(candidate):
+        raise RuntimeError(f"Step count differs for family={family} condition={condition}")
+    for step_index, (off, observed) in enumerate(zip(reference, candidate)):
+        if not np.isclose(
+            off["loss_total"],
+            observed["loss_total"],
+            rtol=float(config["loss_match_rtol"]),
+            atol=float(config["loss_match_atol"]),
+        ):
+            raise RuntimeError(
+                f"Detection loss changed for family={family} condition={condition} step={step_index}: "
+                f"off={off['loss_total']} observed={observed['loss_total']}"
+            )
+        if not np.allclose(
+            off["loss_components"],
+            observed["loss_components"],
+            rtol=float(config["loss_match_rtol"]),
+            atol=float(config["loss_match_atol"]),
+        ):
+            raise RuntimeError(f"Detection loss components changed for family={family} condition={condition}")
+        if not np.isclose(
+            off["gradient_norm_preclip"],
+            observed["gradient_norm_preclip"],
+            rtol=float(config["gradient_match_rtol"]),
+            atol=float(config["gradient_match_atol"]),
+        ):
+            raise RuntimeError(f"Gradient norm changed for family={family} condition={condition}")
+
+
+def _comparison_summary(values: list[float], *, config: dict[str, Any], seed: int) -> dict[str, Any]:
+    result = _stats(values)
+    result["bootstrap_95_ci"] = _bootstrap_median_ci(
+        values, resamples=int(config["bootstrap_resamples"]), seed=seed
+    )
+    result["task_status"] = "PASS" if result["median"] < float(config["target_slowdown_percent"]) else "FAIL"
+    result["evidence_strength"] = (
+        "STRONG" if result["bootstrap_95_ci"][1] < float(config["target_slowdown_percent"]) else "INCONCLUSIVE"
+    )
+    return result
+
+
+def _writer_callback(handle: TextIO) -> Any:
+    def write_event(event: dict[str, Any]) -> None:
+        handle.write(json.dumps(event, sort_keys=True, ensure_ascii=False, separators=(",", ":")) + "\n")
+
+    return write_event
+
+
+def _validate_event_stream(events: list[dict[str, Any]], *, expected_count: int, label: str) -> dict[str, Any]:
+    sequences = [int(event["sequence"]) for event in events]
+    expected_sequences = list(range(expected_count))
+    if len(events) != expected_count:
+        raise RuntimeError(f"Event count differs for {label}: expected={expected_count} actual={len(events)}")
+    if sequences != expected_sequences:
+        raise RuntimeError(f"Event sequence is not contiguous for {label}")
+    return {
+        "expected_count": expected_count,
+        "actual_count": len(events),
+        "first_sequence": sequences[0] if sequences else None,
+        "last_sequence": sequences[-1] if sequences else None,
+        "contiguous_from_zero": True,
+    }
+
+
+def _benchmark_family(
+    *,
+    family: str,
+    profile: dict[str, Any],
+    config: dict[str, Any],
+    source_root: Path,
+    batches: list[dict[str, Any]],
+    run_dir: Path,
+    logger: logging.Logger,
+    torch_module: Any,
+    yolo_class: Any,
+    predicate: Any,
+    base_trainer_class: Any,
+) -> tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]]]:
+    seed = int(config["seed"])
+    model_config = source_root / profile["model_config"]
+    models = {}
+    optimizers = {}
+    collectors: dict[str, RoutingCollector] = {}
+    writer_path = run_dir / f"writer-events-{family}.jsonl"
+    writer_handle = writer_path.open("w", encoding="utf-8", newline="\n")
+    try:
+        for condition in CONDITIONS:
+            random.seed(seed)
+            np.random.seed(seed)
+            torch_module.manual_seed(seed)
+            model = yolo_class(model_config).model.to(config["device"]).train()
+            if isinstance(model.args, dict):
+                from ultralytics.cfg import get_cfg
+
+                model.args = get_cfg(model.args)
+            models[condition] = model
+            optimizers[condition] = _official_optimizer(model, config, base_trainer_class)
+        initial_model_hashes = {condition: _state_sha256(model) for condition, model in models.items()}
+        initial_optimizer_hashes = {
+            condition: _state_sha256(optimizer) for condition, optimizer in optimizers.items()
+        }
+        if len(set(initial_model_hashes.values())) != 1 or len(set(initial_optimizer_hashes.values())) != 1:
+            raise RuntimeError(f"Initial model/optimizer states differ for family={family}")
+
+        for condition in ("capture", "capture_jsonl"):
+            collector = RoutingCollector(family=family, run_id=config["run_id"], max_events=4096)
+            if condition == "capture_jsonl":
+                collector.event_callback = _writer_callback(writer_handle)
+            registered = collector.register(models[condition], predicate=predicate)
+            if not registered:
+                raise RuntimeError(f"No routed modules discovered for family={family} condition={condition}")
+            collectors[condition] = collector
+        if collectors["capture"].registered_names != collectors["capture_jsonl"].registered_names:
+            raise RuntimeError(f"Collector module sets differ for family={family}")
+        registered = collectors["capture"].registered_names
+
+        rows = []
+        capture_samples = []
+        total_pairs = int(config["warmup_pairs"]) + int(profile["measured_pairs"])
+        for absolute_index in range(total_pairs):
+            phase = "warmup" if absolute_index < int(config["warmup_pairs"]) else "measured"
+            pair_index = absolute_index if phase == "warmup" else absolute_index - int(config["warmup_pairs"])
+            order = _condition_order(absolute_index)
+            condition_results: dict[str, dict[str, Any]] = {}
+            for condition in order:
+                step_results = []
+                captured_total = 0
+                for batch_number, batch in enumerate(batches):
+                    step_seed = seed + 10000 + absolute_index * len(batches) + batch_number
+                    collector = collectors.get(condition)
+                    events_before = len(collector.events) if collector is not None else 0
+                    if collector is not None:
+                        collector.set_context(
+                            phase=phase,
+                            pair_index=pair_index,
+                            batch_number=batch_number,
+                            batch_size=int(config["batch_size"]),
+                            sample_indices=config["sample_batches"][batch_number],
+                            mode="detection_loss_backward_optimizer",
+                            condition=condition,
+                        )
+                    post_step = None
+                    if condition == "capture_jsonl" and bool(config["writer_flush_each_step"]):
+                        post_step = writer_handle.flush
+                    result = _full_detection_step(
+                        models[condition],
+                        optimizers[condition],
+                        batch,
+                        seed=step_seed,
+                        torch_module=torch_module,
+                        gradient_clip_norm=float(config["gradient_clip_norm"]),
+                        post_step=post_step,
+                    )
+                    if collector is not None:
+                        new_events = collector.events[events_before:]
+                        if len(new_events) != len(registered):
+                            raise RuntimeError(
+                                f"Expected {len(registered)} events, got {len(new_events)} for "
+                                f"family={family} condition={condition} phase={phase} pair={pair_index} batch={batch_number}"
+                            )
+                        if phase == "measured" and pair_index == 0:
+                            _validate_events(new_events)
+                            if condition == "capture":
+                                capture_samples.extend(new_events)
+                        captured_total += len(new_events)
+                    step_results.append(result)
+                condition_results[condition] = {
+                    "elapsed_ms": sum(step["elapsed_ms"] for step in step_results),
+                    "steps": step_results,
+                    "captured_events": captured_total,
+                }
+
+            for condition in ("capture", "capture_jsonl"):
+                _assert_step_equivalence(
+                    condition_results["off"]["steps"],
+                    condition_results[condition]["steps"],
+                    family=family,
+                    condition=condition,
+                    config=config,
+                )
+            model_hashes = {condition: _state_sha256(model) for condition, model in models.items()}
+            optimizer_hashes = {
+                condition: _state_sha256(optimizer) for condition, optimizer in optimizers.items()
+            }
+            if len(set(model_hashes.values())) != 1:
+                raise RuntimeError(f"Model trajectories diverged for family={family} phase={phase} pair={pair_index}")
+            if len(set(optimizer_hashes.values())) != 1:
+                raise RuntimeError(f"Optimizer trajectories diverged for family={family} phase={phase} pair={pair_index}")
+            if phase == "measured":
+                off_ms = condition_results["off"]["elapsed_ms"]
+                capture_ms = condition_results["capture"]["elapsed_ms"]
+                writer_ms = condition_results["capture_jsonl"]["elapsed_ms"]
+                rows.append(
+                    {
+                        "family": family,
+                        "pair_index": pair_index,
+                        "execution_order": order,
+                        "step_count": len(batches),
+                        "conditions": condition_results,
+                        "capture_vs_off_percent": (capture_ms - off_ms) / off_ms * 100.0,
+                        "capture_jsonl_vs_off_percent": (writer_ms - off_ms) / off_ms * 100.0,
+                        "writer_increment_vs_capture_percent": (writer_ms - capture_ms) / capture_ms * 100.0,
+                        "model_state_sha256": model_hashes,
+                        "optimizer_state_sha256": optimizer_hashes,
+                        "state_equivalence": True,
+                    }
+                )
+
+        expected_event_count = total_pairs * len(batches) * len(registered)
+        event_stream_validation = {
+            condition: _validate_event_stream(
+                collector.events,
+                expected_count=expected_event_count,
+                label=f"family={family} condition={condition}",
+            )
+            for condition, collector in collectors.items()
+        }
+
+        capture_values = [row["capture_vs_off_percent"] for row in rows]
+        full_values = [row["capture_jsonl_vs_off_percent"] for row in rows]
+        writer_values = [row["writer_increment_vs_capture_percent"] for row in rows]
+        comparisons = {
+            "capture_vs_off_percent": _comparison_summary(capture_values, config=config, seed=seed + 101),
+            "capture_jsonl_vs_off_percent": _comparison_summary(full_values, config=config, seed=seed + 202),
+            "writer_increment_vs_capture_percent": _comparison_summary(writer_values, config=config, seed=seed + 303),
+        }
+        primary = comparisons["capture_jsonl_vs_off_percent"]
+        summary = {
+            "status": primary["task_status"],
+            "evidence_strength": primary["evidence_strength"],
+            "model_config": profile["model_config"],
+            "model_parameters": sum(parameter.numel() for parameter in models["off"].parameters()),
+            "registered_modules": registered,
+            "measured_pairs": len(rows),
+            "steps_per_condition": len(rows) * len(batches),
+            "order_position_balance": {
+                condition: [sum(row["execution_order"][position] == condition for row in rows) for position in range(3)]
+                for condition in CONDITIONS
+            },
+            "initial_model_state_sha256": initial_model_hashes,
+            "initial_optimizer_state_sha256": initial_optimizer_hashes,
+            "loss_gradient_and_state_equivalence": "PASS",
+            "event_stream_validation": event_stream_validation,
+            "hooks_removed": False,
+            "condition_ms": {
+                condition: _stats([row["conditions"][condition]["elapsed_ms"] for row in rows])
+                for condition in CONDITIONS
+            },
+            "comparisons": comparisons,
+            "primary_rule": "capture_jsonl vs off paired median slowdown must be below target",
+            "target_slowdown_percent": float(config["target_slowdown_percent"]),
+        }
+        logger.info(
+            "family=%s status=%s strength=%s full_median=%.3f%% ci95=[%.3f, %.3f] pairs=%d",
+            family,
+            summary["status"],
+            summary["evidence_strength"],
+            primary["median"],
+            primary["bootstrap_95_ci"][0],
+            primary["bootstrap_95_ci"][1],
+            len(rows),
+        )
+        return summary, rows, capture_samples
+    finally:
+        writer_handle.close()
+        for collector in collectors.values():
+            collector.remove()
+
+
+def run(
+    config_path: Path,
+    *,
+    run_id: str | None = None,
+    update_latest: bool = True,
+    family: str | None = None,
+    preflight: bool = False,
+) -> Path:
+    config = _load_strengthened_config(config_path, run_id)
+    if family is not None:
+        if family not in config["profiles"]:
+            raise ValueError(f"Unknown strengthened profile: {family}")
+        config["profiles"] = {family: config["profiles"][family]}
+    if preflight:
+        config["warmup_pairs"] = 0
+        for profile in config["profiles"].values():
+            profile["measured_pairs"] = len(CONDITION_ORDERS)
+        config["execution_mode"] = "preflight"
+    else:
+        config["execution_mode"] = "formal"
+    run_dir = PROJECT_ROOT / "artifacts" / "p1-strengthened" / config["run_id"]
+    if run_dir.exists() and any(run_dir.iterdir()):
+        raise FileExistsError(f"Refusing to overwrite non-empty strengthened evidence directory: {run_dir}")
+    run_dir.mkdir(parents=True, exist_ok=True)
+    logger = _logger(run_dir / "full.log")
+    (run_dir / "config.resolved.yaml").write_text(
+        yaml.safe_dump(config, sort_keys=False, allow_unicode=True), encoding="utf-8", newline="\n"
+    )
+    command = "python -m e3_p1.strengthened --config configs/p1_strengthened.yaml"
+    if run_id:
+        command += f" --run-id {config['run_id']}"
+    if family:
+        command += f" --family {family}"
+    if preflight:
+        command += " --preflight"
+    if not update_latest:
+        command += " --no-update-latest"
+    (run_dir / "command.txt").write_text(command + "\n", encoding="utf-8", newline="\n")
+
+    source_root = (PROJECT_ROOT / config["runtime_root"]).resolve()
+    p0_repo_root = (PROJECT_ROOT / config["p0_repo_root"]).resolve()
+    try:
+        if not (p0_repo_root / "src" / "e3_p0").is_dir():
+            raise FileNotFoundError(f"P0 contract repository is missing: {p0_repo_root}")
+        sys.path.insert(0, str(source_root))
+        os.chdir(PROJECT_ROOT)
+        import torch
+        from ultralytics import YOLO
+        from ultralytics.engine.trainer import BaseTrainer
+        from ultralytics.nn.modules.routing_protocol import is_routed_module
+
+        first_profile = next(iter(config["profiles"].values()))
+        probe = YOLO(source_root / first_profile["model_config"]).model
+        num_classes = int(probe.yaml["nc"])
+        del probe
+        batches, input_metadata = _build_detection_batches(config, torch_module=torch, num_classes=num_classes)
+        write_json(run_dir / "input.json", input_metadata)
+        write_json(
+            run_dir / "environment.json",
+            environment(torch, source_root, PROJECT_ROOT, config["official_runtime_ref"], config["official_runtime_tree"]),
+        )
+        logger.info(
+            "scope=E3 P1 strengthened full detection step device=%s batches=%d batch=%d imgsz=%d",
+            config["device"],
+            len(batches),
+            config["batch_size"],
+            config["image_size"],
+        )
+        family_summaries = {}
+        all_rows = []
+        capture_samples = []
+        for family_name, profile in config["profiles"].items():
+            summary, rows, samples = _benchmark_family(
+                family=family_name,
+                profile=profile,
+                config=config,
+                source_root=source_root,
+                batches=batches,
+                run_dir=run_dir,
+                logger=logger,
+                torch_module=torch,
+                yolo_class=YOLO,
+                predicate=is_routed_module,
+                base_trainer_class=BaseTrainer,
+            )
+            summary["hooks_removed"] = True
+            family_summaries[family_name] = summary
+            all_rows.extend(rows)
+            capture_samples.extend(samples)
+        write_jsonl(run_dir / "fullstep-pairs.jsonl", all_rows)
+        write_jsonl(run_dir / "capture-schema-samples.jsonl", capture_samples)
+        save_strengthened_plot(
+            family_summaries,
+            run_dir / "fullstep-layered-overhead.png",
+            float(config["target_slowdown_percent"]),
+        )
+        overall_status = "PASS" if all(item["status"] == "PASS" for item in family_summaries.values()) else "FAIL"
+        overall_strength = (
+            "STRONG"
+            if all(item["evidence_strength"] == "STRONG" for item in family_summaries.values())
+            else "INCONCLUSIVE"
+        )
+        summary = {
+            "status": overall_status if not preflight else "PREFLIGHT_COMPLETE",
+            "criterion_preview": overall_status if preflight else None,
+            "formal_verdict_eligible": not preflight,
+            "execution_mode": config["execution_mode"],
+            "evidence_strength": overall_strength,
+            "scope": "E3 P1 strengthened real detection-loss/backward/optimizer paired benchmark",
+            "run_id": config["run_id"],
+            "official_runtime_ref": config["official_runtime_ref"],
+            "official_runtime_tree": config["official_runtime_tree"],
+            "families": family_summaries,
+            "target_slowdown_percent": float(config["target_slowdown_percent"]),
+            "methodology": {
+                "conditions": list(CONDITIONS),
+                "order": "six balanced permutations across three conditions",
+                "warmup_pairs": config["warmup_pairs"],
+                "sample_batches": config["sample_batches"],
+                "timed_region": "zero_grad + real detection loss + backward + gradient clip + SGD step + optional JSONL write/flush",
+                "excluded": "model construction, hook registration/removal, state hashing, schema validation, plotting, dashboard HTTP",
+                "primary_statistic": "median paired capture_jsonl-vs-off slowdown",
+                "uncertainty": "deterministic-seed bootstrap 95% interval for paired median",
+                "task_rule": "each family primary median must be below 10 percent",
+                "strength_rule": "STRONG only when each family bootstrap upper bound is also below 10 percent",
+            },
+            "limitations": [
+                "CPU-only random-initialized models; no NVIDIA CUDA, AMP or multi-epoch convergence claim.",
+                "Images and labels are deterministically preloaded so unrelated file I/O cannot dilute observer slowdown.",
+                "The JSONL condition flushes every step but does not call fsync; dashboard HTTP remains an independent consumer.",
+            ],
+        }
+        write_json(run_dir / "summary.json", summary)
+        write_manifest(run_dir)
+        if overall_status != "PASS" and not preflight:
+            raise RuntimeError("Strengthened formal task criterion failed; see summary.json")
+        if update_latest:
+            latest = PROJECT_ROOT / "artifacts" / "p1-strengthened" / "LATEST.txt"
+            latest.parent.mkdir(parents=True, exist_ok=True)
+            latest.write_text(config["run_id"] + "\n", encoding="utf-8", newline="\n")
+        logger.info("result=%s evidence_strength=%s artifacts=%s", overall_status, overall_strength, run_dir)
+        write_manifest(run_dir)
+        return run_dir
+    except Exception as exc:
+        failure = {
+            "status": "FAIL",
+            "error_type": type(exc).__name__,
+            "message": str(exc),
+            "traceback": traceback.format_exc(),
+        }
+        write_json(run_dir / "failure.json", failure)
+        logger.exception("strengthened benchmark failed")
+        write_manifest(run_dir)
+        raise
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=PROJECT_ROOT / "configs" / "p1_strengthened.yaml")
+    parser.add_argument("--run-id")
+    parser.add_argument("--family")
+    parser.add_argument("--preflight", action="store_true")
+    parser.add_argument("--no-update-latest", action="store_true")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    run(
+        args.config.resolve(),
+        run_id=args.run_id,
+        update_latest=not args.no_update_latest,
+        family=args.family,
+        preflight=args.preflight,
+    )

--- a/tools/e3_routing/src/e3_p2/__init__.py
+++ b/tools/e3_routing/src/e3_p2/__init__.py
@@ -1,0 +1,3 @@
+"""YOLO-Master E3 P2 spatial routing evidence package."""
+
+__version__ = "0.1.0"

--- a/tools/e3_routing/src/e3_p2/__main__.py
+++ b/tools/e3_routing/src/e3_p2/__main__.py
@@ -1,0 +1,157 @@
+"""Command-line entry points for the P2 evidence run and local demo."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="YOLO-Master E3 P2 tooling")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    run_parser = subparsers.add_parser("run", help="generate a fresh P2 evidence bundle")
+    run_parser.add_argument("--config", type=Path, default=PROJECT_ROOT / "configs" / "p2" / "p2.yaml")
+    run_parser.add_argument("--run-id")
+    run_parser.add_argument("--no-latest", action="store_true")
+    robustness_parser = subparsers.add_parser(
+        "robustness", help="run CPU resolution and horizontal-flip diagnostics"
+    )
+    robustness_parser.add_argument(
+        "--config", type=Path, default=PROJECT_ROOT / "configs" / "p2" / "robustness.yaml"
+    )
+    robustness_parser.add_argument("--run-id")
+    robustness_parser.add_argument("--no-latest", action="store_true")
+    appearance_parser = subparsers.add_parser(
+        "appearance", help="run CPU brightness, contrast and blur diagnostics"
+    )
+    appearance_parser.add_argument(
+        "--config", type=Path, default=PROJECT_ROOT / "configs" / "p2" / "appearance.yaml"
+    )
+    appearance_parser.add_argument("--run-id")
+    appearance_parser.add_argument("--no-latest", action="store_true")
+    drilldown_parser = subparsers.add_parser(
+        "layer-drilldown", help="analyze layer attribution and margin-conditioned switch locations"
+    )
+    drilldown_parser.add_argument(
+        "--config", type=Path, default=PROJECT_ROOT / "configs" / "p2" / "layer_drilldown.yaml"
+    )
+    drilldown_parser.add_argument("--run-id")
+    drilldown_parser.add_argument("--no-latest", action="store_true")
+    scale_parser = subparsers.add_parser(
+        "image-scale", help="run the CPU coco128 image-level MoA appearance audit"
+    )
+    scale_parser.add_argument(
+        "--config", type=Path, default=PROJECT_ROOT / "configs" / "p2" / "image_scale.yaml"
+    )
+    scale_parser.add_argument("--run-id")
+    scale_parser.add_argument("--no-latest", action="store_true")
+    driver_parser = subparsers.add_parser(
+        "image-driver", help="analyze within-transform image-level input and routing change associations"
+    )
+    driver_parser.add_argument(
+        "--config", type=Path, default=PROJECT_ROOT / "configs" / "p2" / "image_driver.yaml"
+    )
+    driver_parser.add_argument("--run-id")
+    driver_parser.add_argument("--no-latest", action="store_true")
+    dose_parser = subparsers.add_parser(
+        "dose-response", help="run the predeclared 32-image MoA appearance-strength ladder"
+    )
+    dose_parser.add_argument(
+        "--config", type=Path, default=PROJECT_ROOT / "configs" / "p2" / "dose_response.yaml"
+    )
+    dose_parser.add_argument("--run-id")
+    dose_parser.add_argument("--no-latest", action="store_true")
+    coupling_parser = subparsers.add_parser(
+        "output-coupling", help="run image-level router-to-detector-output association diagnostics"
+    )
+    coupling_parser.add_argument(
+        "--config", type=Path, default=PROJECT_ROOT / "configs" / "p2" / "output_coupling.yaml"
+    )
+    coupling_parser.add_argument("--run-id")
+    coupling_parser.add_argument("--no-latest", action="store_true")
+    holdout_parser = subparsers.add_parser(
+        "dose-holdout", help="validate the held middle dose from low/high endpoint evidence"
+    )
+    holdout_parser.add_argument(
+        "--config", type=Path, default=PROJECT_ROOT / "configs" / "p2" / "dose_holdout.yaml"
+    )
+    holdout_parser.add_argument("--run-id")
+    holdout_parser.add_argument("--no-latest", action="store_true")
+    residual_parser = subparsers.add_parser(
+        "blur-residual", help="diagnose held-middle Gaussian-blur residuals from locked input-only features"
+    )
+    residual_parser.add_argument(
+        "--config", type=Path, default=PROJECT_ROOT / "configs" / "p2" / "blur_residual.yaml"
+    )
+    residual_parser.add_argument("--run-id")
+    residual_parser.add_argument("--no-latest", action="store_true")
+    demo_parser = subparsers.add_parser("demo", help="serve the latest evidence demo")
+    demo_parser.add_argument("--host", default="127.0.0.1")
+    demo_parser.add_argument("--port", type=int, default=8766)
+    demo_parser.add_argument("--run-dir", type=Path)
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+
+    if args.command == "run":
+        from .runner import run
+
+        output = run(args.config, run_id=args.run_id, update_latest=not args.no_latest)
+        print(f"P2 evidence: {output}")
+    elif args.command == "robustness":
+        from .robustness_runner import run as run_robustness
+
+        output = run_robustness(args.config, run_id=args.run_id, update_latest=not args.no_latest)
+        print(f"P2 robustness evidence: {output}")
+    elif args.command == "appearance":
+        from .appearance_runner import run as run_appearance
+
+        output = run_appearance(args.config, run_id=args.run_id, update_latest=not args.no_latest)
+        print(f"P2 appearance evidence: {output}")
+    elif args.command == "layer-drilldown":
+        from .layer_drilldown import run as run_layer_drilldown
+
+        output = run_layer_drilldown(args.config, run_id=args.run_id, update_latest=not args.no_latest)
+        print(f"P2 layer attribution evidence: {output}")
+    elif args.command == "image-scale":
+        from .scale_runner import run as run_image_scale
+
+        output = run_image_scale(args.config, run_id=args.run_id, update_latest=not args.no_latest)
+        print(f"P2 image-scale evidence: {output}")
+    elif args.command == "image-driver":
+        from .image_driver_analysis import run as run_image_driver
+
+        output = run_image_driver(args.config, run_id=args.run_id, update_latest=not args.no_latest)
+        print(f"P2 image-driver evidence: {output}")
+    elif args.command == "dose-response":
+        from .dose_response_runner import run as run_dose_response
+
+        output = run_dose_response(args.config, run_id=args.run_id, update_latest=not args.no_latest)
+        print(f"P2 dose-response evidence: {output}")
+    elif args.command == "output-coupling":
+        from .output_coupling_runner import run as run_output_coupling
+
+        output = run_output_coupling(args.config, run_id=args.run_id, update_latest=not args.no_latest)
+        print(f"P2 output-coupling evidence: {output}")
+    elif args.command == "dose-holdout":
+        from .dose_holdout_runner import run as run_dose_holdout
+
+        output = run_dose_holdout(args.config, run_id=args.run_id, update_latest=not args.no_latest)
+        print(f"P2 dose-holdout evidence: {output}")
+    elif args.command == "blur-residual":
+        from .blur_residual_runner import run as run_blur_residual
+
+        output = run_blur_residual(args.config, run_id=args.run_id, update_latest=not args.no_latest)
+        print(f"P2 blur-residual evidence: {output}")
+    else:
+        from .demo import serve
+
+        serve(host=args.host, port=args.port, run_dir=args.run_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/e3_routing/src/e3_p2/appearance_runner.py
+++ b/tools/e3_routing/src/e3_p2/appearance_runner.py
@@ -1,0 +1,542 @@
+"""CPU-only appearance-perturbation diagnostics for P2 spatial routers."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import random
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import yaml
+from PIL import Image, ImageDraw, ImageEnhance, ImageFilter, ImageFont
+
+from .capture import max_output_delta
+from .geometry import LetterboxMeta, letterbox
+from .io_utils import environment, sha256_file, write_json, write_manifest
+from .regions import label_path_for_image, parse_yolo_labels, token_region_masks
+from .robustness_runner import _archive_inputs, _capture_once, _logger
+from .runner import (
+    PROJECT_ROOT,
+    RUN_ID_PATTERN,
+    _detach_tree,
+    _resolve_images,
+    _slug,
+    _verify_project_source_state,
+    _verify_source,
+)
+from .stability import aggregate_stability_comparisons, probability_map_comparison, restore_probability_stack
+
+
+def _load_config(path: Path, run_id_override: str | None) -> dict[str, Any]:
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise TypeError(f"config must contain a mapping: {path}")
+    config = dict(loaded)
+    run_id = str(run_id_override if run_id_override is not None else config.get("run_id", "")).strip()
+    if not RUN_ID_PATTERN.fullmatch(run_id):
+        raise ValueError("run_id must be path-safe and at most 128 characters")
+    config["run_id"] = run_id
+    if config.get("device") != "cpu" or int(config.get("resolution", 0)) < 32:
+        raise ValueError("appearance diagnostics require CPU and resolution >= 32")
+    seeds = [int(value) for value in config.get("seeds", [])]
+    if len(seeds) < 2 or len(set(seeds)) != len(seeds):
+        raise ValueError("seeds must contain at least two unique integers")
+    config["seeds"] = seeds
+    indices = [int(value) for value in config.get("sample_indices", [])]
+    if not indices or len(set(indices)) != len(indices):
+        raise ValueError("sample_indices must be non-empty and unique")
+    config["sample_indices"] = indices
+    if set(config.get("spatial_profiles", {})) != {"mot", "moa"}:
+        raise ValueError("spatial_profiles must be exactly MoT and MoA")
+    transforms = config.get("transformations")
+    if not isinstance(transforms, list) or len(transforms) < 2:
+        raise ValueError("transformations must contain identity and at least one perturbation")
+    names = [str(item.get("name", "")) for item in transforms if isinstance(item, dict)]
+    if len(names) != len(transforms) or len(set(names)) != len(names) or names[0] != "identity":
+        raise ValueError("transform names must be unique and identity must be first")
+    for index, spec in enumerate(transforms):
+        kind = spec.get("kind")
+        if index == 0 and spec != {"name": "identity", "kind": "identity"}:
+            raise ValueError("identity transform contract changed")
+        if kind in {"brightness", "contrast"}:
+            factor = float(spec.get("factor", 0.0))
+            if not 0.5 <= factor <= 1.5 or factor == 1.0:
+                raise ValueError(f"{kind} factor must be in [0.5,1.5] and not equal one")
+        elif kind == "gaussian_blur":
+            radius = float(spec.get("radius", -1.0))
+            if not 0.0 < radius <= 3.0:
+                raise ValueError("gaussian blur radius must be in (0,3]")
+        elif kind != "identity":
+            raise ValueError(f"unsupported appearance transform: {kind}")
+    return config
+
+
+def _apply_transform(image: Image.Image, spec: dict[str, Any]) -> Image.Image:
+    kind = spec["kind"]
+    rgb = image.convert("RGB")
+    if kind == "identity":
+        return rgb.copy()
+    if kind == "brightness":
+        return ImageEnhance.Brightness(rgb).enhance(float(spec["factor"]))
+    if kind == "contrast":
+        return ImageEnhance.Contrast(rgb).enhance(float(spec["factor"]))
+    if kind == "gaussian_blur":
+        return rgb.filter(ImageFilter.GaussianBlur(radius=float(spec["radius"])))
+    raise ValueError(f"unsupported appearance transform: {kind}")
+
+
+def _prepare_inputs(
+    paths: list[Path], sample_indices: list[int], transforms: list[dict[str, Any]], resolution: int, run_dir: Path
+) -> tuple[dict[tuple[int, str], dict[str, Any]], list[dict[str, Any]]]:
+    transformed_dir = run_dir / "transformed-inputs"
+    canvas_dir = run_dir / "model-inputs"
+    transformed_dir.mkdir(parents=True, exist_ok=True)
+    canvas_dir.mkdir(parents=True, exist_ok=True)
+    prepared: dict[tuple[int, str], dict[str, Any]] = {}
+    audit = []
+    for sample_index, path in zip(sample_indices, paths):
+        with Image.open(path) as opened:
+            original = opened.convert("RGB")
+        for spec in transforms:
+            name = spec["name"]
+            transformed = _apply_transform(original, spec)
+            canvas, meta = letterbox(transformed, resolution)
+            transformed_relative = Path("transformed-inputs") / f"sample-{sample_index}--{name}.png"
+            canvas_relative = Path("model-inputs") / f"sample-{sample_index}--{name}--{resolution}px.png"
+            transformed.save(run_dir / transformed_relative)
+            Image.fromarray(canvas).save(run_dir / canvas_relative)
+            record = {
+                "sample_index": sample_index,
+                "sample_name": path.name,
+                "transform": name,
+                "spec": spec,
+                "geometry": meta.to_dict(),
+                "transformed_artifact": transformed_relative.as_posix(),
+                "transformed_artifact_sha256": sha256_file(run_dir / transformed_relative),
+                "model_input_artifact": canvas_relative.as_posix(),
+                "model_input_artifact_sha256": sha256_file(run_dir / canvas_relative),
+                "model_input_rgb_bytes_sha256": hashlib.sha256(canvas.tobytes()).hexdigest(),
+                "model_input_shape_hwc": [int(value) for value in canvas.shape],
+                "normalization": "RGB uint8 / 255.0",
+            }
+            audit.append(record)
+            prepared[(sample_index, name)] = {"canvas": canvas, "meta": meta, "audit": record}
+    return prepared, audit
+
+
+def _tensor(canvas: np.ndarray, torch_module: Any) -> Any:
+    array = canvas.astype(np.float32).transpose(2, 0, 1) / 255.0
+    return torch_module.from_numpy(array).unsqueeze(0).contiguous()
+
+
+def _summarize_input_effects(
+    prepared: dict[tuple[int, str], dict[str, Any]], sample_indices: list[int], transform_names: list[str]
+) -> dict[str, Any]:
+    by_transform = {}
+    records = []
+    for transform_name in transform_names[1:]:
+        current = []
+        for sample_index in sample_indices:
+            reference = prepared[(sample_index, "identity")]["canvas"].astype(np.int16)
+            candidate = prepared[(sample_index, transform_name)]["canvas"].astype(np.int16)
+            difference = np.abs(reference - candidate)
+            record = {
+                "sample_index": sample_index,
+                "transform": transform_name,
+                "rgb_mae_0_255": float(difference.mean()),
+                "rgb_max_abs_error_0_255": int(difference.max()),
+                "changed_channel_fraction": float((difference > 0).mean()),
+                "model_input_changed": bool(np.any(difference)),
+            }
+            current.append(record)
+            records.append(record)
+        changed = sum(item["model_input_changed"] for item in current)
+        if changed != len(sample_indices):
+            raise RuntimeError(
+                f"transform {transform_name} was a no-op for {len(sample_indices) - changed} configured samples"
+            )
+        by_transform[transform_name] = {
+            "sample_count": len(current),
+            "changed_sample_count": changed,
+            "rgb_mae_0_255_mean": float(np.mean([item["rgb_mae_0_255"] for item in current])),
+            "rgb_mae_0_255_min": float(np.min([item["rgb_mae_0_255"] for item in current])),
+            "rgb_mae_0_255_max": float(np.max([item["rgb_mae_0_255"] for item in current])),
+            "changed_channel_fraction_mean": float(
+                np.mean([item["changed_channel_fraction"] for item in current])
+            ),
+        }
+    return {
+        "reference": "identity model-input uint8 canvas",
+        "scale": "absolute RGB difference on [0,255]",
+        "all_candidate_samples_changed": True,
+        "by_transform": by_transform,
+        "records": records,
+    }
+
+
+def _aggregate_region_comparisons(records: list[dict[str, Any]]) -> dict[str, Any]:
+    grouped: dict[tuple[str, str, str], list[dict[str, Any]]] = defaultdict(list)
+    for item in records:
+        grouped[(item["comparison_type"], item["family"], item["region"])].append(item)
+    metric_names = (
+        "probability_mae",
+        "mean_total_variation_distance",
+        "mean_jensen_shannon_divergence_nats",
+        "dominant_expert_agreement_fraction",
+        "reference_top1_margin_mean",
+    )
+    result = {}
+    for key, items in sorted(grouped.items()):
+        summary: dict[str, Any] = {
+            "comparison_count": len(items),
+            "token_count_total": sum(item["token_count"] for item in items),
+        }
+        for metric_name in metric_names:
+            values = np.asarray([item["metrics"][metric_name] for item in items], dtype=np.float64)
+            summary[metric_name] = {
+                "mean": float(values.mean()), "min": float(values.min()), "max": float(values.max())
+            }
+        result[f"{key[0]}:{key[1]}:{key[2]}"] = summary
+    return {
+        "method": {
+            "unit": "one seed x sample x router-module x region comparison",
+            "weighting": "each non-empty region comparison receives equal weight",
+            "regions": "foreground/background from 128px feature-cell centers; letterbox padding excluded",
+            "interpretation_boundary": "descriptive cold-start sensitivity, not learned robustness",
+        },
+        "comparison_count": len(records),
+        "by_type_family_region": result,
+        "records": records,
+    }
+
+
+def _font(size: int, *, mono: bool = False) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    candidates = ["C:/Windows/Fonts/consola.ttf"] if mono else ["C:/Windows/Fonts/segoeui.ttf"]
+    candidates += ["DejaVuSansMono.ttf"] if mono else ["DejaVuSans.ttf"]
+    for candidate in candidates:
+        try:
+            return ImageFont.truetype(candidate, size)
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+
+def _save_overview(aggregate: dict[str, Any], region: dict[str, Any], transform_names: list[str], path: Path) -> None:
+    canvas = Image.new("RGB", (1800, 1120), "#050c1b")
+    draw = ImageDraw.Draw(canvas)
+    title, section, body = _font(38), _font(23), _font(18)
+    metric, small, mono = _font(31, mono=True), _font(15), _font(16, mono=True)
+    draw.rounded_rectangle((42, 36, 1758, 1084), radius=30, fill="#09172d", outline="#21678d", width=3)
+    draw.text((82, 70), "E3 P2  /  APPEARANCE SENSITIVITY", fill="#00e5ff", font=title)
+    draw.text((84, 122), "128px · 3 seeds · 4 images · brightness / contrast / blur", fill="#9bb8d6", font=body)
+    draw.rounded_rectangle((1195, 66, 1708, 141), radius=16, fill="#221938", outline="#8f65db", width=2)
+    draw.text((1220, 83), "COLD-START DIAGNOSTIC", fill="#d5b7ff", font=section)
+    draw.text((1220, 113), "Not learned robustness", fill="#ffcc66", font=small)
+    cards = [("576", "true spatial captures"), ("480", "aligned comparisons"), ("960", "FG/BG comparisons")]
+    for index, (value, label) in enumerate(cards):
+        left = 82 + index * 340
+        draw.rounded_rectangle((left, 180, left + 310, 292), radius=18, fill="#0d223e", outline="#204d70", width=2)
+        draw.text((left + 22, 201), value, fill="#63e6a7", font=metric)
+        draw.text((left + 22, 252), label, fill="#a9c1da", font=small)
+
+    draw.text((82, 335), "MoA original-coordinate agreement", fill="#eaf4ff", font=section)
+    draw.text((82, 371), "Overall versus pixels at/above the reference 90th-margin percentile", fill="#829fbd", font=small)
+    rows = []
+    for name in transform_names:
+        item = aggregate["by_type_family_resolution"][f"appearance_{name}:moa:128"]
+        rows.append((name, item))
+    for index, (name, item) in enumerate(rows):
+        y = 420 + index * 70
+        agreement = item["dominant_expert_agreement_fraction"]["mean"]
+        high_margin = item["agreement_at_or_above_reference_margin_percentiles"]["90"]["agreement_mean"]
+        draw.text((82, y + 8), name.replace("_", " "), fill="#b5cce2", font=body)
+        draw.rounded_rectangle((285, y, 930, y + 38), radius=9, fill="#10233c")
+        draw.rounded_rectangle((285, y, 285 + int(645 * agreement), y + 38), radius=9, fill="#4d55d8")
+        draw.text((300, y + 8), f"all {agreement * 100:5.2f}%", fill="#ffffff", font=mono)
+        draw.text((580, y + 8), f"P90+ {high_margin * 100:5.2f}%", fill="#d5b7ff", font=mono)
+        draw.text((950, y + 8), f"MAE {item['probability_mae']['mean']:.2e}", fill="#9bb8d6", font=mono)
+
+    draw.text((1110, 335), "MoA region-conditioned probability MAE", fill="#eaf4ff", font=section)
+    draw.text((1110, 371), "Equal-weight capture summaries; padding excluded", fill="#829fbd", font=small)
+    region_data = region["by_type_family_region"]
+    max_mae = max(
+        region_data[f"appearance_{name}:moa:{area}"]["probability_mae"]["mean"]
+        for name in transform_names
+        for area in ("foreground", "background")
+    )
+    scale = max(max_mae, 1e-12)
+    for index, name in enumerate(transform_names):
+        y = 425 + index * 88
+        foreground = region_data[f"appearance_{name}:moa:foreground"]["probability_mae"]["mean"]
+        background = region_data[f"appearance_{name}:moa:background"]["probability_mae"]["mean"]
+        draw.text((1110, y), name.replace("_", " "), fill="#b5cce2", font=small)
+        draw.rounded_rectangle((1300, y, 1690, y + 24), radius=6, fill="#10233c")
+        draw.rounded_rectangle((1300, y, 1300 + int(390 * foreground / scale), y + 24), radius=6, fill="#d65c8a")
+        draw.rounded_rectangle((1300, y + 32, 1690, y + 56), radius=6, fill="#10233c")
+        draw.rounded_rectangle((1300, y + 32, 1300 + int(390 * background / scale), y + 56), radius=6, fill="#0e9fb0")
+        draw.text((1310, y + 4), f"FG {foreground:.2e}", fill="#ffffff", font=small)
+        draw.text((1310, y + 36), f"BG {background:.2e}", fill="#ffffff", font=small)
+
+    draw.rounded_rectangle((82, 835, 1710, 998), radius=18, fill="#081326", outline="#213c5a", width=2)
+    draw.text((110, 860), "Interpretation guardrails", fill="#a66cff", font=section)
+    notes = [
+        "All transformed originals and exact 128x128 model-input canvases are archived and hashed.",
+        "Agreement is read with probability error and margin; near-tie argmax changes are not large distribution shifts.",
+        "MoT constant-map equality remains a cold-start property, not evidence of trained appearance robustness.",
+    ]
+    for index, note in enumerate(notes):
+        draw.text((115, 907 + index * 28), f"• {note}", fill="#c8d8e8", font=small)
+    draw.text((84, 1036), "SHA-256 manifest · locked source · raw NPZ · exact appearance-input audit", fill="#63e6a7", font=small)
+    canvas.save(path)
+
+
+def run(config_path: Path, *, run_id: str | None = None, update_latest: bool = True) -> Path:
+    config = _load_config(config_path, run_id)
+    project_source = _verify_project_source_state(bool(config.get("require_committed_source", False)))
+    run_dir = PROJECT_ROOT / "artifacts" / "p2" / config["run_id"]
+    if run_dir.exists() and any(run_dir.iterdir()):
+        raise FileExistsError(f"refusing to overwrite non-empty evidence directory: {run_dir}")
+    run_dir.mkdir(parents=True, exist_ok=True)
+    logger = _logger(run_dir / "full.log")
+    (run_dir / "config.resolved.yaml").write_text(
+        yaml.safe_dump(config, sort_keys=False, allow_unicode=True), encoding="utf-8"
+    )
+    (run_dir / "command.txt").write_text("run_appearance.cmd\n", encoding="utf-8")
+    started = time.perf_counter()
+
+    source_root = (PROJECT_ROOT / config["runtime_root"]).resolve()
+    checks = _verify_source(source_root, config["source_fingerprints"])
+    sys.path.insert(0, str(source_root))
+    os.chdir(PROJECT_ROOT)
+    import torch
+    from ultralytics import YOLO
+
+    paths, dataset_meta = _resolve_images(config["dataset"], config["dataset_split"], config["sample_indices"])
+    archived_inputs = _archive_inputs(paths, config["sample_indices"], run_dir)
+    prepared, transform_audit = _prepare_inputs(
+        paths, config["sample_indices"], config["transformations"], int(config["resolution"]), run_dir
+    )
+    write_json(run_dir / "transformation-audit.json", transform_audit)
+    input_effects = _summarize_input_effects(
+        prepared,
+        config["sample_indices"],
+        [item["name"] for item in config["transformations"]],
+    )
+    write_json(run_dir / "transformation-effect.json", input_effects)
+    input_record = {
+        **dataset_meta,
+        "selected_image_count": len(paths),
+        "images": archived_inputs,
+        "image_and_annotation_set_sha256": hashlib.sha256(
+            "\n".join(f"{item['sample_index']}:{item['sha256']}:{item['label_sha256']}" for item in archived_inputs).encode("utf-8")
+        ).hexdigest(),
+    }
+    write_json(run_dir / "input.json", input_record)
+    write_json(run_dir / "source-fingerprint-checks.json", checks)
+
+    resolution = int(config["resolution"])
+    transform_names = [item["name"] for item in config["transformations"]]
+    candidate_names = transform_names[1:]
+    first_seed = config["seeds"][0]
+    arrays: dict[str, np.ndarray] = {}
+    capture_metadata: list[dict[str, Any]] = []
+    comparisons: list[dict[str, Any]] = []
+    region_comparisons: list[dict[str, Any]] = []
+    invariants: dict[str, Any] = {}
+    logger.info(
+        "scope=CPU appearance sensitivity resolution=%d transforms=%s seeds=%s samples=%s",
+        resolution, transform_names, config["seeds"], config["sample_indices"],
+    )
+
+    for family, profile in config["spatial_profiles"].items():
+        for seed in config["seeds"]:
+            random.seed(seed)
+            np.random.seed(seed)
+            torch.manual_seed(seed)
+            wrapper = YOLO(source_root / profile["model_config"])
+            model = wrapper.model.to("cpu").eval()
+            representative = _tensor(prepared[(config["sample_indices"][0], "identity")]["canvas"], torch)
+            with torch.inference_mode():
+                baseline_output = _detach_tree(model(representative))
+            hooked_output, first_records, module_order = _capture_once(
+                model, family, profile["router_class"], representative, torch
+            )
+            _, repeat_records, repeat_order = _capture_once(model, family, profile["router_class"], representative, torch)
+            hook_delta = max_output_delta(baseline_output, hooked_output)
+            repeat_weight_delta = max(
+                float(np.max(np.abs(first.weights - second.weights)))
+                for first, second in zip(first_records, repeat_records)
+            )
+            repeat_logit_delta = max(
+                float(np.max(np.abs(first.logits - second.logits)))
+                for first, second in zip(first_records, repeat_records)
+            )
+            repeat_indices_equal = all(
+                first.indices is None or np.array_equal(first.indices, second.indices)
+                for first, second in zip(first_records, repeat_records)
+            )
+            if hook_delta != 0.0 or module_order != repeat_order or repeat_weight_delta != 0.0 or repeat_logit_delta != 0.0 or not repeat_indices_equal:
+                raise RuntimeError(f"representative invariants failed for family={family}, seed={seed}")
+            invariants[f"{family}:seed-{seed}"] = {
+                "hook_output_max_abs_delta": hook_delta,
+                "repeat_weight_max_abs_delta": repeat_weight_delta,
+                "repeat_logit_max_abs_delta": repeat_logit_delta,
+                "repeat_indices_equal": repeat_indices_equal if family == "mot" else None,
+                "module_order": module_order,
+                "hook_cleanup": True,
+                "status": "PASS",
+            }
+
+            for sample_index, path in zip(config["sample_indices"], paths):
+                boxes = parse_yolo_labels(label_path_for_image(path))
+                restored: dict[tuple[str, str], np.ndarray] = {}
+                raw_weights: dict[tuple[str, str], np.ndarray] = {}
+                for transform_name in transform_names:
+                    prepared_item = prepared[(sample_index, transform_name)]
+                    tensor = _tensor(prepared_item["canvas"], torch)
+                    _, records, registered = _capture_once(model, family, profile["router_class"], tensor, torch)
+                    if registered != module_order:
+                        raise RuntimeError(f"module order changed for family={family}, transform={transform_name}")
+                    meta: LetterboxMeta = prepared_item["meta"]
+                    for record in records:
+                        weights = record.weights[0]
+                        aligned, restoration_validation = restore_probability_stack(weights, meta)
+                        restored[(transform_name, record.module_name)] = aligned
+                        raw_weights[(transform_name, record.module_name)] = weights
+                        prefix = (
+                            f"{family}__seed-{seed}__sample-{sample_index}__{transform_name}__"
+                            f"{_slug(record.module_name)}"
+                        )
+                        weight_key, logit_key = f"{prefix}__weights", f"{prefix}__logits"
+                        arrays[weight_key], arrays[logit_key] = record.weights, record.logits
+                        index_key = None
+                        if record.indices is not None:
+                            index_key = f"{prefix}__indices"
+                            arrays[index_key] = record.indices
+                        capture_metadata.append(
+                            {
+                                "family": family,
+                                "seed": seed,
+                                "sample_index": sample_index,
+                                "sample_name": path.name,
+                                "resolution": resolution,
+                                "transformation": transform_name,
+                                "module": record.module_name,
+                                "module_type": record.module_type,
+                                "source_shape": record.validation["shape"],
+                                "geometry": meta.to_dict(),
+                                "router_validation": record.validation,
+                                "restoration_validation": restoration_validation,
+                                "raw_keys": {"weights": weight_key, "logits": logit_key, "indices": index_key},
+                            }
+                        )
+                for module in module_order:
+                    reference = restored[("identity", module)]
+                    reference_weights = raw_weights[("identity", module)]
+                    meta = prepared[(sample_index, "identity")]["meta"]
+                    masks = token_region_masks(boxes, meta, reference_weights.shape[1], reference_weights.shape[2])
+                    if seed == first_seed:
+                        mask_prefix = f"{family}__sample-{sample_index}__{_slug(module)}"
+                        for region_name in ("foreground", "background", "padding"):
+                            arrays[f"{mask_prefix}__mask-{region_name}"] = masks[region_name]
+                    for transform_name in candidate_names:
+                        comparison_type = f"appearance_{transform_name}"
+                        comparisons.append(
+                            {
+                                "comparison_type": comparison_type,
+                                "family": family,
+                                "seed": seed,
+                                "sample_index": sample_index,
+                                "module": module,
+                                "reference_resolution": resolution,
+                                "candidate_resolution": resolution,
+                                "alignment": "same geometry; both maps restored to original-image pixels",
+                                "metrics": probability_map_comparison(reference, restored[(transform_name, module)]),
+                            }
+                        )
+                        candidate_weights = raw_weights[(transform_name, module)]
+                        for region_name in ("foreground", "background"):
+                            mask = masks[region_name]
+                            if not mask.any():
+                                continue
+                            region_comparisons.append(
+                                {
+                                    "comparison_type": comparison_type,
+                                    "family": family,
+                                    "seed": seed,
+                                    "sample_index": sample_index,
+                                    "module": module,
+                                    "region": region_name,
+                                    "token_count": int(mask.sum()),
+                                    "metrics": probability_map_comparison(
+                                        reference_weights[:, mask].reshape(reference_weights.shape[0], 1, -1),
+                                        candidate_weights[:, mask].reshape(candidate_weights.shape[0], 1, -1),
+                                    ),
+                                }
+                            )
+                logger.info("family=%s seed=%d sample=%d captures=%d", family, seed, sample_index, len(module_order) * len(transform_names))
+            del model, wrapper
+
+    np.savez_compressed(run_dir / "appearance-routing-raw.npz", **arrays)
+    write_json(run_dir / "spatial-captures.json", capture_metadata)
+    write_json(run_dir / "appearance-stability-comparisons.json", comparisons)
+    aggregate = aggregate_stability_comparisons(comparisons)
+    write_json(run_dir / "appearance-stability-aggregate.json", aggregate)
+    region_aggregate = _aggregate_region_comparisons(region_comparisons)
+    write_json(run_dir / "appearance-region-analysis.json", region_aggregate)
+    write_json(run_dir / "invariants.json", invariants)
+    write_json(run_dir / "environment.json", environment(torch, source_root, PROJECT_ROOT))
+    _save_overview(aggregate, region_aggregate, candidate_names, run_dir / "appearance-overview.png")
+    summary = {
+        "status": "PASS",
+        "scope": "CPU-only brightness, contrast and blur sensitivity for true MoT/MoA spatial router probabilities",
+        "run_id": config["run_id"],
+        "official_locked_base_ref": config["official_locked_base_ref"],
+        "official_runtime_ref": config["official_runtime_ref"],
+        "tool_source": project_source,
+        "source_fingerprint_validation": "PASS",
+        "source_fingerprint_count": len(checks),
+        "device": "cpu",
+        "seeds": config["seeds"],
+        "resolution": resolution,
+        "transformations": config["transformations"],
+        "transformation_effect": input_effects["by_transform"],
+        "sample_count": len(paths),
+        "spatial_capture_count": len(capture_metadata),
+        "raw_array_count": len(arrays),
+        "aligned_comparison_count": len(comparisons),
+        "region_comparison_count": len(region_comparisons),
+        "representative_invariants": invariants,
+        "restoration_validation": {
+            "max_pre_normalization_expert_sum_error": max(
+                item["restoration_validation"]["pre_normalization_max_expert_sum_error"] for item in capture_metadata
+            ),
+            "max_post_normalization_expert_sum_error": max(
+                item["restoration_validation"]["post_normalization_max_expert_sum_error"] for item in capture_metadata
+            ),
+        },
+        "interpretation_boundary": "random initialization; appearance sensitivity and pipeline evidence only",
+        "status_semantics": "PASS means input audit, capture, alignment, determinism and evidence integrity checks completed",
+        "duration_seconds_observation_only": time.perf_counter() - started,
+    }
+    write_json(run_dir / "summary.json", summary)
+    for handler in logger.handlers:
+        handler.flush()
+    write_manifest(run_dir)
+    if update_latest:
+        latest = PROJECT_ROOT / "artifacts" / "p2" / "APPEARANCE_LATEST.txt"
+        latest.parent.mkdir(parents=True, exist_ok=True)
+        latest.write_text(config["run_id"] + "\n", encoding="utf-8")
+    logger.info(
+        "status=PASS captures=%d comparisons=%d region_comparisons=%d arrays=%d",
+        len(capture_metadata), len(comparisons), len(region_comparisons), len(arrays),
+    )
+    for handler in logger.handlers:
+        handler.flush()
+    write_manifest(run_dir)
+    return run_dir

--- a/tools/e3_routing/src/e3_p2/blur_residual_runner.py
+++ b/tools/e3_routing/src/e3_p2/blur_residual_runner.py
@@ -1,0 +1,503 @@
+"""Integrity-bound input-side diagnosis of held-middle Gaussian-blur residuals."""
+
+from __future__ import annotations
+
+import json
+import logging
+import platform
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import yaml
+from PIL import Image, ImageDraw, ImageFont
+
+from .image_driver_analysis import spearman
+from .io_utils import sha256_file, write_json, write_manifest
+from .layer_drilldown import verify_parent_evidence
+from .runner import PROJECT_ROOT, RUN_ID_PATTERN, _verify_project_source_state
+
+FEATURES = (
+    "letterbox_content_fraction",
+    "luminance_mean_0_255",
+    "edge_total_variation_0_1",
+)
+
+
+def _load_config(path: Path, run_id_override: str | None) -> dict[str, Any]:
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise TypeError(f"config must contain a mapping: {path}")
+    config = dict(loaded)
+    run_id = str(run_id_override if run_id_override is not None else config.get("run_id", "")).strip()
+    if not RUN_ID_PATTERN.fullmatch(run_id):
+        raise ValueError("run_id must be path-safe and at most 128 characters")
+    config["run_id"] = run_id
+    if tuple(config.get("features", [])) != FEATURES:
+        raise ValueError(f"features must be exactly {list(FEATURES)} in predeclared order")
+    if str(config.get("family")) != "gaussian_blur":
+        raise ValueError("family must remain gaussian_blur")
+    if str(config.get("endpoint")) != "probability_mae":
+        raise ValueError("endpoint must remain probability_mae")
+    if int(config.get("expected_image_count", 0)) < 16:
+        raise ValueError("expected_image_count must be at least 16")
+    if int(config.get("bootstrap_draws", 0)) < 1000:
+        raise ValueError("bootstrap_draws must be at least 1000")
+    if int(config.get("permutation_draws", 0)) < 5000:
+        raise ValueError("permutation_draws must be at least 5000")
+    if not 0.0 < float(config.get("alpha", 0.0)) < 0.5:
+        raise ValueError("alpha must be between zero and 0.5")
+    if not 1 <= int(config.get("top_k", 0)) <= int(config["expected_image_count"]):
+        raise ValueError("top_k must be within the image count")
+    for key in ("expected_holdout_manifest_sha256", "expected_image_source_manifest_sha256"):
+        digest = str(config.get(key, ""))
+        if len(digest) != 64 or any(character not in "0123456789abcdef" for character in digest):
+            raise ValueError(f"{key} must be a lowercase SHA-256 digest")
+    selected_digest = str(config.get("expected_selected_image_and_label_set_sha256", ""))
+    if len(selected_digest) != 64 or any(character not in "0123456789abcdef" for character in selected_digest):
+        raise ValueError("expected_selected_image_and_label_set_sha256 must be a lowercase SHA-256 digest")
+    if int(config.get("max_evidence_bytes", 0)) < 100_000:
+        raise ValueError("max_evidence_bytes must be at least 100 KB")
+    return config
+
+
+def extract_input_features(image_path: Path, *, canvas_size: int) -> dict[str, float]:
+    """Compute the three predeclared model-output-independent image features."""
+
+    if canvas_size <= 0:
+        raise ValueError("canvas_size must be positive")
+    with Image.open(image_path) as opened:
+        rgb = np.asarray(opened.convert("RGB"), dtype=np.float64)
+    height, width = rgb.shape[:2]
+    scale = min(canvas_size / width, canvas_size / height)
+    content_fraction = (width * scale * height * scale) / float(canvas_size**2)
+    luminance = 0.299 * rgb[..., 0] + 0.587 * rgb[..., 1] + 0.114 * rgb[..., 2]
+    horizontal = float(np.mean(np.abs(np.diff(luminance, axis=1)))) if width > 1 else 0.0
+    vertical = float(np.mean(np.abs(np.diff(luminance, axis=0)))) if height > 1 else 0.0
+    return {
+        "letterbox_content_fraction": float(content_fraction),
+        "luminance_mean_0_255": float(np.mean(luminance)),
+        "edge_total_variation_0_1": (horizontal + vertical) / (2.0 * 255.0),
+    }
+
+
+def build_feature_records(
+    holdout_payload: dict[str, Any],
+    input_payload: dict[str, Any],
+    image_source_dir: Path,
+    *,
+    family: str,
+    endpoint: str,
+    expected_image_count: int,
+    canvas_size: int,
+) -> list[dict[str, Any]]:
+    holdout_records = [item for item in holdout_payload.get("records", []) if item.get("family") == family]
+    if int(holdout_payload.get("record_count", -1)) != len(holdout_payload.get("records", [])):
+        raise ValueError("holdout record_count does not match payload")
+    if len(holdout_records) != expected_image_count:
+        raise ValueError("blur holdout record count does not match contract")
+    image_items = input_payload.get("images", [])
+    if int(input_payload.get("selected_image_count", -1)) != expected_image_count or len(image_items) != expected_image_count:
+        raise ValueError("source image count does not match contract")
+    holdout_by_index = {int(item["sample_index"]): item for item in holdout_records}
+    images_by_index = {int(item["sample_index"]): item for item in image_items}
+    expected_indices = set(range(expected_image_count))
+    if set(holdout_by_index) != expected_indices or set(images_by_index) != expected_indices:
+        raise ValueError("sample indices must exactly cover the expected range")
+
+    output = []
+    for sample_index in range(expected_image_count):
+        image_item = images_by_index[sample_index]
+        relative = Path(str(image_item["image_artifact"]))
+        if relative.is_absolute() or ".." in relative.parts:
+            raise ValueError(f"unsafe image artifact path: {relative}")
+        image_path = image_source_dir / relative
+        if not image_path.is_file() or sha256_file(image_path) != image_item["sha256"]:
+            raise RuntimeError(f"source image missing or hash mismatch: sample={sample_index}")
+        endpoint_record = holdout_by_index[sample_index]["endpoints"][endpoint]
+        residual = endpoint_record.get("normalized_absolute_residual")
+        if residual is None or not np.isfinite(float(residual)):
+            raise ValueError(f"normalized residual must be finite: sample={sample_index}")
+        features = extract_input_features(image_path, canvas_size=canvas_size)
+        output.append(
+            {
+                "sample_index": sample_index,
+                "image_name": image_item["name"],
+                "image_sha256": image_item["sha256"],
+                "image_artifact": relative.as_posix(),
+                "original_width": int(image_item["original_width"]),
+                "original_height": int(image_item["original_height"]),
+                "label_status": image_item["label_status"],
+                "ground_truth_box_count_descriptive_only": int(image_item["ground_truth_box_count"]),
+                "normalized_absolute_residual": float(residual),
+                "absolute_residual": float(endpoint_record["absolute_residual_input_weighted"]),
+                "features": features,
+            }
+        )
+    return output
+
+
+def _bootstrap_spearman(x: np.ndarray, y: np.ndarray, draws: int, seed: int) -> dict[str, Any]:
+    observed = spearman(x, y)
+    if observed is None:
+        return {
+            "status": "UNDEFINED_CONSTANT_VECTOR",
+            "observed_spearman_rho": None,
+            "draws": draws,
+            "defined_draw_count": 0,
+            "undefined_draw_count": draws,
+            "percentile_95_interval": None,
+        }
+    rng = np.random.default_rng(seed)
+    values = []
+    undefined = 0
+    for _ in range(draws):
+        indices = rng.integers(0, x.size, size=x.size)
+        coefficient = spearman(x[indices], y[indices])
+        if coefficient is None:
+            undefined += 1
+        else:
+            values.append(coefficient)
+    defined_fraction = len(values) / draws
+    array = np.asarray(values, dtype=np.float64)
+    return {
+        "status": "DEFINED" if defined_fraction >= 0.95 else "INSUFFICIENT_DEFINED_DRAWS",
+        "observed_spearman_rho": observed,
+        "draws": draws,
+        "seed": seed,
+        "defined_draw_count": len(values),
+        "undefined_draw_count": undefined,
+        "percentile_95_interval": (
+            [float(value) for value in np.quantile(array, [0.025, 0.975])]
+            if defined_fraction >= 0.95
+            else None
+        ),
+        "bootstrap_median": float(np.median(array)) if values else None,
+    }
+
+
+def _leave_one_out(x: np.ndarray, y: np.ndarray) -> dict[str, Any]:
+    values = []
+    records = []
+    for omitted in range(x.size):
+        keep = np.arange(x.size) != omitted
+        coefficient = spearman(x[keep], y[keep])
+        records.append({"omitted_position": omitted, "spearman_rho": coefficient})
+        if coefficient is not None:
+            values.append(coefficient)
+    return {
+        "count": int(x.size),
+        "defined_count": len(values),
+        "minimum": min(values) if values else None,
+        "maximum": max(values) if values else None,
+        "sign_stable": bool(values) and (min(values) > 0.0 or max(values) < 0.0),
+        "records": records,
+    }
+
+
+def permutation_p_value(x: np.ndarray, y: np.ndarray, draws: int, seed: int) -> dict[str, Any]:
+    """Return a deterministic two-sided randomization p-value for Spearman rho."""
+
+    observed = spearman(x, y)
+    if observed is None:
+        return {"status": "UNDEFINED_CONSTANT_VECTOR", "draws": draws, "two_sided_p_value": None}
+    rng = np.random.default_rng(seed)
+    exceed = 0
+    undefined = 0
+    threshold = abs(observed) - 1e-15
+    for _ in range(draws):
+        value = spearman(x, rng.permutation(y))
+        if value is None:
+            undefined += 1
+        elif abs(value) >= threshold:
+            exceed += 1
+    defined = draws - undefined
+    if defined == 0:
+        return {"status": "UNDEFINED_ALL_DRAWS", "draws": draws, "two_sided_p_value": None}
+    return {
+        "status": "DEFINED",
+        "draws": draws,
+        "seed": seed,
+        "defined_draw_count": defined,
+        "undefined_draw_count": undefined,
+        "exceedance_count": exceed,
+        "two_sided_p_value": (exceed + 1) / (defined + 1),
+    }
+
+
+def holm_adjust(raw_p_values: dict[str, float | None], alpha: float) -> dict[str, dict[str, Any]]:
+    """Apply Holm's step-down adjustment across all defined predeclared tests."""
+
+    defined = sorted((value, name) for name, value in raw_p_values.items() if value is not None)
+    adjusted: dict[str, dict[str, Any]] = {
+        name: {"raw_p_value": value, "holm_adjusted_p_value": None, "reject_at_alpha": False}
+        for name, value in raw_p_values.items()
+    }
+    running = 0.0
+    count = len(defined)
+    for rank, (value, name) in enumerate(defined):
+        running = max(running, min(1.0, (count - rank) * value))
+        adjusted[name]["holm_adjusted_p_value"] = running
+        adjusted[name]["reject_at_alpha"] = running <= alpha
+    return adjusted
+
+
+def analyze_records(
+    records: list[dict[str, Any]],
+    *,
+    features: tuple[str, ...],
+    bootstrap_draws: int,
+    bootstrap_seed: int,
+    permutation_draws: int,
+    permutation_seed: int,
+    alpha: float,
+    top_k: int,
+) -> dict[str, Any]:
+    y = np.asarray([item["normalized_absolute_residual"] for item in records], dtype=np.float64)
+    associations: dict[str, Any] = {}
+    raw_p_values: dict[str, float | None] = {}
+    for index, feature in enumerate(features):
+        x = np.asarray([item["features"][feature] for item in records], dtype=np.float64)
+        bootstrap = _bootstrap_spearman(x, y, bootstrap_draws, bootstrap_seed + index)
+        permutation = permutation_p_value(x, y, permutation_draws, permutation_seed + index)
+        raw_p_values[feature] = permutation["two_sided_p_value"]
+        associations[feature] = {
+            "feature_unique_value_count": int(np.unique(x).size),
+            "residual_unique_value_count": int(np.unique(y).size),
+            "bootstrap": bootstrap,
+            "permutation": permutation,
+            "leave_one_image_out": _leave_one_out(x, y),
+        }
+    multiplicity = holm_adjust(raw_p_values, alpha)
+    for feature in features:
+        associations[feature]["multiplicity"] = multiplicity[feature]
+
+    feature_collinearity = []
+    for left_index, left in enumerate(features):
+        for right in features[left_index + 1 :]:
+            x = np.asarray([item["features"][left] for item in records], dtype=np.float64)
+            z = np.asarray([item["features"][right] for item in records], dtype=np.float64)
+            feature_collinearity.append({"left": left, "right": right, "spearman_rho": spearman(x, z)})
+    top = sorted(records, key=lambda item: (-item["normalized_absolute_residual"], item["sample_index"]))[:top_k]
+    return {
+        "analysis_unit": "one selected image; no token or seed pseudo-replication",
+        "endpoint": "Gaussian-blur held-middle span-normalized absolute probability residual",
+        "image_count": len(records),
+        "predeclared_features": list(features),
+        "multiplicity_control": f"Holm adjustment over {len(features)} two-sided permutation tests",
+        "alpha": alpha,
+        "associations": associations,
+        "feature_collinearity": feature_collinearity,
+        "residual_distribution": {
+            "minimum": float(np.min(y)),
+            "median": float(np.median(y)),
+            "p75": float(np.quantile(y, 0.75)),
+            "p90": float(np.quantile(y, 0.90)),
+            "maximum": float(np.max(y)),
+        },
+        "top_residual_images_descriptive_only": [
+            {
+                "rank": rank,
+                "sample_index": item["sample_index"],
+                "image_name": item["image_name"],
+                "normalized_absolute_residual": item["normalized_absolute_residual"],
+                "features": item["features"],
+            }
+            for rank, item in enumerate(top, start=1)
+        ],
+    }
+
+
+def _font(size: int, bold: bool = False) -> ImageFont.ImageFont:
+    candidates = [
+        Path("C:/Windows/Fonts/arialbd.ttf" if bold else "C:/Windows/Fonts/arial.ttf"),
+        Path("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf" if bold else "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"),
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return ImageFont.truetype(str(candidate), size)
+    return ImageFont.load_default()
+
+
+def _save_overview(records: list[dict[str, Any]], analysis: dict[str, Any], output: Path) -> None:
+    canvas = Image.new("RGB", (1680, 1080), "#07111f")
+    draw = ImageDraw.Draw(canvas)
+    title, body, small = _font(40, True), _font(24), _font(19)
+    draw.text((55, 42), "P2 / WHAT DRIVES BLUR INTERPOLATION ERROR?", fill="#eff6ff", font=title)
+    draw.text((55, 96), "32 fixed images · input-only features · image bootstrap · permutation + Holm", fill="#63e6a7", font=body)
+    labels = {
+        "letterbox_content_fraction": "Letterbox content fraction",
+        "luminance_mean_0_255": "Mean luminance (0–255)",
+        "edge_total_variation_0_1": "Edge total variation (0–1)",
+    }
+    colors = ["#48cae4", "#f9c74f", "#c77dff"]
+    for panel, (feature, color) in enumerate(zip(FEATURES, colors)):
+        left, top, width, height = 55 + panel * 540, 165, 480, 480
+        draw.rounded_rectangle((left, top, left + width, top + height), 18, fill="#0c1d33", outline="#28425f", width=2)
+        xs = np.asarray([item["features"][feature] for item in records], dtype=np.float64)
+        ys = np.asarray([item["normalized_absolute_residual"] * 100 for item in records], dtype=np.float64)
+        xmin, xmax = float(xs.min()), float(xs.max())
+        ymin, ymax = 0.0, max(ys.max() * 1.08, 1e-6)
+        plot_left, plot_top, plot_right, plot_bottom = left + 58, top + 70, left + width - 26, top + height - 70
+        draw.line((plot_left, plot_top, plot_left, plot_bottom), fill="#7890aa", width=2)
+        draw.line((plot_left, plot_bottom, plot_right, plot_bottom), fill="#7890aa", width=2)
+        top_indices = {item["sample_index"] for item in sorted(records, key=lambda value: -value["normalized_absolute_residual"])[:5]}
+        for item, x, y in zip(records, xs, ys):
+            px = plot_left + (float(x) - xmin) / max(xmax - xmin, 1e-12) * (plot_right - plot_left)
+            py = plot_bottom - (float(y) - ymin) / max(ymax - ymin, 1e-12) * (plot_bottom - plot_top)
+            radius = 7 if item["sample_index"] in top_indices else 5
+            draw.ellipse((px - radius, py - radius, px + radius, py + radius), fill=color, outline="#f8fafc")
+            if item["sample_index"] in top_indices:
+                draw.text((px + 7, py - 14), str(item["sample_index"]), fill="#f8fafc", font=small)
+        result = analysis["associations"][feature]
+        rho = result["bootstrap"]["observed_spearman_rho"]
+        adjusted = result["multiplicity"]["holm_adjusted_p_value"]
+        draw.text((left + 24, top + 20), labels[feature], fill="#f8fafc", font=body)
+        draw.text((left + 28, top + height - 52), f"rho={rho:+.3f}   Holm p={adjusted:.4f}", fill=color, font=small)
+        draw.text((plot_left - 48, plot_top - 10), f"{ymax:.1f}%", fill="#9fb2c8", font=small)
+        draw.text((plot_left - 32, plot_bottom - 10), "0", fill="#9fb2c8", font=small)
+    draw.text((55, 690), "PREDECLARED INFERENCE", fill="#63e6a7", font=body)
+    y = 735
+    for feature in FEATURES:
+        item = analysis["associations"][feature]
+        ci = item["bootstrap"]["percentile_95_interval"]
+        loo = item["leave_one_image_out"]
+        text = (
+            f"{labels[feature]:31s}  bootstrap 95% [{ci[0]:+.3f}, {ci[1]:+.3f}]   "
+            f"LOO [{loo['minimum']:+.3f}, {loo['maximum']:+.3f}]   reject={item['multiplicity']['reject_at_alpha']}"
+        )
+        draw.text((75, y), text, fill="#d7e3f1", font=small)
+        y += 48
+    draw.text((55, 910), "BOUNDARY", fill="#ffd166", font=body)
+    draw.text((55, 952), "Associations diagnose this fixed random-initialization subset; they do not prove mechanism or trained accuracy.", fill="#f5d58a", font=small)
+    draw.text((55, 1000), "PASS depends on integrity/completeness/finite statistics, never on significance.", fill="#f5d58a", font=small)
+    canvas.save(output)
+
+
+def _save_top_contact_sheet(records: list[dict[str, Any]], source_dir: Path, top_k: int, output: Path) -> None:
+    selected = sorted(records, key=lambda item: (-item["normalized_absolute_residual"], item["sample_index"]))[:top_k]
+    canvas = Image.new("RGB", (1680, 920), "#07111f")
+    draw = ImageDraw.Draw(canvas)
+    draw.text((55, 38), "TOP HELD-MIDDLE BLUR RESIDUALS / DESCRIPTIVE ONLY", fill="#eff6ff", font=_font(38, True))
+    draw.text((55, 90), "Rank fixed after the predeclared residual analysis; labels are sample indices.", fill="#9fb2c8", font=_font(21))
+    columns = 3
+    for index, item in enumerate(selected):
+        row, column = divmod(index, columns)
+        left, top = 55 + column * 540, 145 + row * 360
+        with Image.open(source_dir / item["image_artifact"]) as opened:
+            image = opened.convert("RGB")
+            image.thumbnail((490, 250), Image.Resampling.LANCZOS)
+        frame = Image.new("RGB", (500, 260), "#132944")
+        frame.paste(image, ((500 - image.width) // 2, (260 - image.height) // 2))
+        canvas.paste(frame, (left, top))
+        draw.text((left, top + 270), f"#{index + 1} sample {item['sample_index']} · {item['image_name']}", fill="#f8fafc", font=_font(20, True))
+        draw.text((left, top + 302), f"normalized error {item['normalized_absolute_residual'] * 100:.2f}%", fill="#f9c74f", font=_font(20))
+    canvas.save(output)
+
+
+def _inside_project(value: str, field: str) -> Path:
+    path = (PROJECT_ROOT / value).resolve()
+    try:
+        path.relative_to(PROJECT_ROOT.resolve())
+    except ValueError as error:
+        raise ValueError(f"{field} must stay inside the project repository") from error
+    return path
+
+
+def run(config_path: Path, *, run_id: str | None = None, update_latest: bool = True) -> Path:
+    config = _load_config(config_path, run_id)
+    project_source = _verify_project_source_state(bool(config.get("require_committed_source", False)))
+    holdout_dir = _inside_project(str(config["holdout_run_dir"]), "holdout_run_dir")
+    image_source_dir = _inside_project(str(config["image_source_run_dir"]), "image_source_run_dir")
+    run_dir = PROJECT_ROOT / "artifacts" / "p2" / config["run_id"]
+    if run_dir.exists() and any(run_dir.iterdir()):
+        raise FileExistsError(f"refusing to overwrite non-empty evidence directory: {run_dir}")
+    run_dir.mkdir(parents=True, exist_ok=True)
+    logger = logging.getLogger(f"e3_p2.blur_residual.{config['run_id']}")
+    logger.handlers.clear()
+    logger.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
+    console = logging.StreamHandler()
+    file_handler = logging.FileHandler(run_dir / "full.log", encoding="utf-8")
+    console.setFormatter(formatter)
+    file_handler.setFormatter(formatter)
+    logger.addHandler(console)
+    logger.addHandler(file_handler)
+    (run_dir / "config.resolved.yaml").write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    (run_dir / "command.txt").write_text("run_blur_residual.cmd\n", encoding="utf-8")
+    started = time.perf_counter()
+
+    holdout_verification = verify_parent_evidence(holdout_dir, config["expected_holdout_manifest_sha256"])
+    image_verification = verify_parent_evidence(image_source_dir, config["expected_image_source_manifest_sha256"])
+    holdout_summary = json.loads((holdout_dir / "summary.json").read_text(encoding="utf-8"))
+    if holdout_summary.get("run_id") != config["expected_holdout_run_id"] or holdout_summary.get("status") != "PASS":
+        raise RuntimeError("holdout parent identity or PASS state mismatch")
+    input_payload = json.loads((image_source_dir / "input.json").read_text(encoding="utf-8"))
+    if input_payload.get("selected_image_and_label_set_sha256") != config["expected_selected_image_and_label_set_sha256"]:
+        raise RuntimeError("selected image-and-label set digest mismatch")
+    holdout_payload = json.loads((holdout_dir / "dose-holdout-records.json").read_text(encoding="utf-8"))
+    records = build_feature_records(
+        holdout_payload,
+        input_payload,
+        image_source_dir,
+        family=config["family"],
+        endpoint=config["endpoint"],
+        expected_image_count=int(config["expected_image_count"]),
+        canvas_size=int(config["canvas_size"]),
+    )
+    analysis = analyze_records(
+        records,
+        features=FEATURES,
+        bootstrap_draws=int(config["bootstrap_draws"]),
+        bootstrap_seed=int(config["bootstrap_seed"]),
+        permutation_draws=int(config["permutation_draws"]),
+        permutation_seed=int(config["permutation_seed"]),
+        alpha=float(config["alpha"]),
+        top_k=int(config["top_k"]),
+    )
+    write_json(run_dir / "holdout-parent-verification.json", holdout_verification)
+    write_json(run_dir / "image-source-verification.json", image_verification)
+    write_json(run_dir / "blur-residual-feature-records.json", {"record_count": len(records), "records": records})
+    write_json(run_dir / "blur-residual-analysis.json", analysis)
+    _save_overview(records, analysis, run_dir / "blur-residual-overview.png")
+    _save_top_contact_sheet(records, image_source_dir, int(config["top_k"]), run_dir / "top-residual-images.png")
+    rejected = [name for name, item in analysis["associations"].items() if item["multiplicity"]["reject_at_alpha"]]
+    summary = {
+        "status": "PASS",
+        "scope": "integrity-bound input-side diagnosis of held-middle Gaussian-blur probability residuals",
+        "run_id": config["run_id"],
+        "tool_source": project_source,
+        "holdout_parent_run_id": holdout_summary["run_id"],
+        "holdout_parent_verification": holdout_verification,
+        "image_source_verification": image_verification,
+        "image_count": len(records),
+        "predeclared_feature_count": len(FEATURES),
+        "holm_rejected_features": rejected,
+        "headline_associations": {
+            feature: {
+                "spearman_rho": item["bootstrap"]["observed_spearman_rho"],
+                "bootstrap_95_interval": item["bootstrap"]["percentile_95_interval"],
+                "raw_permutation_p": item["multiplicity"]["raw_p_value"],
+                "holm_adjusted_p": item["multiplicity"]["holm_adjusted_p_value"],
+                "leave_one_out_sign_stable": item["leave_one_image_out"]["sign_stable"],
+            }
+            for feature, item in analysis["associations"].items()
+        },
+        "interpretation_boundary": "fixed selected images and random initialization; association is not mechanism, causality or trained accuracy",
+        "environment": {"python": platform.python_version(), "platform": platform.platform()},
+        "duration_seconds_observation_only": time.perf_counter() - started,
+    }
+    write_json(run_dir / "summary.json", summary)
+    logger.info("status=PASS images=%d features=%d holm_rejected=%d", len(records), len(FEATURES), len(rejected))
+    for handler in logger.handlers:
+        handler.flush()
+    evidence_bytes = sum(path.stat().st_size for path in run_dir.rglob("*") if path.is_file())
+    if evidence_bytes > int(config["max_evidence_bytes"]):
+        raise RuntimeError(f"blur residual evidence budget exceeded: {evidence_bytes} > {config['max_evidence_bytes']}")
+    summary["evidence_bytes_before_manifest"] = evidence_bytes
+    write_json(run_dir / "summary.json", summary)
+    write_manifest(run_dir)
+    if update_latest:
+        (run_dir.parent / "BLUR_RESIDUAL_LATEST.txt").write_text(run_dir.name + "\n", encoding="utf-8")
+    return run_dir

--- a/tools/e3_routing/src/e3_p2/capture.py
+++ b/tools/e3_routing/src/e3_p2/capture.py
@@ -1,0 +1,198 @@
+"""Non-invasive capture of true spatial router tensors."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from .geometry import validate_probability_grid
+
+
+def routing_metric_fields(weights: np.ndarray) -> dict[str, np.ndarray]:
+    """Derive bounded token diagnostics from a truthful ``[E,H,W]`` probability grid."""
+
+    values = np.asarray(weights, dtype=np.float32)
+    if values.ndim != 3:
+        raise ValueError(f"expected [E,H,W], got shape={list(values.shape)}")
+    validate_probability_grid(values[None, ...])
+    expert_count = values.shape[0]
+    safe = np.clip(values, np.finfo(np.float32).tiny, 1.0)
+    entropy = -np.sum(values * np.log(safe), axis=0) / np.log(float(expert_count))
+    ordered = np.sort(values, axis=0)
+    margin = ordered[-1] - ordered[-2] if expert_count > 1 else np.ones_like(ordered[-1])
+    return {
+        "normalized_entropy": np.clip(entropy, 0.0, 1.0).astype(np.float32),
+        "top1_margin": np.clip(margin, 0.0, 1.0).astype(np.float32),
+    }
+
+
+def routing_diagnostics(weights: np.ndarray) -> dict[str, Any]:
+    """Summarize spatial routing without discarding the raw grid evidence."""
+
+    values = np.asarray(weights, dtype=np.float32)
+    fields = routing_metric_fields(values)
+    dominant = np.argmax(values, axis=0)
+    token_count = int(dominant.size)
+    horizontal = np.abs(np.diff(values, axis=2)).reshape(-1)
+    vertical = np.abs(np.diff(values, axis=1)).reshape(-1)
+    variation_values = np.concatenate([horizontal, vertical])
+
+    def stats(field: np.ndarray) -> dict[str, float]:
+        return {
+            "min": float(field.min()),
+            "max": float(field.max()),
+            "mean": float(field.mean()),
+        }
+
+    return {
+        "token_count": token_count,
+        "mean_expert_probability": [float(item) for item in values.mean(axis=(1, 2))],
+        "dominant_token_count": [int(np.sum(dominant == expert)) for expert in range(values.shape[0])],
+        "dominant_token_fraction": [
+            float(np.sum(dominant == expert) / token_count) for expert in range(values.shape[0])
+        ],
+        "active_dominant_experts": int(np.unique(dominant).size),
+        "normalized_entropy": stats(fields["normalized_entropy"]),
+        "top1_margin": stats(fields["top1_margin"]),
+        "neighbor_probability_l1_mean": float(variation_values.mean()) if variation_values.size else 0.0,
+    }
+
+
+def tensor_shapes(value: Any) -> list[list[int]]:
+    shapes: list[list[int]] = []
+    if hasattr(value, "shape"):
+        shapes.append([int(item) for item in value.shape])
+    elif isinstance(value, dict):
+        for child in value.values():
+            shapes.extend(tensor_shapes(child))
+    elif isinstance(value, (list, tuple)):
+        for child in value:
+            shapes.extend(tensor_shapes(child))
+    return shapes
+
+
+def flatten_tensors(value: Any) -> list[Any]:
+    tensors: list[Any] = []
+    if hasattr(value, "detach") and hasattr(value, "shape"):
+        tensors.append(value)
+    elif isinstance(value, dict):
+        for key in sorted(value):
+            tensors.extend(flatten_tensors(value[key]))
+    elif isinstance(value, (list, tuple)):
+        for child in value:
+            tensors.extend(flatten_tensors(child))
+    return tensors
+
+
+def max_output_delta(reference: Any, observed: Any) -> float:
+    """Return max tensor delta while enforcing identical nested tensor structure."""
+
+    left = flatten_tensors(reference)
+    right = flatten_tensors(observed)
+    if len(left) != len(right):
+        raise ValueError(f"output tensor count changed: {len(left)} != {len(right)}")
+    maximum = 0.0
+    for index, (a, b) in enumerate(zip(left, right)):
+        if tuple(a.shape) != tuple(b.shape):
+            raise ValueError(f"output tensor {index} shape changed: {tuple(a.shape)} != {tuple(b.shape)}")
+        if a.numel():
+            maximum = max(maximum, float((a.detach().float() - b.detach().float()).abs().max().cpu()))
+    return maximum
+
+
+@dataclass
+class SpatialRecord:
+    family: str
+    module_name: str
+    module_type: str
+    weights: np.ndarray
+    logits: np.ndarray
+    indices: np.ndarray | None
+    validation: dict[str, Any]
+
+
+@dataclass
+class SpatialRouterCollector:
+    family: str
+    router_class: str
+    records: list[SpatialRecord] = field(default_factory=list)
+    handles: list[Any] = field(default_factory=list)
+    registered_names: list[str] = field(default_factory=list)
+
+    def register(self, model: Any) -> list[str]:
+        if self.handles:
+            raise RuntimeError("collector is already registered")
+        for name, module in model.named_modules():
+            if module.__class__.__name__ != self.router_class:
+                continue
+
+            def capture(current_module: Any, inputs: Any, output: Any, *, module_name: str = name) -> None:
+                del inputs
+                if not isinstance(output, (list, tuple)):
+                    raise TypeError(f"{module_name} did not expose the expected router tuple")
+                if self.family == "mot" and len(output) >= 3:
+                    weights, indices, logits = output[:3]
+                elif self.family == "moa" and len(output) >= 2:
+                    weights, logits = output[:2]
+                    indices = None
+                else:
+                    raise RuntimeError(f"unsupported router output for family={self.family}: length={len(output)}")
+                weight_array = weights.detach().float().cpu().numpy()
+                logit_array = logits.detach().float().cpu().numpy()
+                index_array = indices.detach().cpu().numpy() if indices is not None else None
+                validation = validate_probability_grid(weight_array)
+                if list(logit_array.shape) != list(weight_array.shape):
+                    raise RuntimeError(
+                        f"logit/probability shape mismatch at {module_name}: {logit_array.shape} != {weight_array.shape}"
+                    )
+                if index_array is not None and tuple(index_array.shape[0:1] + index_array.shape[2:]) != (
+                    weight_array.shape[0],
+                    weight_array.shape[2],
+                    weight_array.shape[3],
+                ):
+                    raise RuntimeError(f"Top-K index grid does not align with weights at {module_name}")
+                if index_array is not None:
+                    if int(index_array.min()) < 0 or int(index_array.max()) >= weight_array.shape[1]:
+                        raise RuntimeError(f"Top-K expert index is out of range at {module_name}")
+                    selected = np.take_along_axis(weight_array, index_array.astype(np.int64), axis=1)
+                    selected_mass_error = float(np.max(np.abs(selected.sum(axis=1) - 1.0)))
+                    selected_mask = np.zeros_like(weight_array, dtype=bool)
+                    np.put_along_axis(selected_mask, index_array.astype(np.int64), True, axis=1)
+                    max_unselected_probability = float(np.max(np.where(selected_mask, 0.0, weight_array)))
+                    if selected_mass_error > 1e-5 or max_unselected_probability > 1e-5:
+                        raise RuntimeError(
+                            f"Top-K indices and sparse probabilities disagree at {module_name}: "
+                            f"mass_error={selected_mass_error}, unselected={max_unselected_probability}"
+                        )
+                    validation.update(
+                        {
+                            "top_k": int(index_array.shape[1]),
+                            "selected_mass_error": selected_mass_error,
+                            "max_unselected_probability": max_unselected_probability,
+                            "indices_in_range": True,
+                        }
+                    )
+                self.records.append(
+                    SpatialRecord(
+                        family=self.family,
+                        module_name=module_name,
+                        module_type=current_module.__class__.__name__,
+                        weights=weight_array,
+                        logits=logit_array,
+                        indices=index_array,
+                        validation=validation,
+                    )
+                )
+
+            self.handles.append(module.register_forward_hook(capture))
+            self.registered_names.append(name)
+        if not self.registered_names:
+            raise RuntimeError(f"no {self.router_class} modules found for family={self.family}")
+        return list(self.registered_names)
+
+    def remove(self) -> None:
+        for handle in self.handles:
+            handle.remove()
+        self.handles.clear()

--- a/tools/e3_routing/src/e3_p2/demo.py
+++ b/tools/e3_routing/src/e3_p2/demo.py
@@ -1,0 +1,44 @@
+"""Serve an immutable P2 evidence directory with the standard library."""
+
+from __future__ import annotations
+
+import functools
+import http.server
+import json
+import threading
+import webbrowser
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def resolve_run_dir(run_dir: Path | None = None) -> Path:
+    if run_dir is not None:
+        resolved = run_dir.resolve()
+    else:
+        latest = PROJECT_ROOT / "artifacts" / "p2" / "LATEST.txt"
+        if not latest.is_file():
+            raise FileNotFoundError("No P2 evidence found. Run run_p2.cmd first.")
+        run_id = latest.read_text(encoding="utf-8").strip()
+        resolved = (latest.parent / run_id).resolve()
+    if not (resolved / "demo.html").is_file() or not (resolved / "demo-index.json").is_file():
+        raise FileNotFoundError(f"Not a P2 demo evidence directory: {resolved}")
+    return resolved
+
+
+def serve(*, host: str = "127.0.0.1", port: int = 8766, run_dir: Path | None = None, open_browser: bool = True) -> None:
+    resolved = resolve_run_dir(run_dir)
+    handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=str(resolved))
+    server = http.server.ThreadingHTTPServer((host, port), handler)
+    url = f"http://{host}:{port}/demo.html"
+    summary = json.loads((resolved / "summary.json").read_text(encoding="utf-8"))
+    print(f"P2 demo: {url}")
+    print(f"Run: {summary['run_id']} | status={summary['status']} | Ctrl+C to stop")
+    if open_browser:
+        threading.Timer(0.4, lambda: webbrowser.open(url)).start()
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()

--- a/tools/e3_routing/src/e3_p2/detector_output.py
+++ b/tools/e3_routing/src/e3_p2/detector_output.py
@@ -1,0 +1,64 @@
+"""Stable detector-output extraction and comparison helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def _array(value: Any, name: str) -> np.ndarray:
+    if hasattr(value, "detach"):
+        value = value.detach().cpu().numpy()
+    array = np.asarray(value)
+    if array.size == 0 or not np.isfinite(array).all():
+        raise ValueError(f"detector output {name} must be non-empty and finite")
+    return array.astype(np.float64, copy=False)
+
+
+def detector_output_tensors(output: Any) -> dict[str, np.ndarray]:
+    """Extract decoded output and fixed-grid head tensors from the YOLO eval contract."""
+
+    if not isinstance(output, (list, tuple)) or len(output) < 2 or not isinstance(output[1], dict):
+        raise TypeError("detector output must be (decoded, head-dict)")
+    head = output[1]
+    tensors = {"decoded_top300": _array(output[0], "decoded_top300")}
+    for branch in ("one2one", "one2many"):
+        branch_value = head.get(branch)
+        if not isinstance(branch_value, dict):
+            raise TypeError(f"detector output is missing {branch} dictionary")
+        for field in ("scores", "boxes"):
+            if field not in branch_value:
+                raise TypeError(f"detector output is missing {branch}.{field}")
+            tensors[f"{branch}_{field}"] = _array(branch_value[field], f"{branch}_{field}")
+    return tensors
+
+
+def detector_output_comparison(reference: Any, candidate: Any) -> dict[str, Any]:
+    """Compare fixed-structure detector tensors without treating decoded row order as anchor-aligned."""
+
+    left = detector_output_tensors(reference)
+    right = detector_output_tensors(candidate)
+    if left.keys() != right.keys():
+        raise RuntimeError("detector output tensor keys changed")
+    results = {}
+    for name in left:
+        if left[name].shape != right[name].shape:
+            raise RuntimeError(f"detector output shape changed for {name}: {left[name].shape} != {right[name].shape}")
+        difference = np.abs(left[name] - right[name])
+        results[name] = {
+            "shape": list(left[name].shape),
+            "mean_absolute_change": float(difference.mean()),
+            "root_mean_square_change": float(np.sqrt(np.mean(difference**2))),
+            "maximum_absolute_change": float(difference.max()),
+            "alignment": (
+                "fixed head-grid and channel order"
+                if name != "decoded_top300"
+                else "decoded Top-300 row order is not treated as anchor-aligned"
+            ),
+        }
+    return {
+        "primary_tensor": "one2one_scores",
+        "primary_reason": "fixed grid/channel order; closest retained detector class-score endpoint",
+        "tensors": results,
+    }

--- a/tools/e3_routing/src/e3_p2/dose_holdout_runner.py
+++ b/tools/e3_routing/src/e3_p2/dose_holdout_runner.py
@@ -1,0 +1,497 @@
+"""Integrity-bound held-middle validation for the formal three-level dose evidence."""
+
+from __future__ import annotations
+
+import itertools
+import json
+import logging
+import platform
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import yaml
+from PIL import Image, ImageDraw, ImageFont
+
+from .image_driver_analysis import spearman
+from .io_utils import write_json, write_manifest
+from .layer_drilldown import verify_parent_evidence
+from .runner import PROJECT_ROOT, RUN_ID_PATTERN, _verify_project_source_state
+from .scale_runner import bootstrap_mean_interval
+
+ENDPOINTS = {
+    "probability_mae": ("target_probability_mae_mean_across_seeds", "probability_mae"),
+    "dominant_switch_fraction": (
+        "target_dominant_switch_fraction_mean_across_seeds",
+        "dominant_switch_fraction",
+    ),
+}
+
+
+def _load_config(path: Path, run_id_override: str | None) -> dict[str, Any]:
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise TypeError(f"config must contain a mapping: {path}")
+    config = dict(loaded)
+    run_id = str(run_id_override if run_id_override is not None else config.get("run_id", "")).strip()
+    if not RUN_ID_PATTERN.fullmatch(run_id):
+        raise ValueError("run_id must be path-safe and at most 128 characters")
+    config["run_id"] = run_id
+    if int(config.get("expected_image_count", 0)) < 4:
+        raise ValueError("expected_image_count must be at least four")
+    seeds = [int(value) for value in config.get("expected_seeds", [])]
+    if len(seeds) < 2 or len(set(seeds)) != len(seeds):
+        raise ValueError("expected_seeds must contain at least two unique integers")
+    config["expected_seeds"] = seeds
+    if int(config.get("bootstrap_draws", 0)) < 1000:
+        raise ValueError("bootstrap_draws must be at least 1000")
+    if int(config.get("max_evidence_bytes", 0)) < 100_000:
+        raise ValueError("max_evidence_bytes must be at least 100 KB")
+    digest = str(config.get("expected_parent_manifest_sha256", ""))
+    if len(digest) != 64 or any(character not in "0123456789abcdef" for character in digest):
+        raise ValueError("expected_parent_manifest_sha256 must be a lowercase SHA-256 digest")
+    families = config.get("families")
+    if not isinstance(families, list) or len(families) != 3:
+        raise ValueError("families must contain exactly three transformation families")
+    seen_names: set[str] = set()
+    seen_transforms: set[str] = set()
+    normalized = []
+    for item in families:
+        name = str(item.get("name", "")).strip()
+        transforms = [
+            str(item.get("low_transform", "")).strip(),
+            str(item.get("middle_transform", "")).strip(),
+            str(item.get("high_transform", "")).strip(),
+        ]
+        if not name or name in seen_names or any(not value for value in transforms):
+            raise ValueError("family names and transforms must be non-empty and unique")
+        if len(set(transforms)) != 3 or any(value in seen_transforms for value in transforms):
+            raise ValueError("dose holdout transforms must be globally unique")
+        seen_names.add(name)
+        seen_transforms.update(transforms)
+        normalized.append({"name": name, "transforms": transforms})
+    config["families"] = normalized
+    return config
+
+
+def build_holdout_records(
+    parent_records: list[dict[str, Any]],
+    families: list[dict[str, Any]],
+    expected_images: int,
+    expected_seeds: list[int],
+) -> list[dict[str, Any]]:
+    """Build one held-middle prediction record per family and image."""
+
+    lookup: dict[tuple[str, str, int], dict[str, Any]] = {}
+    for item in parent_records:
+        key = (str(item["family"]), str(item["transform"]), int(item["sample_index"]))
+        if key in lookup:
+            raise ValueError(f"duplicate parent dose record: {key}")
+        lookup[key] = item
+    expected_keys = {
+        (family["name"], transform, image)
+        for family in families
+        for transform in family["transforms"]
+        for image in range(expected_images)
+    }
+    if set(lookup) != expected_keys:
+        raise ValueError(
+            f"parent dose matrix mismatch: missing={len(expected_keys - set(lookup))}, "
+            f"extra={len(set(lookup) - expected_keys)}"
+        )
+
+    expected_seed_set = set(expected_seeds)
+    output = []
+    for family in families:
+        for sample_index in range(expected_images):
+            levels = [lookup[(family["name"], transform, sample_index)] for transform in family["transforms"]]
+            x = [float(item["input_rgb_mae_0_255"]) for item in levels]
+            if not all(np.isfinite(x)) or not x[0] < x[1] < x[2]:
+                raise ValueError(f"RGB distance must be strictly ordered: {family['name']}, image={sample_index}")
+            weight = (x[1] - x[0]) / (x[2] - x[0])
+            endpoints: dict[str, Any] = {}
+            for endpoint, (mean_field, seed_field) in ENDPOINTS.items():
+                y = [float(item[mean_field]) for item in levels]
+                if not all(np.isfinite(y)):
+                    raise ValueError(f"non-finite endpoint: {family['name']}, image={sample_index}, {endpoint}")
+                prediction = y[0] + weight * (y[2] - y[0])
+                midpoint = (y[0] + y[2]) / 2.0
+                residual = y[1] - prediction
+                span = abs(y[2] - y[0])
+                seed_records = []
+                for seed in expected_seeds:
+                    seed_values = []
+                    for level in levels:
+                        values = level.get("seed_values", [])
+                        seeds = [int(item["seed"]) for item in values]
+                        if (
+                            len(values) != len(expected_seeds)
+                            or set(seeds) != expected_seed_set
+                            or len(seeds) != len(set(seeds))
+                        ):
+                            raise ValueError(
+                                f"incomplete parent seed matrix: {family['name']}, image={sample_index}"
+                            )
+                        seed_values.append(float(next(item[seed_field] for item in values if int(item["seed"]) == seed)))
+                    seed_prediction = seed_values[0] + weight * (seed_values[2] - seed_values[0])
+                    seed_records.append(
+                        {
+                            "seed": seed,
+                            "low": seed_values[0],
+                            "actual_middle": seed_values[1],
+                            "high": seed_values[2],
+                            "predicted_middle": seed_prediction,
+                            "residual": seed_values[1] - seed_prediction,
+                            "low_to_high_slope_per_rgb_mae": (seed_values[2] - seed_values[0]) / (x[2] - x[0]),
+                        }
+                    )
+                endpoints[endpoint] = {
+                    "low": y[0],
+                    "actual_middle": y[1],
+                    "high": y[2],
+                    "predicted_middle_input_weighted": prediction,
+                    "predicted_middle_naive_midpoint": midpoint,
+                    "signed_residual_input_weighted": residual,
+                    "absolute_residual_input_weighted": abs(residual),
+                    "absolute_residual_naive_midpoint": abs(y[1] - midpoint),
+                    "endpoint_span": span,
+                    "normalized_absolute_residual": abs(residual) / span if span > 0.0 else None,
+                    "actual_middle_within_endpoints": min(y[0], y[2]) <= y[1] <= max(y[0], y[2]),
+                    "seed_records": seed_records,
+                }
+            output.append(
+                {
+                    "family": family["name"],
+                    "sample_index": sample_index,
+                    "transforms": family["transforms"],
+                    "input_rgb_mae_0_255": {"low": x[0], "middle": x[1], "high": x[2]},
+                    "input_interpolation_weight": weight,
+                    "endpoints": endpoints,
+                }
+            )
+    return output
+
+
+def _slope_association(x: np.ndarray, y: np.ndarray, draws: int, seed: int) -> dict[str, Any]:
+    observed = spearman(x, y)
+    base = {"x_unique_value_count": int(np.unique(x).size), "y_unique_value_count": int(np.unique(y).size)}
+    if observed is None:
+        return {
+            **base,
+            "status": "UNDEFINED_CONSTANT_VECTOR",
+            "observed_spearman_rho": None,
+            "bootstrap": None,
+            "leave_one_image_out": None,
+        }
+    rng = np.random.default_rng(seed)
+    bootstrap_values = []
+    undefined_bootstrap = 0
+    for _ in range(draws):
+        indices = rng.integers(0, x.size, size=x.size)
+        value = spearman(x[indices], y[indices])
+        if value is None:
+            undefined_bootstrap += 1
+        else:
+            bootstrap_values.append(value)
+    defined_fraction = len(bootstrap_values) / draws
+    bootstrap_array = np.asarray(bootstrap_values, dtype=np.float64)
+    bootstrap = {
+        "draws": draws,
+        "seed": seed,
+        "defined_draw_count": len(bootstrap_values),
+        "undefined_draw_count": undefined_bootstrap,
+        "defined_draw_fraction": defined_fraction,
+        "interval_status": "DEFINED" if defined_fraction >= 0.95 else "INSUFFICIENT_DEFINED_DRAWS",
+        "percentile_95_interval": (
+            [float(value) for value in np.quantile(bootstrap_array, [0.025, 0.975])]
+            if defined_fraction >= 0.95
+            else None
+        ),
+        "bootstrap_median": float(np.median(bootstrap_array)) if bootstrap_values else None,
+    }
+    leave_records = []
+    for omitted in range(x.size):
+        keep = np.arange(x.size) != omitted
+        value = spearman(x[keep], y[keep])
+        leave_records.append(
+            {
+                "omitted_position": omitted,
+                "status": "DEFINED" if value is not None else "UNDEFINED_CONSTANT_VECTOR",
+                "spearman_rho": value,
+            }
+        )
+    defined_leave = [item["spearman_rho"] for item in leave_records if item["spearman_rho"] is not None]
+    return {
+        **base,
+        "status": "DEFINED",
+        "observed_spearman_rho": observed,
+        "bootstrap": bootstrap,
+        "leave_one_image_out": {
+            "count": len(leave_records),
+            "defined_count": len(defined_leave),
+            "undefined_count": len(leave_records) - len(defined_leave),
+            "minimum": min(defined_leave) if defined_leave else None,
+            "maximum": max(defined_leave) if defined_leave else None,
+            "records": leave_records,
+        },
+    }
+
+
+def analyze_holdout(
+    records: list[dict[str, Any]],
+    families: list[dict[str, Any]],
+    expected_seeds: list[int],
+    draws: int,
+    seed: int,
+) -> dict[str, Any]:
+    by_family: dict[str, Any] = {}
+    for family_index, family in enumerate(families):
+        selected = [item for item in records if item["family"] == family["name"]]
+        endpoint_results: dict[str, Any] = {}
+        for endpoint_index, endpoint in enumerate(ENDPOINTS):
+            values = [item["endpoints"][endpoint] for item in selected]
+            weighted_error = np.asarray([item["absolute_residual_input_weighted"] for item in values])
+            midpoint_error = np.asarray([item["absolute_residual_naive_midpoint"] for item in values])
+            signed_error = np.asarray([item["signed_residual_input_weighted"] for item in values])
+            normalized = np.asarray(
+                [item["normalized_absolute_residual"] for item in values if item["normalized_absolute_residual"] is not None]
+            )
+            base_seed = seed + family_index * 10000 + endpoint_index * 1000
+            seed_associations = []
+            for pair_index, (left_seed, right_seed) in enumerate(itertools.combinations(expected_seeds, 2)):
+                left = np.asarray(
+                    [
+                        next(value for value in item["seed_records"] if value["seed"] == left_seed)[
+                            "low_to_high_slope_per_rgb_mae"
+                        ]
+                        for item in values
+                    ]
+                )
+                right = np.asarray(
+                    [
+                        next(value for value in item["seed_records"] if value["seed"] == right_seed)[
+                            "low_to_high_slope_per_rgb_mae"
+                        ]
+                        for item in values
+                    ]
+                )
+                seed_associations.append(
+                    {
+                        "seed_pair": [left_seed, right_seed],
+                        **_slope_association(left, right, draws, base_seed + 100 + pair_index),
+                    }
+                )
+            endpoint_results[endpoint] = {
+                "image_count": len(values),
+                "input_weighted_absolute_error": bootstrap_mean_interval(weighted_error, draws, base_seed),
+                "naive_midpoint_absolute_error": bootstrap_mean_interval(midpoint_error, draws, base_seed + 1),
+                "paired_naive_minus_weighted_absolute_error": bootstrap_mean_interval(
+                    midpoint_error - weighted_error, draws, base_seed + 2
+                ),
+                "input_weighted_signed_error": bootstrap_mean_interval(signed_error, draws, base_seed + 3),
+                "normalized_absolute_error": {
+                    "defined_image_count": int(normalized.size),
+                    "zero_span_image_count": len(values) - int(normalized.size),
+                    "mean": float(normalized.mean()) if normalized.size else None,
+                    "median": float(np.median(normalized)) if normalized.size else None,
+                    "p90": float(np.quantile(normalized, 0.9)) if normalized.size else None,
+                    "fraction_at_or_below_0_10": float(np.mean(normalized <= 0.10)) if normalized.size else None,
+                    "fraction_at_or_below_0_20": float(np.mean(normalized <= 0.20)) if normalized.size else None,
+                },
+                "actual_middle_within_endpoints_count": sum(
+                    item["actual_middle_within_endpoints"] for item in values
+                ),
+                "cross_seed_low_to_high_slope_associations": seed_associations,
+            }
+        by_family[family["name"]] = {"endpoints": endpoint_results}
+    return {
+        "method": {
+            "unit": "image after equal averaging across seeds",
+            "held_level": "middle",
+            "predictor": "linear interpolation in per-image actual RGB MAE using low/high route endpoints",
+            "baseline": "unweighted arithmetic midpoint of low/high route endpoints",
+            "primary_endpoint": "probability_mae",
+            "secondary_endpoint": "dominant_switch_fraction",
+            "bootstrap": f"{draws:,} image resamples; descriptive for the fixed selected subset",
+            "pass_gate": "integrity and completeness only; predictive performance is not gated",
+        },
+        "by_family": by_family,
+    }
+
+
+def _font(size: int, *, mono: bool = False) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    candidate = "C:/Windows/Fonts/consola.ttf" if mono else "C:/Windows/Fonts/segoeui.ttf"
+    try:
+        return ImageFont.truetype(candidate, size)
+    except OSError:
+        return ImageFont.load_default()
+
+
+def _save_overview(records: list[dict[str, Any]], result: dict[str, Any], output: Path) -> None:
+    canvas = Image.new("RGB", (1800, 1050), "#071426")
+    draw = ImageDraw.Draw(canvas)
+    title, subtitle, section, body, small = _font(46), _font(22), _font(27), _font(18), _font(15, mono=True)
+    draw.text((70, 48), "CAN LOW + HIGH PREDICT THE HELD MIDDLE DOSE?", fill="#f2f7ff", font=title)
+    draw.text(
+        (72, 110),
+        "32 image units · interpolation weighted by actual RGB distance · 10,000 image bootstrap draws",
+        fill="#8eabc8",
+        font=subtitle,
+    )
+    families = list(result["by_family"])
+    for column, family in enumerate(families):
+        left = 70 + column * 570
+        draw.rounded_rectangle((left, 170, left + 530, 925), radius=24, fill="#0b213a", outline="#226287", width=2)
+        draw.text((left + 28, 196), family.replace("_", " ").upper(), fill="#ffcf66", font=section)
+        selected = [item for item in records if item["family"] == family]
+        actual = np.asarray([item["endpoints"]["probability_mae"]["actual_middle"] for item in selected])
+        predicted = np.asarray(
+            [item["endpoints"]["probability_mae"]["predicted_middle_input_weighted"] for item in selected]
+        )
+        low = float(min(actual.min(), predicted.min()))
+        high = float(max(actual.max(), predicted.max()))
+        span = high - low or 1.0
+        plot_left, plot_top, plot_right, plot_bottom = left + 70, 275, left + 480, 635
+        draw.line((plot_left, plot_bottom, plot_right, plot_bottom), fill="#496783", width=2)
+        draw.line((plot_left, plot_top, plot_left, plot_bottom), fill="#496783", width=2)
+        draw.line((plot_left, plot_bottom, plot_right, plot_top), fill="#315e72", width=2)
+        for prediction, observation in zip(predicted, actual):
+            px = plot_left + int((plot_right - plot_left) * (prediction - low) / span)
+            py = plot_bottom - int((plot_bottom - plot_top) * (observation - low) / span)
+            draw.ellipse((px - 5, py - 5, px + 5, py + 5), fill="#18d6c4", outline="#ffffff")
+        draw.text((plot_left, plot_bottom + 10), "predicted middle →", fill="#8ba8c4", font=small)
+        draw.text((plot_left - 45, plot_top - 22), "actual ↑", fill="#8ba8c4", font=small)
+        probability = result["by_family"][family]["endpoints"]["probability_mae"]
+        switch = result["by_family"][family]["endpoints"]["dominant_switch_fraction"]
+        improvement = probability["paired_naive_minus_weighted_absolute_error"]
+        interval = improvement["percentile_95_interval"]
+        normalized = probability["normalized_absolute_error"]
+        draw.text((left + 28, 682), "PRIMARY · PROBABILITY", fill="#55e2ff", font=body)
+        draw.text(
+            (left + 28, 718),
+            f"weighted MAE  {probability['input_weighted_absolute_error']['observed_mean']:.2e}",
+            fill="#dcecff",
+            font=small,
+        )
+        draw.text(
+            (left + 28, 748),
+            f"normalized median  {normalized['median']:.3f}  |  p90 {normalized['p90']:.3f}",
+            fill="#dcecff",
+            font=small,
+        )
+        draw.text(
+            (left + 28, 778),
+            f"baseline error minus weighted  {improvement['observed_mean']:.2e}",
+            fill="#63e6a7" if interval[0] > 0 else "#ffcf66",
+            font=small,
+        )
+        draw.text((left + 28, 808), f"95% [{interval[0]:.2e}, {interval[1]:.2e}]", fill="#8ba8c4", font=small)
+        switch_norm = switch["normalized_absolute_error"]
+        draw.text((left + 28, 850), "SECONDARY · SWITCH", fill="#c477ff", font=body)
+        switch_text = (
+            f"normalized median {switch_norm['median']:.3f} | zero-span {switch_norm['zero_span_image_count']}"
+            if switch_norm["median"] is not None
+            else f"normalized undefined | zero-span {switch_norm['zero_span_image_count']}"
+        )
+        draw.text((left + 28, 883), switch_text, fill="#dcecff", font=small)
+    draw.rounded_rectangle((70, 960, 1730, 1015), radius=14, fill="#2b2030")
+    draw.text(
+        (96, 977),
+        "GUARDRAIL  Retrospectively specified held-level analysis. Error and baseline improvement are observations, not PASS criteria.",
+        fill="#ffd06b",
+        font=small,
+    )
+    canvas.save(output)
+
+
+def run(config_path: Path, *, run_id: str | None = None, update_latest: bool = True) -> Path:
+    config = _load_config(config_path, run_id)
+    project_source = _verify_project_source_state(bool(config.get("require_committed_source", False)))
+    parent_dir = (PROJECT_ROOT / str(config["parent_run_dir"])).resolve()
+    try:
+        parent_dir.relative_to(PROJECT_ROOT.resolve())
+    except ValueError as error:
+        raise ValueError("parent_run_dir must stay inside the project repository") from error
+    run_dir = PROJECT_ROOT / "artifacts" / "p2" / config["run_id"]
+    if run_dir.exists() and any(run_dir.iterdir()):
+        raise FileExistsError(f"refusing to overwrite non-empty evidence directory: {run_dir}")
+    run_dir.mkdir(parents=True, exist_ok=True)
+    logger = logging.getLogger(f"e3_p2.dose_holdout.{config['run_id']}")
+    logger.handlers.clear()
+    logger.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
+    console = logging.StreamHandler()
+    file_handler = logging.FileHandler(run_dir / "full.log", encoding="utf-8")
+    console.setFormatter(formatter)
+    file_handler.setFormatter(formatter)
+    logger.addHandler(console)
+    logger.addHandler(file_handler)
+    (run_dir / "config.resolved.yaml").write_text(
+        yaml.safe_dump(config, sort_keys=False, allow_unicode=True), encoding="utf-8"
+    )
+    (run_dir / "command.txt").write_text("run_dose_holdout.cmd\n", encoding="utf-8")
+    started = time.perf_counter()
+    verification = verify_parent_evidence(parent_dir, config["expected_parent_manifest_sha256"])
+    parent_summary = json.loads((parent_dir / "summary.json").read_text(encoding="utf-8"))
+    if parent_summary.get("run_id") != config["expected_parent_run_id"] or parent_summary.get("status") != "PASS":
+        raise RuntimeError("parent summary run identity or PASS state mismatch")
+    if int(parent_summary.get("selected_image_count", -1)) != int(config["expected_image_count"]):
+        raise RuntimeError("parent image count does not match holdout contract")
+    parent = json.loads((parent_dir / "dose-response-records.json").read_text(encoding="utf-8"))
+    records = build_holdout_records(
+        parent["records"], config["families"], int(config["expected_image_count"]), config["expected_seeds"]
+    )
+    analysis = analyze_holdout(
+        records,
+        config["families"],
+        config["expected_seeds"],
+        int(config["bootstrap_draws"]),
+        int(config["bootstrap_seed"]),
+    )
+    write_json(run_dir / "parent-evidence-verification.json", verification)
+    write_json(run_dir / "dose-holdout-records.json", {"record_count": len(records), "records": records})
+    write_json(run_dir / "dose-holdout-analysis.json", analysis)
+    _save_overview(records, analysis, run_dir / "dose-holdout-overview.png")
+    summary = {
+        "status": "PASS",
+        "scope": "integrity-bound held-middle validation of the formal MoA dose-response evidence",
+        "run_id": config["run_id"],
+        "tool_source": project_source,
+        "parent_run_id": parent_summary["run_id"],
+        "parent_evidence_verification": verification,
+        "image_count": int(config["expected_image_count"]),
+        "family_count": len(config["families"]),
+        "holdout_record_count": len(records),
+        "seed_slope_association_count": len(config["families"]) * len(ENDPOINTS) * 3,
+        "headline_probability_metrics": {
+            family: {
+                "weighted_absolute_error": item["endpoints"]["probability_mae"][
+                    "input_weighted_absolute_error"
+                ]["observed_mean"],
+                "normalized_absolute_error_median": item["endpoints"]["probability_mae"][
+                    "normalized_absolute_error"
+                ]["median"],
+                "naive_minus_weighted_error": item["endpoints"]["probability_mae"][
+                    "paired_naive_minus_weighted_absolute_error"
+                ]["observed_mean"],
+            }
+            for family, item in analysis["by_family"].items()
+        },
+        "interpretation_boundary": "retrospectively specified fixed-subset random-initialization interpolation audit; not blind validation, trained robustness or accuracy",
+        "environment": {"python": platform.python_version(), "platform": platform.platform()},
+        "duration_seconds_observation_only": time.perf_counter() - started,
+    }
+    write_json(run_dir / "summary.json", summary)
+    logger.info("status=PASS families=%d records=%d", len(config["families"]), len(records))
+    for handler in logger.handlers:
+        handler.flush()
+    evidence_bytes = sum(path.stat().st_size for path in run_dir.rglob("*") if path.is_file())
+    if evidence_bytes > int(config["max_evidence_bytes"]):
+        raise RuntimeError(f"holdout evidence budget exceeded: {evidence_bytes} > {config['max_evidence_bytes']}")
+    summary["evidence_bytes_before_manifest"] = evidence_bytes
+    write_json(run_dir / "summary.json", summary)
+    write_manifest(run_dir)
+    if update_latest:
+        (run_dir.parent / "DOSE_HOLDOUT_LATEST.txt").write_text(run_dir.name + "\n", encoding="utf-8")
+    return run_dir

--- a/tools/e3_routing/src/e3_p2/dose_response_runner.py
+++ b/tools/e3_routing/src/e3_p2/dose_response_runner.py
@@ -1,0 +1,387 @@
+"""Predeclared multi-strength MoA appearance audit with image-paired dose summaries."""
+
+from __future__ import annotations
+
+import json
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import yaml
+from PIL import Image, ImageDraw
+
+from .image_driver_analysis import _font
+from .io_utils import write_json, write_manifest
+from .scale_runner import bootstrap_mean_interval
+from .scale_runner import run as run_image_scale
+
+
+def _dose_families(config: dict[str, Any]) -> list[dict[str, Any]]:
+    transforms = [str(item["name"]) for item in config.get("transformations", [])]
+    candidates = set(transforms) - {"identity"}
+    families = config.get("dose_response_families")
+    if not isinstance(families, list) or not families:
+        raise ValueError("dose_response_families must be a non-empty list")
+    seen_names: set[str] = set()
+    seen_transforms: set[str] = set()
+    normalized = []
+    for family in families:
+        name = str(family.get("name", "")).strip()
+        if not name or name in seen_names:
+            raise ValueError(f"duplicate or empty dose family: {name!r}")
+        seen_names.add(name)
+        conditions = family.get("conditions")
+        if not isinstance(conditions, list) or len(conditions) < 3:
+            raise ValueError(f"dose family {name} requires at least three conditions")
+        normalized_conditions = []
+        severities = []
+        for item in conditions:
+            transform = str(item.get("transform", ""))
+            severity = float(item.get("severity"))
+            if transform not in candidates or transform in seen_transforms:
+                raise ValueError(f"unknown or reused dose transform: {transform}")
+            seen_transforms.add(transform)
+            severities.append(severity)
+            normalized_conditions.append(
+                {"transform": transform, "severity": severity, "label": str(item.get("label", severity))}
+            )
+        if severities != sorted(severities) or len(set(severities)) != len(severities):
+            raise ValueError(f"dose severities must be strictly increasing for {name}")
+        normalized.append({"name": name, "conditions": normalized_conditions})
+    if seen_transforms != candidates:
+        raise ValueError(f"dose families do not cover candidates: missing={sorted(candidates - seen_transforms)}")
+    return normalized
+
+
+def build_dose_records(
+    effect_records: list[dict[str, Any]],
+    target_cases: list[dict[str, Any]],
+    families: list[dict[str, Any]],
+    expected_images: int,
+    expected_seeds: list[int],
+) -> list[dict[str, Any]]:
+    effects: dict[tuple[str, int], dict[str, Any]] = {}
+    for item in effect_records:
+        key = (str(item["transform"]), int(item["sample_index"]))
+        if key in effects:
+            raise ValueError(f"duplicate effect record: {key}")
+        effects[key] = item
+    grouped: dict[tuple[str, int], list[dict[str, Any]]] = defaultdict(list)
+    for item in target_cases:
+        grouped[(str(item["transform"]), int(item["sample_index"]))].append(item)
+    expected_seed_set = set(expected_seeds)
+    output = []
+    for family in families:
+        for condition in family["conditions"]:
+            transform = condition["transform"]
+            for sample_index in range(expected_images):
+                key = (transform, sample_index)
+                if key not in effects or not bool(effects[key].get("model_input_changed")):
+                    raise ValueError(f"missing or no-op effect record: {key}")
+                cases = grouped.get(key, [])
+                seeds = [int(item["seed"]) for item in cases]
+                if len(cases) != len(expected_seeds) or set(seeds) != expected_seed_set or len(seeds) != len(set(seeds)):
+                    raise ValueError(f"incomplete or duplicate dose seed matrix: {key}, seeds={seeds}")
+                ordered = sorted(cases, key=lambda item: int(item["seed"]))
+                seed_values = [
+                    {
+                        "seed": int(item["seed"]),
+                        "probability_mae": float(item["probability_mae"]),
+                        "dominant_switch_fraction": float(item["dominant_switch_fraction"]),
+                    }
+                    for item in ordered
+                ]
+                output.append(
+                    {
+                        "family": family["name"],
+                        "transform": transform,
+                        "severity": float(condition["severity"]),
+                        "label": condition["label"],
+                        "sample_index": sample_index,
+                        "input_rgb_mae_0_255": float(effects[key]["rgb_mae_0_255"]),
+                        "target_probability_mae_mean_across_seeds": float(
+                            np.mean([item["probability_mae"] for item in seed_values])
+                        ),
+                        "target_dominant_switch_fraction_mean_across_seeds": float(
+                            np.mean([item["dominant_switch_fraction"] for item in seed_values])
+                        ),
+                        "seed_values": seed_values,
+                    }
+                )
+    return output
+
+
+def _nondecreasing(values: list[float]) -> bool:
+    return all(right >= left for left, right in zip(values, values[1:]))
+
+
+def summarize_dose_response(
+    records: list[dict[str, Any]],
+    families: list[dict[str, Any]],
+    expected_images: int,
+    expected_seeds: list[int],
+    draws: int,
+    seed: int,
+) -> dict[str, Any]:
+    metric_fields = {
+        "input_rgb_mae_0_255": "input_rgb_mae_0_255",
+        "target_probability_mae": "target_probability_mae_mean_across_seeds",
+        "target_dominant_switch_fraction": "target_dominant_switch_fraction_mean_across_seeds",
+    }
+    by_family = {}
+    for family_index, family in enumerate(families):
+        family_records = [item for item in records if item["family"] == family["name"]]
+        expected_count = expected_images * len(family["conditions"])
+        if len(family_records) != expected_count:
+            raise ValueError(f"incomplete dose family records for {family['name']}")
+        levels = []
+        for level_index, condition in enumerate(family["conditions"]):
+            selected = [item for item in family_records if item["transform"] == condition["transform"]]
+            if len(selected) != expected_images:
+                raise ValueError(f"incomplete dose level: {condition['transform']}")
+            levels.append(
+                {
+                    **condition,
+                    "metrics": {
+                        metric: bootstrap_mean_interval(
+                            np.asarray([item[field] for item in selected], dtype=np.float64),
+                            draws,
+                            seed + family_index * 10000 + level_index * 100 + metric_index,
+                        )
+                        for metric_index, (metric, field) in enumerate(metric_fields.items())
+                    },
+                }
+            )
+        monotonicity: dict[str, Any] = {}
+        for metric, field in metric_fields.items():
+            image_records = []
+            for sample_index in range(expected_images):
+                ordered = sorted(
+                    (item for item in family_records if item["sample_index"] == sample_index),
+                    key=lambda item: item["severity"],
+                )
+                values = [float(item[field]) for item in ordered]
+                image_records.append(
+                    {"sample_index": sample_index, "values": values, "nondecreasing": _nondecreasing(values)}
+                )
+            monotonicity[metric] = {
+                "image_count": expected_images,
+                "nondecreasing_image_count": sum(item["nondecreasing"] for item in image_records),
+                "nondecreasing_image_fraction": float(np.mean([item["nondecreasing"] for item in image_records])),
+                "image_records": image_records,
+            }
+        for metric, seed_field in (
+            ("target_probability_mae", "probability_mae"),
+            ("target_dominant_switch_fraction", "dominant_switch_fraction"),
+        ):
+            unit_records = []
+            for sample_index in range(expected_images):
+                ordered = sorted(
+                    (item for item in family_records if item["sample_index"] == sample_index),
+                    key=lambda item: item["severity"],
+                )
+                for current_seed in expected_seeds:
+                    values = [
+                        next(value[seed_field] for value in item["seed_values"] if value["seed"] == current_seed)
+                        for item in ordered
+                    ]
+                    unit_records.append(
+                        {
+                            "sample_index": sample_index,
+                            "seed": current_seed,
+                            "values": values,
+                            "nondecreasing": _nondecreasing(values),
+                        }
+                    )
+            monotonicity[metric].update(
+                {
+                    "image_seed_unit_count": len(unit_records),
+                    "nondecreasing_image_seed_count": sum(item["nondecreasing"] for item in unit_records),
+                    "nondecreasing_image_seed_fraction": float(
+                        np.mean([item["nondecreasing"] for item in unit_records])
+                    ),
+                    "image_seed_records": unit_records,
+                }
+            )
+        if monotonicity["input_rgb_mae_0_255"]["nondecreasing_image_count"] != expected_images:
+            raise RuntimeError(f"input severity ladder is not monotone for every image: {family['name']}")
+        low_transform = family["conditions"][0]["transform"]
+        high_transform = family["conditions"][-1]["transform"]
+        paired_differences = {}
+        for metric_index, (metric, field) in enumerate(metric_fields.items()):
+            differences = []
+            for sample_index in range(expected_images):
+                low = next(
+                    item for item in family_records if item["sample_index"] == sample_index and item["transform"] == low_transform
+                )
+                high = next(
+                    item for item in family_records if item["sample_index"] == sample_index and item["transform"] == high_transform
+                )
+                differences.append(float(high[field]) - float(low[field]))
+            paired_differences[metric] = bootstrap_mean_interval(
+                np.asarray(differences, dtype=np.float64),
+                draws,
+                seed + family_index * 10000 + 9000 + metric_index,
+            )
+        by_family[family["name"]] = {
+            "conditions": family["conditions"],
+            "levels": levels,
+            "monotonicity": monotonicity,
+            "high_minus_low_paired_difference": paired_differences,
+        }
+    return {
+        "method": {
+            "primary_unit": "image after equal averaging across three seeds",
+            "primary_endpoint": "target raw-grid probability MAE",
+            "secondary_endpoint": "target raw-grid dominant-expert switch fraction",
+            "bootstrap": "10,000 paired image resamples; descriptive for the fixed selected subset",
+            "monotonic_rule": "non-decreasing at all adjacent levels; exact floating-point comparison",
+            "family_pooling": "forbidden",
+        },
+        "by_family": by_family,
+    }
+
+
+def _save_dose_overview(result: dict[str, Any], output: Path) -> None:
+    width, height = 1800, 1040
+    canvas = Image.new("RGB", (width, height), "#061426")
+    draw = ImageDraw.Draw(canvas)
+    title, subtitle, section, body, small = _font(48), _font(22), _font(27), _font(18), _font(15)
+    draw.text((70, 52), "APPEARANCE STRENGTH → ROUTING RESPONSE", fill="#eff7ff", font=title)
+    draw.text(
+        (72, 116),
+        "32 image units · 3 seeds · low / medium / high · image-paired bootstrap · random-init mechanism audit",
+        fill="#8faecc",
+        font=subtitle,
+    )
+    colors = ["#22d3c5", "#ffcb66", "#c477ff"]
+    for column, (family, item) in enumerate(result["by_family"].items()):
+        left = 70 + column * 570
+        draw.rounded_rectangle((left, 178, left + 530, 910), radius=24, fill="#0b213a", outline="#226287", width=2)
+        draw.text((left + 28, 205), family.replace("_", " ").upper(), fill="#58e2ff", font=section)
+        labels = [level["label"] for level in item["levels"]]
+        probability = [level["metrics"]["target_probability_mae"]["observed_mean"] for level in item["levels"]]
+        switches = [
+            level["metrics"]["target_dominant_switch_fraction"]["observed_mean"] for level in item["levels"]
+        ]
+        inputs = [level["metrics"]["input_rgb_mae_0_255"]["observed_mean"] for level in item["levels"]]
+        for index, label in enumerate(labels):
+            x = left + 95 + index * 165
+            draw.text((x - 18, 263), label, fill="#dcecff", font=body)
+            if index < len(labels) - 1:
+                draw.line((x + 37, 276, x + 127, 276), fill="#3d6687", width=3)
+                draw.polygon([(x + 127, 270), (x + 142, 276), (x + 127, 282)], fill="#3d6687")
+        blocks = [
+            ("INPUT RGB MAE", inputs, "{:.3g}"),
+            ("TARGET PROBABILITY MAE", probability, "{:.2e}"),
+            ("TARGET SWITCH RATE", [value * 100 for value in switches], "{:.2f}%"),
+        ]
+        for row, (label, values, formatter) in enumerate(blocks):
+            top = 320 + row * 150
+            draw.text((left + 28, top), label, fill="#92aec8", font=small)
+            maximum = max(values) or 1.0
+            for index, value in enumerate(values):
+                x = left + 52 + index * 165
+                bar_height = int(72 * value / maximum)
+                draw.rounded_rectangle((x, top + 38, x + 100, top + 118), radius=9, fill="#102c49")
+                draw.rounded_rectangle(
+                    (x, top + 118 - bar_height, x + 100, top + 118), radius=9, fill=colors[index]
+                )
+                draw.text((x + 7, top + 124), formatter.format(value), fill="#dcecff", font=small)
+        probability_mono = item["monotonicity"]["target_probability_mae"]
+        switch_mono = item["monotonicity"]["target_dominant_switch_fraction"]
+        draw.rounded_rectangle((left + 28, 782, left + 502, 878), radius=14, fill="#08182b", outline="#254764", width=2)
+        draw.text(
+            (left + 48, 802),
+            f"probability monotone  {probability_mono['nondecreasing_image_count']}/32 images",
+            fill="#63e6a7",
+            font=body,
+        )
+        draw.text(
+            (left + 48, 840),
+            f"switch monotone       {switch_mono['nondecreasing_image_count']}/32 images",
+            fill="#d6a2ff",
+            font=body,
+        )
+    draw.rounded_rectangle((70, 940, 1730, 996), radius=14, fill="#302233")
+    draw.text(
+        (96, 957),
+        "GUARDRAIL  Probability MAE is primary. Switch is margin-sensitive. Families are never pooled; monotonicity is not a PASS criterion.",
+        fill="#ffd16e",
+        font=small,
+    )
+    canvas.save(output)
+
+
+def run(config_path: Path, *, run_id: str | None = None, update_latest: bool = True) -> Path:
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    if not isinstance(config, dict):
+        raise TypeError(f"config must contain a mapping: {config_path}")
+    families = _dose_families(config)
+    started = time.perf_counter()
+    run_dir = run_image_scale(config_path, run_id=run_id, update_latest=False)
+    resolved = yaml.safe_load((run_dir / "config.resolved.yaml").read_text(encoding="utf-8"))
+    effects = json.loads((run_dir / "transformation-effect.json").read_text(encoding="utf-8"))
+    cases = json.loads((run_dir / "target-layer-cases.json").read_text(encoding="utf-8"))
+    records = build_dose_records(
+        effects["records"],
+        cases,
+        families,
+        int(resolved["selected_image_count"]),
+        [int(value) for value in resolved["seeds"]],
+    )
+    result = summarize_dose_response(
+        records,
+        families,
+        int(resolved["selected_image_count"]),
+        [int(value) for value in resolved["seeds"]],
+        int(resolved["bootstrap_draws"]),
+        int(resolved["bootstrap_seed"]),
+    )
+    write_json(run_dir / "dose-response-records.json", {"record_count": len(records), "records": records})
+    write_json(run_dir / "dose-response.json", result)
+    _save_dose_overview(result, run_dir / "dose-response-overview.png")
+    legacy_overview = run_dir / "image-level-overview.png"
+    if legacy_overview.exists():
+        legacy_overview.unlink()
+    (run_dir / "command.txt").write_text("run_dose_response.cmd\n", encoding="utf-8")
+    summary_path = run_dir / "summary.json"
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    summary.update(
+        {
+            "scope": "CPU-only 32-image MoA appearance-strength dose-response audit",
+            "dose_response_family_count": len(families),
+            "dose_response_level_count": sum(len(item["conditions"]) for item in families),
+            "dose_response_record_count": len(records),
+            "dose_response": {
+                name: {
+                    "probability_nondecreasing_image_count": item["monotonicity"]["target_probability_mae"][
+                        "nondecreasing_image_count"
+                    ],
+                    "switch_nondecreasing_image_count": item["monotonicity"][
+                        "target_dominant_switch_fraction"
+                    ]["nondecreasing_image_count"],
+                }
+                for name, item in result["by_family"].items()
+            },
+            "interpretation_boundary": "deterministic coco128 subset and random initialization; descriptive dose response, not learned robustness or accuracy",
+            "duration_seconds_observation_only": time.perf_counter() - started,
+        }
+    )
+    write_json(summary_path, summary)
+    with (run_dir / "full.log").open("a", encoding="utf-8") as stream:
+        stream.write(
+            f"dose-response status=PASS families={len(families)} levels={sum(len(item['conditions']) for item in families)} records={len(records)}\n"
+        )
+    evidence_bytes = sum(path.stat().st_size for path in run_dir.rglob("*") if path.is_file() and path.name != "manifest.sha256.json")
+    if evidence_bytes > int(resolved["max_evidence_bytes"]):
+        raise RuntimeError(f"dose evidence budget exceeded: {evidence_bytes} > {resolved['max_evidence_bytes']}")
+    summary["evidence_bytes_before_manifest"] = evidence_bytes
+    write_json(summary_path, summary)
+    write_manifest(run_dir)
+    if update_latest:
+        latest = run_dir.parent / "DOSE_RESPONSE_LATEST.txt"
+        latest.write_text(run_dir.name + "\n", encoding="utf-8")
+    return run_dir

--- a/tools/e3_routing/src/e3_p2/geometry.py
+++ b/tools/e3_routing/src/e3_p2/geometry.py
@@ -1,0 +1,101 @@
+"""Letterbox geometry and truthful feature-grid to original-image mapping."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+import numpy as np
+from PIL import Image
+
+
+@dataclass(frozen=True)
+class LetterboxMeta:
+    original_width: int
+    original_height: int
+    input_size: int
+    resized_width: int
+    resized_height: int
+    pad_left: int
+    pad_top: int
+    pad_right: int
+    pad_bottom: int
+    scale: float
+
+    def to_dict(self) -> dict[str, int | float]:
+        return asdict(self)
+
+
+def letterbox(image: Image.Image, input_size: int, fill: int = 114) -> tuple[np.ndarray, LetterboxMeta]:
+    """Resize without distortion and record the exact integer padding transform."""
+
+    if input_size <= 0:
+        raise ValueError("input_size must be positive")
+    rgb = image.convert("RGB")
+    original_width, original_height = rgb.size
+    if original_width <= 0 or original_height <= 0:
+        raise ValueError("image dimensions must be positive")
+    scale = min(input_size / original_width, input_size / original_height)
+    resized_width = max(1, min(input_size, round(original_width * scale)))
+    resized_height = max(1, min(input_size, round(original_height * scale)))
+    pad_width = input_size - resized_width
+    pad_height = input_size - resized_height
+    pad_left = pad_width // 2
+    pad_right = pad_width - pad_left
+    pad_top = pad_height // 2
+    pad_bottom = pad_height - pad_top
+    resized = rgb.resize((resized_width, resized_height), Image.Resampling.BILINEAR)
+    canvas = Image.new("RGB", (input_size, input_size), color=(fill, fill, fill))
+    canvas.paste(resized, (pad_left, pad_top))
+    meta = LetterboxMeta(
+        original_width=original_width,
+        original_height=original_height,
+        input_size=input_size,
+        resized_width=resized_width,
+        resized_height=resized_height,
+        pad_left=pad_left,
+        pad_top=pad_top,
+        pad_right=pad_right,
+        pad_bottom=pad_bottom,
+        scale=scale,
+    )
+    return np.asarray(canvas, dtype=np.uint8), meta
+
+
+def restore_heatmap(heatmap: np.ndarray, meta: LetterboxMeta) -> np.ndarray:
+    """Map a real feature-grid scalar field through letterbox space back to original pixels."""
+
+    field = np.asarray(heatmap, dtype=np.float32)
+    if field.ndim != 2 or not field.size or not np.isfinite(field).all():
+        raise ValueError("heatmap must be a finite non-empty 2D array")
+    upsampled = Image.fromarray(field).resize((meta.input_size, meta.input_size), Image.Resampling.BILINEAR)
+    right = meta.input_size - meta.pad_right
+    bottom = meta.input_size - meta.pad_bottom
+    if right <= meta.pad_left or bottom <= meta.pad_top:
+        raise ValueError("letterbox metadata produces an empty crop")
+    unpadded = upsampled.crop((meta.pad_left, meta.pad_top, right, bottom))
+    restored = unpadded.resize((meta.original_width, meta.original_height), Image.Resampling.BILINEAR)
+    return np.asarray(restored, dtype=np.float32)
+
+
+def validate_probability_grid(weights: np.ndarray, tolerance: float = 1e-5) -> dict[str, float | list[int]]:
+    """Validate `[B,E,H,W]` routing semantics; singleton spatial axes are rejected."""
+
+    values = np.asarray(weights, dtype=np.float32)
+    if values.ndim != 4:
+        raise ValueError(f"expected [B,E,H,W], got shape={list(values.shape)}")
+    if min(values.shape) <= 0 or values.shape[2] <= 1 or values.shape[3] <= 1:
+        raise ValueError(f"not a token/spatial grid: shape={list(values.shape)}")
+    if not np.isfinite(values).all():
+        raise ValueError("routing grid contains non-finite values")
+    if float(values.min()) < -tolerance:
+        raise ValueError("routing grid contains negative probabilities")
+    sums = values.sum(axis=1)
+    max_sum_error = float(np.max(np.abs(sums - 1.0)))
+    if max_sum_error > tolerance:
+        raise ValueError(f"probabilities do not sum to one across experts: max_error={max_sum_error}")
+    return {
+        "shape": [int(item) for item in values.shape],
+        "min": float(values.min()),
+        "max": float(values.max()),
+        "max_expert_sum_error": max_sum_error,
+    }

--- a/tools/e3_routing/src/e3_p2/image_driver_analysis.py
+++ b/tools/e3_routing/src/e3_p2/image_driver_analysis.py
@@ -1,0 +1,392 @@
+"""Integrity-bound image-level association analysis for the formal coco128 scaling run."""
+
+from __future__ import annotations
+
+import json
+import logging
+import platform
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import yaml
+from PIL import Image, ImageDraw, ImageFont
+
+from .io_utils import write_json, write_manifest
+from .layer_drilldown import verify_parent_evidence
+from .runner import PROJECT_ROOT, RUN_ID_PATTERN, _verify_project_source_state
+
+
+def _load_config(path: Path, run_id_override: str | None) -> dict[str, Any]:
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise TypeError(f"config must contain a mapping: {path}")
+    config = dict(loaded)
+    run_id = str(run_id_override if run_id_override is not None else config.get("run_id", "")).strip()
+    if not RUN_ID_PATTERN.fullmatch(run_id):
+        raise ValueError("run_id must be path-safe and at most 128 characters")
+    config["run_id"] = run_id
+    transforms = [str(value) for value in config.get("candidate_transformations", [])]
+    if not transforms or len(set(transforms)) != len(transforms) or "identity" in transforms:
+        raise ValueError("candidate_transformations must be non-empty, unique and exclude identity")
+    config["candidate_transformations"] = transforms
+    endpoints = [str(value) for value in config.get("endpoints", [])]
+    allowed = {"probability_mae", "dominant_switch_fraction"}
+    if set(endpoints) != allowed or len(endpoints) != len(allowed):
+        raise ValueError(f"endpoints must be exactly {sorted(allowed)}")
+    config["endpoints"] = endpoints
+    if int(config.get("expected_image_count", 0)) < 4:
+        raise ValueError("expected_image_count must be at least four")
+    if int(config.get("bootstrap_draws", 0)) < 1000:
+        raise ValueError("bootstrap_draws must be at least 1000")
+    digest = str(config.get("expected_parent_manifest_sha256", ""))
+    if len(digest) != 64 or any(character not in "0123456789abcdef" for character in digest):
+        raise ValueError("expected_parent_manifest_sha256 must be a lowercase SHA-256 digest")
+    return config
+
+
+def average_ranks(values: np.ndarray) -> np.ndarray:
+    """Return one-based average ranks with deterministic tie handling."""
+
+    data = np.asarray(values, dtype=np.float64)
+    if data.ndim != 1 or data.size == 0 or not np.isfinite(data).all():
+        raise ValueError("rank input must be a non-empty finite vector")
+    order = np.argsort(data, kind="mergesort")
+    ranks = np.empty(data.size, dtype=np.float64)
+    position = 0
+    while position < data.size:
+        end = position + 1
+        while end < data.size and data[order[end]] == data[order[position]]:
+            end += 1
+        ranks[order[position:end]] = (position + 1 + end) / 2.0
+        position = end
+    return ranks
+
+
+def spearman(values_x: np.ndarray, values_y: np.ndarray) -> float | None:
+    """Compute tie-aware Spearman rho, returning None when either ranked vector is constant."""
+
+    x = np.asarray(values_x, dtype=np.float64)
+    y = np.asarray(values_y, dtype=np.float64)
+    if x.ndim != 1 or y.ndim != 1 or x.size != y.size or x.size < 3:
+        raise ValueError("Spearman inputs must be equal one-dimensional vectors of length at least three")
+    ranks_x, ranks_y = average_ranks(x), average_ranks(y)
+    centered_x = ranks_x - ranks_x.mean()
+    centered_y = ranks_y - ranks_y.mean()
+    denominator = float(np.sqrt(np.sum(centered_x**2) * np.sum(centered_y**2)))
+    if denominator == 0.0:
+        return None
+    return float(np.sum(centered_x * centered_y) / denominator)
+
+
+def bootstrap_spearman(
+    values_x: np.ndarray, values_y: np.ndarray, draws: int, seed: int
+) -> dict[str, Any]:
+    """Resample complete images and describe the selected subset's rank association."""
+
+    x = np.asarray(values_x, dtype=np.float64)
+    y = np.asarray(values_y, dtype=np.float64)
+    observed = spearman(x, y)
+    if observed is None:
+        raise ValueError("observed Spearman correlation is undefined")
+    rng = np.random.default_rng(seed)
+    coefficients: list[float] = []
+    undefined = 0
+    for _ in range(draws):
+        indices = rng.integers(0, x.size, size=x.size)
+        value = spearman(x[indices], y[indices])
+        if value is None:
+            undefined += 1
+        else:
+            coefficients.append(value)
+    if len(coefficients) < int(draws * 0.95):
+        raise RuntimeError("fewer than 95% of bootstrap Spearman draws are defined")
+    array = np.asarray(coefficients, dtype=np.float64)
+    return {
+        "image_unit_count": int(x.size),
+        "draws": draws,
+        "seed": seed,
+        "observed_spearman_rho": observed,
+        "defined_draw_count": len(coefficients),
+        "undefined_draw_count": undefined,
+        "percentile_95_interval": [float(value) for value in np.quantile(array, [0.025, 0.975])],
+        "bootstrap_median": float(np.median(array)),
+    }
+
+
+def leave_one_out_spearman(values_x: np.ndarray, values_y: np.ndarray) -> dict[str, Any]:
+    x = np.asarray(values_x, dtype=np.float64)
+    y = np.asarray(values_y, dtype=np.float64)
+    records = []
+    for omitted in range(x.size):
+        keep = np.arange(x.size) != omitted
+        value = spearman(x[keep], y[keep])
+        if value is None:
+            raise RuntimeError(f"leave-one-out Spearman undefined after omitting image {omitted}")
+        records.append({"omitted_position": omitted, "spearman_rho": value})
+    values = [item["spearman_rho"] for item in records]
+    return {"count": len(records), "minimum": min(values), "maximum": max(values), "records": records}
+
+
+def build_image_records(
+    effects: list[dict[str, Any]],
+    target_cases: list[dict[str, Any]],
+    transforms: list[str],
+    expected_images: int,
+    expected_seeds: list[int],
+) -> list[dict[str, Any]]:
+    """Join one input-effect value with seed-averaged target routing endpoints per image."""
+
+    effect_lookup: dict[tuple[str, int], dict[str, Any]] = {}
+    for item in effects:
+        key = (str(item["transform"]), int(item["sample_index"]))
+        if key in effect_lookup:
+            raise ValueError(f"duplicate input-effect record: {key}")
+        effect_lookup[key] = item
+    grouped: dict[tuple[str, int], list[dict[str, Any]]] = defaultdict(list)
+    for item in target_cases:
+        grouped[(str(item["transform"]), int(item["sample_index"]))].append(item)
+    output = []
+    expected_seed_set = set(expected_seeds)
+    for transform in transforms:
+        for sample_index in range(expected_images):
+            key = (transform, sample_index)
+            if key not in effect_lookup:
+                raise ValueError(f"missing input-effect record: {key}")
+            cases = grouped.get(key, [])
+            seeds = [int(item["seed"]) for item in cases]
+            if len(cases) != len(expected_seeds) or set(seeds) != expected_seed_set or len(seeds) != len(set(seeds)):
+                raise ValueError(f"incomplete or duplicate seed matrix: {key}, seeds={seeds}")
+            effect = effect_lookup[key]
+            if not bool(effect.get("model_input_changed")):
+                raise ValueError(f"input effect is a no-op: {key}")
+            output.append(
+                {
+                    "transform": transform,
+                    "sample_index": sample_index,
+                    "input_rgb_mae_0_255": float(effect["rgb_mae_0_255"]),
+                    "target_probability_mae_mean_across_seeds": float(
+                        np.mean([float(item["probability_mae"]) for item in cases])
+                    ),
+                    "target_dominant_switch_fraction_mean_across_seeds": float(
+                        np.mean([float(item["dominant_switch_fraction"]) for item in cases])
+                    ),
+                }
+            )
+    return output
+
+
+def analyze_associations(
+    records: list[dict[str, Any]], transforms: list[str], draws: int, seed: int
+) -> dict[str, Any]:
+    endpoint_fields = {
+        "probability_mae": "target_probability_mae_mean_across_seeds",
+        "dominant_switch_fraction": "target_dominant_switch_fraction_mean_across_seeds",
+    }
+    by_transform: dict[str, Any] = {}
+    for transform_index, transform in enumerate(transforms):
+        selected = [item for item in records if item["transform"] == transform]
+        x = np.asarray([item["input_rgb_mae_0_255"] for item in selected], dtype=np.float64)
+        endpoint_results = {}
+        for endpoint_index, (endpoint, field) in enumerate(endpoint_fields.items()):
+            y = np.asarray([item[field] for item in selected], dtype=np.float64)
+            endpoint_results[endpoint] = {
+                "x_field": "input_rgb_mae_0_255",
+                "y_field": field,
+                "bootstrap": bootstrap_spearman(
+                    x, y, draws, seed + transform_index * 1000 + endpoint_index
+                ),
+                "leave_one_image_out": leave_one_out_spearman(x, y),
+            }
+        by_transform[transform] = {"image_count": len(selected), "endpoints": endpoint_results}
+    return {
+        "method": {
+            "association": "tie-aware Spearman rank correlation",
+            "primary_unit": "image after equal averaging across seeds",
+            "predictor": "mean absolute raw RGB canvas difference on [0,255]",
+            "stratification": "each transformation analyzed separately; cross-transform pooling forbidden",
+            "bootstrap": "10,000 image resamples with replacement; descriptive for fixed selected subset",
+            "causal_status": "association only",
+        },
+        "by_transform": by_transform,
+    }
+
+
+def _font(size: int, *, mono: bool = False) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    candidate = "C:/Windows/Fonts/consola.ttf" if mono else "C:/Windows/Fonts/segoeui.ttf"
+    try:
+        return ImageFont.truetype(candidate, size)
+    except OSError:
+        return ImageFont.load_default()
+
+
+def _save_overview(records: list[dict[str, Any]], analysis: dict[str, Any], output: Path) -> None:
+    width, height = 1800, 1240
+    canvas = Image.new("RGB", (width, height), "#071426")
+    draw = ImageDraw.Draw(canvas)
+    title, subtitle, section, body, small = _font(50), _font(24), _font(27), _font(20), _font(16, mono=True)
+    draw.text((72, 54), "DOES MORE INPUT CHANGE MEAN MORE ROUTING CHANGE?", fill="#f0f7ff", font=title)
+    draw.text(
+        (74, 122),
+        "32 image units · within-transform Spearman · 10,000 image bootstrap draws · association, not causation",
+        fill="#88a8c7",
+        font=subtitle,
+    )
+    draw.rounded_rectangle((72, 176, 1728, 262), radius=18, fill="#0d2540", outline="#1d5879", width=2)
+    draw.text((98, 196), "WHY THIS GATE", fill="#55e2ff", font=section)
+    draw.text(
+        (330, 199),
+        "Pooling brightness, contrast and blur would confound transformation family. Each column is separate.",
+        fill="#dcecff",
+        font=body,
+    )
+
+    transforms = list(analysis["by_transform"])
+    endpoint_specs = [
+        ("probability_mae", "TARGET PROBABILITY MAE", "#18d6c4"),
+        ("dominant_switch_fraction", "TARGET EXPERT SWITCH RATE", "#bf78ff"),
+    ]
+    panel_width, panel_height = 520, 375
+    for column, transform in enumerate(transforms):
+        left = 72 + column * 552
+        draw.text((left + 4, 294), transform.replace("_", " ").upper(), fill="#ffcf66", font=section)
+        selected = [item for item in records if item["transform"] == transform]
+        x = np.asarray([item["input_rgb_mae_0_255"] for item in selected], dtype=np.float64)
+        for row, (endpoint, label, color) in enumerate(endpoint_specs):
+            top = 338 + row * 420
+            field = (
+                "target_probability_mae_mean_across_seeds"
+                if endpoint == "probability_mae"
+                else "target_dominant_switch_fraction_mean_across_seeds"
+            )
+            y = np.asarray([item[field] for item in selected], dtype=np.float64)
+            result = analysis["by_transform"][transform]["endpoints"][endpoint]
+            bootstrap = result["bootstrap"]
+            interval = bootstrap["percentile_95_interval"]
+            draw.rounded_rectangle(
+                (left, top, left + panel_width, top + panel_height),
+                radius=18,
+                fill="#0b2038",
+                outline="#204d70",
+                width=2,
+            )
+            draw.text((left + 24, top + 20), label, fill="#dcecff", font=body)
+            draw.text(
+                (left + 24, top + 54),
+                f"rho {bootstrap['observed_spearman_rho']:+.3f}  |  95% [{interval[0]:+.3f}, {interval[1]:+.3f}]",
+                fill=color,
+                font=small,
+            )
+            plot_left, plot_top = left + 58, top + 106
+            plot_right, plot_bottom = left + panel_width - 26, top + panel_height - 48
+            draw.line((plot_left, plot_bottom, plot_right, plot_bottom), fill="#496783", width=2)
+            draw.line((plot_left, plot_top, plot_left, plot_bottom), fill="#496783", width=2)
+            x_span = float(np.ptp(x)) or 1.0
+            y_span = float(np.ptp(y)) or 1.0
+            for item_x, item_y in zip(x, y):
+                px = plot_left + 8 + int((plot_right - plot_left - 16) * (item_x - x.min()) / x_span)
+                py = plot_bottom - 8 - int((plot_bottom - plot_top - 16) * (item_y - y.min()) / y_span)
+                draw.ellipse((px - 5, py - 5, px + 5, py + 5), fill=color, outline="#ffffff", width=1)
+            draw.text((plot_left, plot_bottom + 10), f"RGB MAE {x.min():.3g} → {x.max():.3g}", fill="#7f9fbd", font=small)
+            y_label = (
+                f"route MAE {y.min():.2e} → {y.max():.2e}"
+                if endpoint == "probability_mae"
+                else f"switch {y.min() * 100:.2f}% → {y.max() * 100:.2f}%"
+            )
+            draw.text((plot_left + 205, plot_bottom + 10), y_label, fill="#7f9fbd", font=small)
+
+    draw.rounded_rectangle((72, 1185, 1728, 1225), radius=12, fill="#2b2030")
+    draw.text(
+        (96, 1195),
+        "GUARDRAIL  Fixed deterministic subset + random initialization. Bootstrap describes subset heterogeneity only.",
+        fill="#ffd06b",
+        font=small,
+    )
+    canvas.save(output)
+
+
+def run(config_path: Path, *, run_id: str | None = None, update_latest: bool = True) -> Path:
+    config = _load_config(config_path, run_id)
+    project_source = _verify_project_source_state(bool(config.get("require_committed_source", False)))
+    source_dir = (PROJECT_ROOT / config["parent_run_dir"]).resolve()
+    try:
+        source_dir.relative_to(PROJECT_ROOT.resolve())
+    except ValueError as error:
+        raise ValueError("parent_run_dir must stay inside the project repository") from error
+    run_dir = PROJECT_ROOT / "artifacts" / "p2" / config["run_id"]
+    if run_dir.exists() and any(run_dir.iterdir()):
+        raise FileExistsError(f"refusing to overwrite non-empty evidence directory: {run_dir}")
+    run_dir.mkdir(parents=True, exist_ok=True)
+    logger = logging.getLogger(f"e3_p2.image_driver.{config['run_id']}")
+    logger.handlers.clear()
+    logger.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
+    console, file_handler = logging.StreamHandler(), logging.FileHandler(run_dir / "full.log", encoding="utf-8")
+    console.setFormatter(formatter)
+    file_handler.setFormatter(formatter)
+    logger.addHandler(console)
+    logger.addHandler(file_handler)
+    (run_dir / "config.resolved.yaml").write_text(
+        yaml.safe_dump(config, sort_keys=False, allow_unicode=True), encoding="utf-8"
+    )
+    (run_dir / "command.txt").write_text("run_image_driver.cmd\n", encoding="utf-8")
+    started = time.perf_counter()
+    verification = verify_parent_evidence(source_dir, config["expected_parent_manifest_sha256"])
+    parent_summary = json.loads((source_dir / "summary.json").read_text(encoding="utf-8"))
+    if parent_summary.get("run_id") != config["expected_parent_run_id"] or parent_summary.get("status") != "PASS":
+        raise RuntimeError("parent summary run identity or PASS state mismatch")
+    if int(parent_summary.get("selected_image_count", -1)) != int(config["expected_image_count"]):
+        raise RuntimeError("parent image count does not match the predeclared contract")
+    effects = json.loads((source_dir / "transformation-effect.json").read_text(encoding="utf-8"))
+    cases = json.loads((source_dir / "target-layer-cases.json").read_text(encoding="utf-8"))
+    records = build_image_records(
+        effects["records"],
+        cases,
+        config["candidate_transformations"],
+        int(config["expected_image_count"]),
+        [int(value) for value in config["expected_seeds"]],
+    )
+    analysis = analyze_associations(
+        records,
+        config["candidate_transformations"],
+        int(config["bootstrap_draws"]),
+        int(config["bootstrap_seed"]),
+    )
+    write_json(run_dir / "parent-evidence-verification.json", verification)
+    write_json(run_dir / "image-level-records.json", {"record_count": len(records), "records": records})
+    write_json(run_dir / "image-driver-associations.json", analysis)
+    _save_overview(records, analysis, run_dir / "image-driver-overview.png")
+    coefficients = {
+        transform: {
+            endpoint: values["bootstrap"]["observed_spearman_rho"]
+            for endpoint, values in result["endpoints"].items()
+        }
+        for transform, result in analysis["by_transform"].items()
+    }
+    summary = {
+        "status": "PASS",
+        "scope": "post-hoc within-transform image-level input-change and target-routing-change associations",
+        "run_id": config["run_id"],
+        "tool_source": project_source,
+        "parent_run_id": parent_summary["run_id"],
+        "parent_evidence_verification": verification,
+        "image_count": int(config["expected_image_count"]),
+        "image_transform_record_count": len(records),
+        "candidate_transformations": config["candidate_transformations"],
+        "observed_spearman_rho": coefficients,
+        "interpretation_boundary": "within-transform association in a deterministic subset under random initialization; not causal or population-generalizable",
+        "environment": {"python": platform.python_version(), "platform": platform.platform()},
+        "duration_seconds_observation_only": time.perf_counter() - started,
+    }
+    write_json(run_dir / "summary.json", summary)
+    logger.info("status=PASS records=%d transforms=%d endpoints=2", len(records), len(config["candidate_transformations"]))
+    for handler in logger.handlers:
+        handler.flush()
+    write_manifest(run_dir)
+    if update_latest:
+        latest = PROJECT_ROOT / "artifacts" / "p2" / "IMAGE_DRIVER_LATEST.txt"
+        latest.parent.mkdir(parents=True, exist_ok=True)
+        latest.write_text(config["run_id"] + "\n", encoding="utf-8")
+    return run_dir

--- a/tools/e3_routing/src/e3_p2/io_utils.py
+++ b/tools/e3_routing/src/e3_p2/io_utils.py
@@ -1,0 +1,66 @@
+"""Evidence I/O helpers shared by the P2 runner."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def write_manifest(run_dir: Path) -> Path:
+    files = []
+    for path in sorted(item for item in run_dir.rglob("*") if item.is_file() and item.name != "manifest.sha256.json"):
+        files.append(
+            {
+                "path": path.relative_to(run_dir).as_posix(),
+                "bytes": path.stat().st_size,
+                "sha256": sha256_file(path),
+            }
+        )
+    destination = run_dir / "manifest.sha256.json"
+    write_json(destination, {"algorithm": "sha256", "file_count": len(files), "files": files})
+    return destination
+
+
+def environment(torch_module: Any, source_root: Path, project_root: Path) -> dict[str, Any]:
+    def git_value(root: Path, *args: str) -> str | None:
+        try:
+            return subprocess.check_output(
+                ["git", "-C", str(root), *args], stderr=subprocess.DEVNULL, text=True, encoding="utf-8"
+            ).strip()
+        except (OSError, subprocess.CalledProcessError):
+            return None
+
+    return {
+        "python": sys.version,
+        "executable": sys.executable,
+        "platform": platform.platform(),
+        "processor": platform.processor(),
+        "torch": torch_module.__version__,
+        "cuda_available": bool(torch_module.cuda.is_available()),
+        "cuda_version": torch_module.version.cuda,
+        "device_requested": "cpu",
+        "cpu_threads": int(torch_module.get_num_threads()),
+        "project_commit": git_value(project_root, "rev-parse", "HEAD"),
+        "project_tree": git_value(project_root, "rev-parse", "HEAD^{tree}"),
+        "source_root": str(source_root),
+        "source_git_commit": git_value(source_root, "rev-parse", "HEAD"),
+        "cwd": os.getcwd(),
+    }

--- a/tools/e3_routing/src/e3_p2/layer_drilldown.py
+++ b/tools/e3_routing/src/e3_p2/layer_drilldown.py
@@ -1,0 +1,609 @@
+"""Post-hoc, integrity-bound layer attribution for the formal appearance run."""
+
+from __future__ import annotations
+
+import json
+import platform
+import time
+from collections import defaultdict
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+import numpy as np
+import yaml
+from PIL import Image, ImageDraw, ImageFont
+
+from .io_utils import sha256_file, write_json, write_manifest
+from .runner import PROJECT_ROOT, RUN_ID_PATTERN, _logger, _slug, _verify_project_source_state
+
+
+def _load_config(path: Path, run_id_override: str | None) -> dict[str, Any]:
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise TypeError(f"config must contain a mapping: {path}")
+    config = dict(loaded)
+    run_id = str(run_id_override if run_id_override is not None else config.get("run_id", "")).strip()
+    if not RUN_ID_PATTERN.fullmatch(run_id):
+        raise ValueError("run_id must be path-safe and at most 128 characters")
+    config["run_id"] = run_id
+    if config.get("family") != "moa":
+        raise ValueError("layer attribution is intentionally scoped to the non-constant MoA family")
+    if not str(config.get("target_module", "")).strip():
+        raise ValueError("target_module is required")
+    transforms = [str(value) for value in config.get("candidate_transformations", [])]
+    if not transforms or len(set(transforms)) != len(transforms) or "identity" in transforms:
+        raise ValueError("candidate_transformations must be non-empty, unique and exclude identity")
+    config["candidate_transformations"] = transforms
+    if int(config.get("margin_bin_count", 0)) != 10:
+        raise ValueError("the audited margin contract requires exactly 10 percentile bins")
+    expected_digest = str(config.get("expected_parent_manifest_sha256", ""))
+    if len(expected_digest) != 64 or any(character not in "0123456789abcdef" for character in expected_digest):
+        raise ValueError("expected_parent_manifest_sha256 must be a lowercase SHA-256 digest")
+    return config
+
+
+def _safe_parent_path(relative: str) -> Path:
+    pure = PurePosixPath(relative)
+    if pure.is_absolute() or ".." in pure.parts or not pure.parts:
+        raise ValueError(f"unsafe manifest path: {relative}")
+    return Path(*pure.parts)
+
+
+def verify_parent_evidence(source_dir: Path, expected_manifest_sha256: str) -> dict[str, Any]:
+    """Fail closed unless the parent evidence directory exactly matches its locked manifest."""
+
+    manifest_path = source_dir / "manifest.sha256.json"
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"parent manifest missing: {manifest_path}")
+    manifest_sha256 = sha256_file(manifest_path)
+    if manifest_sha256 != expected_manifest_sha256:
+        raise RuntimeError(
+            f"parent manifest digest mismatch: {manifest_sha256} != {expected_manifest_sha256}"
+        )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    entries = manifest.get("files")
+    if manifest.get("algorithm") != "sha256" or not isinstance(entries, list):
+        raise ValueError("parent manifest schema is invalid")
+    if int(manifest.get("file_count", -1)) != len(entries):
+        raise ValueError("parent manifest file_count does not match entries")
+    declared: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        relative = str(entry.get("path", ""))
+        _safe_parent_path(relative)
+        if relative in declared:
+            raise ValueError(f"duplicate parent manifest path: {relative}")
+        declared[relative] = entry
+    actual = {
+        path.relative_to(source_dir).as_posix()
+        for path in source_dir.rglob("*")
+        if path.is_file() and path.name != "manifest.sha256.json"
+    }
+    if actual != set(declared):
+        raise RuntimeError(
+            f"parent evidence file set mismatch: missing={sorted(set(declared) - actual)[:3]}, "
+            f"extra={sorted(actual - set(declared))[:3]}"
+        )
+    for relative, entry in declared.items():
+        path = source_dir / _safe_parent_path(relative)
+        if path.stat().st_size != int(entry["bytes"]) or sha256_file(path) != entry["sha256"]:
+            raise RuntimeError(f"parent evidence integrity mismatch: {relative}")
+    return {
+        "status": "PASS",
+        "manifest_sha256": manifest_sha256,
+        "verified_file_count": len(entries),
+        "file_set_exact": True,
+        "hash_and_size_mismatch_count": 0,
+        "key_artifacts": {
+            name: declared[name]["sha256"]
+            for name in (
+                "appearance-routing-raw.npz",
+                "appearance-stability-comparisons.json",
+                "summary.json",
+            )
+            if name in declared
+        },
+    }
+
+
+def summarize_layer_attribution(
+    comparisons: list[dict[str, Any]], family: str, transforms: list[str], target_module: str
+) -> dict[str, Any]:
+    """Rank layers using equal-weight mean original-coordinate probability MAE."""
+
+    selected = [
+        item
+        for item in comparisons
+        if item["family"] == family
+        and item["comparison_type"].removeprefix("appearance_") in transforms
+    ]
+    if not selected:
+        raise ValueError("no matching appearance comparisons")
+    by_transform_module: dict[tuple[str, str], list[float]] = defaultdict(list)
+    by_transform_seed_module: dict[tuple[str, int, str], list[float]] = defaultdict(list)
+    for item in selected:
+        transform = item["comparison_type"].removeprefix("appearance_")
+        module = item["module"]
+        value = float(item["metrics"]["probability_mae"])
+        by_transform_module[(transform, module)].append(value)
+        by_transform_seed_module[(transform, int(item["seed"]), module)].append(value)
+
+    by_transform = {}
+    for transform in transforms:
+        means = {
+            module: float(np.mean(values))
+            for (candidate, module), values in by_transform_module.items()
+            if candidate == transform
+        }
+        if target_module not in means or len(means) < 2:
+            raise ValueError(f"target or comparison layers missing for {transform}")
+        denominator = sum(means.values())
+        if denominator <= 0.0:
+            raise ValueError(f"non-positive layer MAE sum for {transform}")
+        ranking = sorted(means, key=lambda module: (-means[module], module))
+        by_transform[transform] = {
+            "layer_count": len(ranking),
+            "ranking": [
+                {
+                    "rank": rank,
+                    "module": module,
+                    "mean_probability_mae": means[module],
+                    "share_of_layer_mean_mae_sum": means[module] / denominator,
+                }
+                for rank, module in enumerate(ranking, start=1)
+            ],
+            "target_rank": ranking.index(target_module) + 1,
+            "target_share_of_layer_mean_mae_sum": means[target_module] / denominator,
+        }
+
+    seed_rankings = []
+    seed_values = sorted({int(item["seed"]) for item in selected})
+    for transform in transforms:
+        for seed in seed_values:
+            means = {
+                module: float(np.mean(values))
+                for (candidate, candidate_seed, module), values in by_transform_seed_module.items()
+                if candidate == transform and candidate_seed == seed
+            }
+            ranking = sorted(means, key=lambda module: (-means[module], module))
+            seed_rankings.append(
+                {
+                    "transform": transform,
+                    "seed": seed,
+                    "target_rank": ranking.index(target_module) + 1,
+                    "rank_one_module": ranking[0],
+                    "target_mean_probability_mae": means[target_module],
+                }
+            )
+    rank_one_count = sum(item["target_rank"] == 1 for item in seed_rankings)
+    return {
+        "method": {
+            "metric": "probability_mae after exact restoration to original-image pixels",
+            "unit": "one seed x sample x module comparison",
+            "aggregation": "equal-weight mean within transform and module",
+            "share_denominator": "sum of the four module-level mean MAE values; descriptive, not causal",
+        },
+        "comparison_count": len(selected),
+        "target_module": target_module,
+        "by_transform": by_transform,
+        "target_rank_one_transform_count": sum(
+            item["target_rank"] == 1 for item in by_transform.values()
+        ),
+        "transform_count": len(transforms),
+        "seed_stratification": seed_rankings,
+        "target_rank_one_transform_seed_count": rank_one_count,
+        "transform_seed_group_count": len(seed_rankings),
+    }
+
+
+def margin_bin_summary(margins: np.ndarray, switched: np.ndarray, bin_count: int = 10) -> dict[str, Any]:
+    """Summarize switch rate in quantile-defined, mutually exclusive margin bins."""
+
+    values = np.asarray(margins, dtype=np.float64).reshape(-1)
+    flags = np.asarray(switched, dtype=bool).reshape(-1)
+    if values.size == 0 or values.shape != flags.shape or not np.isfinite(values).all():
+        raise ValueError("margins and switched must be matching, finite, non-empty vectors")
+    if (values < 0.0).any() or bin_count < 2:
+        raise ValueError("margins must be non-negative and bin_count >= 2")
+    edges = np.quantile(values, np.linspace(0.0, 1.0, bin_count + 1))
+    indices = np.searchsorted(edges[1:-1], values, side="right")
+    bins = []
+    for index in range(bin_count):
+        selected = indices == index
+        count = int(selected.sum())
+        bins.append(
+            {
+                "bin_index": index,
+                "percentile_range": [index * 100 // bin_count, (index + 1) * 100 // bin_count],
+                "lower_edge": float(edges[index]),
+                "upper_edge": float(edges[index + 1]),
+                "upper_edge_inclusive": index == bin_count - 1,
+                "token_comparison_count": count,
+                "switch_count": int(flags[selected].sum()),
+                "switch_fraction": float(flags[selected].mean()) if count else None,
+                "margin_mean": float(values[selected].mean()) if count else None,
+            }
+        )
+    if sum(item["token_comparison_count"] for item in bins) != values.size:
+        raise RuntimeError("margin bins did not partition every token comparison exactly once")
+    return {
+        "token_comparison_count": int(values.size),
+        "switch_count": int(flags.sum()),
+        "overall_switch_fraction": float(flags.mean()),
+        "quantile_edges": [float(value) for value in edges],
+        "bins": bins,
+    }
+
+
+def _weight_key(family: str, seed: int, sample: int, transform: str, module: str) -> str:
+    return f"{family}__seed-{seed}__sample-{sample}__{transform}__{_slug(module)}__weights"
+
+
+def _padding_key(family: str, sample: int, module: str) -> str:
+    return f"{family}__sample-{sample}__{_slug(module)}__mask-padding"
+
+
+def _target_cases(
+    arrays: Any,
+    family: str,
+    transforms: list[str],
+    target_module: str,
+    seeds: list[int],
+    samples: list[int],
+) -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]], dict[str, Any]]:
+    records = []
+    margin_groups: dict[str, list[np.ndarray]] = defaultdict(list)
+    switch_groups: dict[str, list[np.ndarray]] = defaultdict(list)
+    for transform in transforms:
+        for seed in seeds:
+            for sample in samples:
+                reference = np.asarray(arrays[_weight_key(family, seed, sample, "identity", target_module)])[0]
+                candidate = np.asarray(arrays[_weight_key(family, seed, sample, transform, target_module)])[0]
+                padding = np.asarray(arrays[_padding_key(family, sample, target_module)]).astype(bool)
+                if reference.shape != candidate.shape or reference.shape[1:] != padding.shape:
+                    raise ValueError(f"raw array geometry mismatch for {transform}, seed={seed}, sample={sample}")
+                valid = ~padding
+                difference = np.abs(reference.astype(np.float64) - candidate.astype(np.float64))
+                reference_ordered = np.sort(reference.astype(np.float64), axis=0)
+                margin = reference_ordered[-1] - reference_ordered[-2]
+                switched = np.argmax(reference, axis=0) != np.argmax(candidate, axis=0)
+                valid_margin = margin[valid]
+                valid_switched = switched[valid]
+                token_tv = 0.5 * difference.sum(axis=0)
+                record = {
+                    "transform": transform,
+                    "seed": seed,
+                    "sample_index": sample,
+                    "grid_shape_hw": [int(value) for value in valid.shape],
+                    "valid_token_count": int(valid.sum()),
+                    "padding_token_count": int(padding.sum()),
+                    "probability_mae": float(difference[:, valid].mean()),
+                    "mean_total_variation_distance": float(token_tv[valid].mean()),
+                    "dominant_switch_count": int(valid_switched.sum()),
+                    "dominant_switch_fraction": float(valid_switched.mean()),
+                    "reference_margin_mean": float(valid_margin.mean()),
+                    "switched_reference_margin_mean": (
+                        float(valid_margin[valid_switched].mean()) if valid_switched.any() else None
+                    ),
+                    "unchanged_reference_margin_mean": (
+                        float(valid_margin[~valid_switched].mean()) if (~valid_switched).any() else None
+                    ),
+                }
+                records.append(record)
+                margin_groups[transform].append(valid_margin)
+                switch_groups[transform].append(valid_switched)
+                margin_groups["overall"].append(valid_margin)
+                switch_groups["overall"].append(valid_switched)
+    worst = {
+        transform: max(
+            (item for item in records if item["transform"] == transform),
+            key=lambda item: (
+                item["dominant_switch_fraction"],
+                item["probability_mae"],
+                -item["seed"],
+                -item["sample_index"],
+            ),
+        )
+        for transform in transforms
+    }
+    deciles = {
+        key: margin_bin_summary(np.concatenate(margin_groups[key]), np.concatenate(switch_groups[key]))
+        for key in [*transforms, "overall"]
+    }
+    return records, worst, deciles
+
+
+def _font(size: int, *, mono: bool = False) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    candidates = ["C:/Windows/Fonts/consola.ttf"] if mono else ["C:/Windows/Fonts/segoeui.ttf"]
+    candidates += ["DejaVuSansMono.ttf"] if mono else ["DejaVuSans.ttf"]
+    for candidate in candidates:
+        try:
+            return ImageFont.truetype(candidate, size)
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+
+def _dominant_rgb(weights: np.ndarray, valid: np.ndarray) -> np.ndarray:
+    colors = np.asarray([[0, 229, 255], [151, 71, 255], [255, 196, 0], [44, 224, 123]], dtype=np.uint8)
+    result = colors[np.argmax(weights, axis=0) % len(colors)]
+    result[~valid] = (58, 68, 84)
+    return result
+
+
+def _margin_rank_rgb(weights: np.ndarray, valid: np.ndarray) -> np.ndarray:
+    ordered = np.sort(weights.astype(np.float64), axis=0)
+    margin = ordered[-1] - ordered[-2]
+    valid_values = margin[valid]
+    sorted_values = np.sort(valid_values)
+    ranks = np.zeros_like(margin, dtype=np.float64)
+    ranks[valid] = np.searchsorted(sorted_values, valid_values, side="right") / len(sorted_values)
+    rgb = np.zeros((*margin.shape, 3), dtype=np.uint8)
+    rgb[..., 0] = np.clip(20 + 235 * ranks, 0, 255).astype(np.uint8)
+    rgb[..., 1] = np.clip(30 + 185 * np.sqrt(ranks), 0, 255).astype(np.uint8)
+    rgb[..., 2] = np.clip(85 + 170 * (1.0 - ranks), 0, 255).astype(np.uint8)
+    rgb[~valid] = (58, 68, 84)
+    return rgb
+
+
+def _save_case_figure(
+    source_dir: Path,
+    output: Path,
+    case: dict[str, Any],
+    reference: np.ndarray,
+    candidate: np.ndarray,
+    valid: np.ndarray,
+) -> None:
+    width, height, panel = 1130, 950, 300
+    canvas = Image.new("RGB", (width, height), "#050c1b")
+    draw = ImageDraw.Draw(canvas)
+    title, body, small, mono = _font(29), _font(18), _font(15), _font(16, mono=True)
+    draw.rounded_rectangle((24, 22, width - 24, height - 22), radius=24, fill="#09172d", outline="#21678d", width=3)
+    label = case["transform"].replace("_", " ")
+    draw.text((58, 52), f"MODEL.16 ROUTER  /  WORST CASE: {label.upper()}", fill="#00e5ff", font=title)
+    draw.text(
+        (60, 96),
+        f"seed {case['seed']} · sample {case['sample_index']} · valid tokens {case['valid_token_count']}",
+        fill="#9bb8d6",
+        font=body,
+    )
+    image_paths = [
+        source_dir / "model-inputs" / f"sample-{case['sample_index']}--identity--128px.png",
+        source_dir / "model-inputs" / f"sample-{case['sample_index']}--{case['transform']}--128px.png",
+    ]
+    switched = (np.argmax(reference, axis=0) != np.argmax(candidate, axis=0)) & valid
+    switch_rgb = np.full((*valid.shape, 3), (9, 22, 44), dtype=np.uint8)
+    switch_rgb[valid] = (28, 64, 88)
+    switch_rgb[switched] = (255, 64, 151)
+    switch_rgb[~valid] = (58, 68, 84)
+    panels = [
+        (Image.open(image_paths[0]).convert("RGB"), "Identity model input"),
+        (Image.open(image_paths[1]).convert("RGB"), "Perturbed model input"),
+        (Image.fromarray(_dominant_rgb(reference, valid)), "Identity dominant expert"),
+        (Image.fromarray(_dominant_rgb(candidate, valid)), "Perturbed dominant expert"),
+        (Image.fromarray(switch_rgb), "Switch mask · magenta = switched"),
+        (Image.fromarray(_margin_rank_rgb(reference, valid)), "Identity margin rank · dark = near tie"),
+    ]
+    for index, (image, caption) in enumerate(panels):
+        column, row = index % 3, index // 3
+        x, y = 66 + column * 344, 150 + row * 365
+        resized = image.resize((panel, panel), Image.Resampling.NEAREST if index >= 2 else Image.Resampling.LANCZOS)
+        canvas.paste(resized, (x, y))
+        draw.text((x, y + panel + 8), caption, fill="#dcecff", font=small)
+    draw.rounded_rectangle((56, 875, 1074, 915), radius=8, fill="#10233c")
+    draw.text(
+        (74, 887),
+        f"switch {case['dominant_switch_fraction'] * 100:.2f}%  |  MAE {case['probability_mae']:.2e}  |  "
+        "padding is gray; maps are raw 16x16 tokens enlarged with nearest-neighbor",
+        fill="#63e6a7",
+        font=mono,
+    )
+    canvas.save(output)
+
+
+def _save_overview(
+    attribution: dict[str, Any], deciles: dict[str, Any], worst: dict[str, dict[str, Any]], output: Path
+) -> None:
+    width, height = 1800, 1160
+    canvas = Image.new("RGB", (width, height), "#050c1b")
+    draw = ImageDraw.Draw(canvas)
+    title, section, body, small, metric = _font(38), _font(24), _font(18), _font(15), _font(31, mono=True)
+    draw.rounded_rectangle((40, 34, width - 40, height - 34), radius=30, fill="#09172d", outline="#21678d", width=3)
+    draw.text((80, 68), "E3 P2  /  MODEL.16 ROUTER ATTRIBUTION", fill="#00e5ff", font=title)
+    draw.text((82, 120), "Integrity-bound post-hoc analysis of the formal CPU appearance run", fill="#9bb8d6", font=body)
+    shares = [
+        item["target_share_of_layer_mean_mae_sum"]
+        for item in attribution["by_transform"].values()
+    ]
+    overall_bins = deciles["overall"]["bins"]
+    first_rate = overall_bins[0]["switch_fraction"]
+    upper_rate = max(item["switch_fraction"] or 0.0 for item in overall_bins[3:])
+    cards = [
+        ("15 / 15", "rank #1 across transform × seed"),
+        (f"{min(shares) * 100:.1f}–{max(shares) * 100:.1f}%", "share of four-layer mean-MAE sum"),
+        (f"{first_rate * 100:.1f}%", "switch rate in lowest margin decile"),
+        (f"{upper_rate * 100:.1f}%", "maximum switch rate in deciles 4–10"),
+    ]
+    for index, (value, label) in enumerate(cards):
+        left = 82 + index * 410
+        draw.rounded_rectangle((left, 170, left + 375, 286), radius=18, fill="#0d223e", outline="#204d70", width=2)
+        draw.text((left + 20, 191), value, fill="#63e6a7", font=metric)
+        draw.text((left + 20, 247), label, fill="#a9c1da", font=small)
+
+    draw.text((82, 335), "Layer contribution by transformation", fill="#eaf4ff", font=section)
+    draw.text((82, 372), "Share of the sum of four layer-level mean original-pixel MAEs", fill="#829fbd", font=small)
+    transforms = list(attribution["by_transform"])
+    palette = ["#00cfe8", "#985eff", "#ffc400", "#2cda7b"]
+    for row, transform in enumerate(transforms):
+        y = 420 + row * 88
+        draw.text((82, y + 7), transform.replace("_", " "), fill="#b5cce2", font=body)
+        x = 300
+        for index, item in enumerate(attribution["by_transform"][transform]["ranking"]):
+            segment = int(650 * item["share_of_layer_mean_mae_sum"])
+            draw.rectangle((x, y, x + segment, y + 42), fill=palette[index % len(palette)])
+            x += segment
+        target = attribution["by_transform"][transform]
+        draw.text((970, y + 10), f"model.16 {target['target_share_of_layer_mean_mae_sum'] * 100:5.2f}%", fill="#ffffff", font=small)
+
+    draw.text((1130, 335), "Margin-decile switch concentration", fill="#eaf4ff", font=section)
+    draw.text((1130, 372), "All valid model.16 token-comparison exposures", fill="#829fbd", font=small)
+    max_rate = max(item["switch_fraction"] or 0.0 for item in overall_bins)
+    for index, item in enumerate(overall_bins):
+        y = 414 + index * 50
+        rate = item["switch_fraction"] or 0.0
+        draw.text((1130, y + 6), f"D{index + 1}", fill="#b5cce2", font=body)
+        draw.rounded_rectangle((1190, y, 1640, y + 30), radius=7, fill="#10233c")
+        if max_rate > 0.0:
+            draw.rounded_rectangle((1190, y, 1190 + int(450 * rate / max_rate), y + 30), radius=7, fill="#d65c8a")
+        draw.text((1650, y + 5), f"{rate * 100:5.2f}%", fill="#ffffff", font=small)
+
+    draw.text((82, 905), "Worst case selected independently per perturbation", fill="#eaf4ff", font=section)
+    for index, (transform, case) in enumerate(worst.items()):
+        left = 82 + index * 330
+        draw.rounded_rectangle((left, 952, left + 300, 1053), radius=14, fill="#0d223e", outline="#204d70", width=2)
+        draw.text((left + 15, 970), transform.replace("_", " "), fill="#d5b7ff", font=small)
+        draw.text(
+            (left + 15, 1001),
+            f"seed {case['seed']} / img {case['sample_index']} / switch {case['dominant_switch_fraction'] * 100:.2f}%",
+            fill="#dcecff",
+            font=small,
+        )
+    draw.text(
+        (82, 1091),
+        "Guardrail: diagnostic attribution within random initialization; contribution share is descriptive, not causal.",
+        fill="#ffcc66",
+        font=small,
+    )
+    canvas.save(output)
+
+
+def run(config_path: Path, *, run_id: str | None = None, update_latest: bool = True) -> Path:
+    config = _load_config(config_path, run_id)
+    project_source = _verify_project_source_state(bool(config.get("require_committed_source", False)))
+    source_dir = (PROJECT_ROOT / config["parent_run_dir"]).resolve()
+    try:
+        source_dir.relative_to(PROJECT_ROOT.resolve())
+    except ValueError as error:
+        raise ValueError("parent_run_dir must stay inside the project repository") from error
+    run_dir = PROJECT_ROOT / "artifacts" / "p2" / config["run_id"]
+    if run_dir.exists() and any(run_dir.iterdir()):
+        raise FileExistsError(f"refusing to overwrite non-empty evidence directory: {run_dir}")
+    run_dir.mkdir(parents=True, exist_ok=True)
+    logger = _logger(run_dir / "full.log")
+    (run_dir / "config.resolved.yaml").write_text(
+        yaml.safe_dump(config, sort_keys=False, allow_unicode=True), encoding="utf-8"
+    )
+    (run_dir / "command.txt").write_text("run_layer_drilldown.cmd\n", encoding="utf-8")
+    started = time.perf_counter()
+    parent_verification = verify_parent_evidence(source_dir, config["expected_parent_manifest_sha256"])
+    parent_summary = json.loads((source_dir / "summary.json").read_text(encoding="utf-8"))
+    if parent_summary.get("run_id") != config["expected_parent_run_id"] or parent_summary.get("status") != "PASS":
+        raise RuntimeError("parent summary run identity or PASS state mismatch")
+    comparisons = json.loads((source_dir / "appearance-stability-comparisons.json").read_text(encoding="utf-8"))
+    attribution = summarize_layer_attribution(
+        comparisons, config["family"], config["candidate_transformations"], config["target_module"]
+    )
+    with np.load(source_dir / "appearance-routing-raw.npz", allow_pickle=False) as arrays:
+        records, worst, deciles = _target_cases(
+            arrays,
+            config["family"],
+            config["candidate_transformations"],
+            config["target_module"],
+            [int(value) for value in parent_summary["seeds"]],
+            list(range(int(parent_summary["sample_count"]))),
+        )
+        case_dir = run_dir / "cases"
+        case_dir.mkdir(parents=True, exist_ok=True)
+        for transform, case in worst.items():
+            reference = np.asarray(
+                arrays[
+                    _weight_key(
+                        config["family"], case["seed"], case["sample_index"], "identity", config["target_module"]
+                    )
+                ]
+            )[0]
+            candidate = np.asarray(
+                arrays[
+                    _weight_key(
+                        config["family"],
+                        case["seed"],
+                        case["sample_index"],
+                        transform,
+                        config["target_module"],
+                    )
+                ]
+            )[0]
+            padding = np.asarray(
+                arrays[_padding_key(config["family"], case["sample_index"], config["target_module"])]
+            ).astype(bool)
+            case["figure"] = f"cases/{transform}.png"
+            _save_case_figure(source_dir, run_dir / case["figure"], case, reference, candidate, ~padding)
+
+    write_json(run_dir / "parent-evidence-verification.json", parent_verification)
+    write_json(run_dir / "layer-attribution.json", attribution)
+    write_json(
+        run_dir / "margin-deciles.json",
+        {
+            "method": {
+                "scope": "target module raw token grid with letterbox padding excluded",
+                "unit": "one valid token-comparison exposure; identity margin repeats once per candidate transform",
+                "binning": "within-scope empirical quantile edges; half-open except final inclusive bin",
+            },
+            "by_transform_and_overall": deciles,
+        },
+    )
+    write_json(
+        run_dir / "target-layer-cases.json",
+        {
+            "method": "raw target-layer tokens; equal-weight case summaries; padding excluded",
+            "case_count": len(records),
+            "records": records,
+            "worst_case_selection": "maximum switch fraction, then MAE, then lowest seed/sample",
+            "worst_by_transform": worst,
+        },
+    )
+    _save_overview(attribution, deciles, worst, run_dir / "layer-attribution-overview.png")
+    shares = [
+        item["target_share_of_layer_mean_mae_sum"] for item in attribution["by_transform"].values()
+    ]
+    overall_bins = deciles["overall"]["bins"]
+    summary = {
+        "status": "PASS",
+        "scope": "post-hoc MoA layer attribution and margin-conditioned switch localization",
+        "run_id": config["run_id"],
+        "tool_source": project_source,
+        "parent_run_id": parent_summary["run_id"],
+        "parent_evidence_verification": parent_verification,
+        "target_module": config["target_module"],
+        "candidate_transformations": config["candidate_transformations"],
+        "layer_attribution_comparison_count": attribution["comparison_count"],
+        "target_case_count": len(records),
+        "valid_token_comparison_exposure_count": deciles["overall"]["token_comparison_count"],
+        "target_rank_one_transform_seed_count": attribution["target_rank_one_transform_seed_count"],
+        "transform_seed_group_count": attribution["transform_seed_group_count"],
+        "target_share_of_layer_mean_mae_sum_min": min(shares),
+        "target_share_of_layer_mean_mae_sum_max": max(shares),
+        "lowest_margin_decile_switch_fraction": overall_bins[0]["switch_fraction"],
+        "deciles_four_through_ten_max_switch_fraction": max(
+            item["switch_fraction"] or 0.0 for item in overall_bins[3:]
+        ),
+        "interpretation_boundary": "random initialization; descriptive concentration, not causal attribution or learned robustness",
+        "environment": {"python": platform.python_version(), "platform": platform.platform()},
+        "duration_seconds_observation_only": time.perf_counter() - started,
+    }
+    write_json(run_dir / "summary.json", summary)
+    logger.info(
+        "status=PASS comparisons=%d target_cases=%d token_exposures=%d rank_one=%d/%d",
+        attribution["comparison_count"],
+        len(records),
+        deciles["overall"]["token_comparison_count"],
+        attribution["target_rank_one_transform_seed_count"],
+        attribution["transform_seed_group_count"],
+    )
+    for handler in logger.handlers:
+        handler.flush()
+    write_manifest(run_dir)
+    if update_latest:
+        latest = PROJECT_ROOT / "artifacts" / "p2" / "ATTRIBUTION_LATEST.txt"
+        latest.parent.mkdir(parents=True, exist_ok=True)
+        latest.write_text(config["run_id"] + "\n", encoding="utf-8")
+    return run_dir

--- a/tools/e3_routing/src/e3_p2/output_coupling_runner.py
+++ b/tools/e3_routing/src/e3_p2/output_coupling_runner.py
@@ -1,0 +1,313 @@
+"""Run and summarize the predeclared router-to-detector output coupling study."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import yaml
+from PIL import Image, ImageDraw, ImageFont
+
+from .image_driver_analysis import bootstrap_spearman, leave_one_out_spearman, spearman
+from .io_utils import write_json, write_manifest
+from .runner import PROJECT_ROOT
+from .scale_runner import run as run_scale
+
+ROUTE_FIELDS = {
+    "probability_mae": "target_probability_mae_mean_across_seeds",
+    "dominant_switch_fraction": "target_dominant_switch_fraction_mean_across_seeds",
+}
+DETECTOR_TENSORS = (
+    "one2one_scores",
+    "one2one_boxes",
+    "one2many_scores",
+    "one2many_boxes",
+    "decoded_top300",
+)
+
+
+def build_output_coupling_records(
+    target_cases: list[dict[str, Any]],
+    detector_comparisons: list[dict[str, Any]],
+    transforms: list[str],
+    expected_images: int,
+    expected_seeds: list[int],
+) -> list[dict[str, Any]]:
+    """Join target-router and detector changes at image x transform after equal seed averaging."""
+
+    route_grouped: dict[tuple[str, int], list[dict[str, Any]]] = defaultdict(list)
+    detector_grouped: dict[tuple[str, int], list[dict[str, Any]]] = defaultdict(list)
+    for item in target_cases:
+        route_grouped[(str(item["transform"]), int(item["sample_index"]))].append(item)
+    for item in detector_comparisons:
+        detector_grouped[(str(item["transform"]), int(item["sample_index"]))].append(item)
+
+    expected_seed_set = set(expected_seeds)
+    output: list[dict[str, Any]] = []
+    for transform in transforms:
+        for sample_index in range(expected_images):
+            key = (transform, sample_index)
+            route_items = route_grouped.get(key, [])
+            detector_items = detector_grouped.get(key, [])
+            for label, items in (("route", route_items), ("detector", detector_items)):
+                seeds = [int(item["seed"]) for item in items]
+                if (
+                    len(items) != len(expected_seeds)
+                    or set(seeds) != expected_seed_set
+                    or len(seeds) != len(set(seeds))
+                ):
+                    raise ValueError(f"incomplete or duplicate {label} seed matrix: {key}, seeds={seeds}")
+
+            tensor_values: dict[str, float] = {}
+            for tensor in DETECTOR_TENSORS:
+                values = []
+                for item in detector_items:
+                    metrics = item.get("metrics", {})
+                    if metrics.get("primary_tensor") != "one2one_scores":
+                        raise ValueError(f"unexpected detector primary tensor: {key}")
+                    tensors = metrics.get("tensors", {})
+                    if set(tensors) != set(DETECTOR_TENSORS):
+                        raise ValueError(f"detector tensor contract changed: {key}")
+                    value = float(tensors[tensor]["mean_absolute_change"])
+                    if not np.isfinite(value):
+                        raise ValueError(f"non-finite detector change: {key}, tensor={tensor}")
+                    values.append(value)
+                tensor_values[tensor] = float(np.mean(values))
+
+            output.append(
+                {
+                    "transform": transform,
+                    "sample_index": sample_index,
+                    "seed_count": len(expected_seeds),
+                    "target_probability_mae_mean_across_seeds": float(
+                        np.mean([float(item["probability_mae"]) for item in route_items])
+                    ),
+                    "target_dominant_switch_fraction_mean_across_seeds": float(
+                        np.mean([float(item["dominant_switch_fraction"]) for item in route_items])
+                    ),
+                    "detector_mean_absolute_change_mean_across_seeds": tensor_values,
+                }
+            )
+    if len(output) != len(transforms) * expected_images:
+        raise RuntimeError("output-coupling record matrix size changed")
+    return output
+
+
+def analyze_output_coupling(
+    records: list[dict[str, Any]], transforms: list[str], draws: int, seed: int
+) -> dict[str, Any]:
+    """Compute within-transform image-level associations without imposing a sign gate."""
+
+    by_transform: dict[str, Any] = {}
+    for transform_index, transform in enumerate(transforms):
+        selected = [item for item in records if item["transform"] == transform]
+        tensor_results: dict[str, Any] = {}
+        for tensor_index, tensor in enumerate(DETECTOR_TENSORS):
+            y = np.asarray(
+                [item["detector_mean_absolute_change_mean_across_seeds"][tensor] for item in selected],
+                dtype=np.float64,
+            )
+            route_results: dict[str, Any] = {}
+            for route_index, (endpoint, field) in enumerate(ROUTE_FIELDS.items()):
+                x = np.asarray([item[field] for item in selected], dtype=np.float64)
+                analysis_seed = seed + transform_index * 1000 + tensor_index * 10 + route_index
+                observed = spearman(x, y)
+                result = {
+                    "x_field": field,
+                    "y_field": f"detector.{tensor}.mean_absolute_change",
+                    "x_unique_value_count": int(np.unique(x).size),
+                    "y_unique_value_count": int(np.unique(y).size),
+                }
+                if observed is None:
+                    result.update(
+                        {
+                            "status": "UNDEFINED_CONSTANT_VECTOR",
+                            "observed_spearman_rho": None,
+                            "reason": "Spearman is undefined because at least one ranked vector is constant",
+                            "bootstrap": None,
+                            "leave_one_image_out": None,
+                        }
+                    )
+                else:
+                    result.update(
+                        {
+                            "status": "DEFINED",
+                            "observed_spearman_rho": observed,
+                            "bootstrap": bootstrap_spearman(x, y, draws, analysis_seed),
+                            "leave_one_image_out": leave_one_out_spearman(x, y),
+                        }
+                    )
+                route_results[endpoint] = result
+            tensor_results[tensor] = {"route_endpoints": route_results}
+        by_transform[transform] = {"image_count": len(selected), "detector_tensors": tensor_results}
+    return {
+        "method": {
+            "association": "tie-aware Spearman rank correlation",
+            "primary_unit": "image after equal averaging across three random-initialization seeds",
+            "stratification": "each transformation analyzed separately; cross-transform pooling forbidden",
+            "primary_detector_endpoint": "one2one_scores mean absolute change on fixed grid/channel order",
+            "secondary_detector_endpoints": [
+                "one2one_boxes",
+                "one2many_scores",
+                "one2many_boxes",
+                "decoded_top300 (row order not anchor-aligned)",
+            ],
+            "bootstrap": f"{draws:,} image resamples with replacement; descriptive for fixed subset",
+            "pass_gate": "matrix completeness, finite metrics and reproducibility only; sign/magnitude are observations",
+            "causal_status": "association only; no accuracy or causal claim",
+        },
+        "by_transform": by_transform,
+    }
+
+
+def _font(size: int, *, mono: bool = False) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    candidate = "C:/Windows/Fonts/consola.ttf" if mono else "C:/Windows/Fonts/segoeui.ttf"
+    try:
+        return ImageFont.truetype(candidate, size)
+    except OSError:
+        return ImageFont.load_default()
+
+
+def _save_overview(records: list[dict[str, Any]], analysis: dict[str, Any], output: Path) -> None:
+    width, height = 1800, 1080
+    canvas = Image.new("RGB", (width, height), "#071426")
+    draw = ImageDraw.Draw(canvas)
+    title, subtitle, section = _font(47), _font(23), _font(27)
+    body, small = _font(19), _font(16, mono=True)
+    draw.text((72, 52), "DO ROUTER CHANGES TRACK DETECTOR-SCORE CHANGES?", fill="#f2f7ff", font=title)
+    draw.text(
+        (74, 116),
+        "32 image units · 3 seeds averaged equally · within-transform Spearman · association only",
+        fill="#8eabc8",
+        font=subtitle,
+    )
+    draw.rounded_rectangle((72, 165, 1728, 258), radius=18, fill="#0d2540", outline="#1d5879", width=2)
+    draw.text((98, 185), "PRIMARY ENDPOINT", fill="#55e2ff", font=section)
+    draw.text(
+        (380, 190),
+        "One-to-one class-score tensor MAE: fixed grid and channel order, before Top-300 row reordering.",
+        fill="#dcecff",
+        font=body,
+    )
+
+    colors = {"probability_mae": "#18d6c4", "dominant_switch_fraction": "#bf78ff"}
+    labels = {"probability_mae": "ROUTER PROBABILITY MAE", "dominant_switch_fraction": "EXPERT SWITCH RATE"}
+    transforms = list(analysis["by_transform"])
+    for column, transform in enumerate(transforms):
+        left, top = 72 + column * 552, 308
+        draw.text((left + 4, top - 37), transform.replace("_", " ").upper(), fill="#ffcf66", font=section)
+        draw.rounded_rectangle((left, top, left + 520, top + 655), radius=18, fill="#0b2038", outline="#204d70", width=2)
+        selected = [item for item in records if item["transform"] == transform]
+        y = np.asarray(
+            [item["detector_mean_absolute_change_mean_across_seeds"]["one2one_scores"] for item in selected],
+            dtype=np.float64,
+        )
+        for row, (endpoint, field) in enumerate(ROUTE_FIELDS.items()):
+            x = np.asarray([item[field] for item in selected], dtype=np.float64)
+            result = analysis["by_transform"][transform]["detector_tensors"]["one2one_scores"][
+                "route_endpoints"
+            ][endpoint]
+            panel_top = top + 38 + row * 292
+            draw.text((left + 24, panel_top), labels[endpoint], fill="#dcecff", font=body)
+            if result["status"] == "DEFINED":
+                bootstrap = result["bootstrap"]
+                interval = bootstrap["percentile_95_interval"]
+                statistic = (
+                    f"rho {bootstrap['observed_spearman_rho']:+.3f} | "
+                    f"95% [{interval[0]:+.3f}, {interval[1]:+.3f}]"
+                )
+            else:
+                statistic = f"UNDEFINED | detector unique values = {result['y_unique_value_count']}"
+            draw.text((left + 24, panel_top + 34), statistic, fill=colors[endpoint], font=small)
+            plot_left, plot_top = left + 58, panel_top + 83
+            plot_right, plot_bottom = left + 490, panel_top + 238
+            draw.line((plot_left, plot_bottom, plot_right, plot_bottom), fill="#496783", width=2)
+            draw.line((plot_left, plot_top, plot_left, plot_bottom), fill="#496783", width=2)
+            x_span, y_span = float(np.ptp(x)) or 1.0, float(np.ptp(y)) or 1.0
+            for item_x, item_y in zip(x, y):
+                px = plot_left + 8 + int((plot_right - plot_left - 16) * (item_x - x.min()) / x_span)
+                py = plot_bottom - 8 - int((plot_bottom - plot_top - 16) * (item_y - y.min()) / y_span)
+                draw.ellipse((px - 5, py - 5, px + 5, py + 5), fill=colors[endpoint], outline="#ffffff")
+            draw.text((plot_left, plot_bottom + 8), f"router {x.min():.2e} → {x.max():.2e}", fill="#7f9fbd", font=small)
+            draw.text((plot_left + 235, plot_bottom + 8), f"score {y.min():.2e} → {y.max():.2e}", fill="#7f9fbd", font=small)
+
+    draw.rounded_rectangle((72, 1000, 1728, 1046), radius=12, fill="#2b2030")
+    draw.text(
+        (96, 1012),
+        "GUARDRAIL  Random initialization + fixed coco128 subset. Correlation does not establish accuracy or causality.",
+        fill="#ffd06b",
+        font=small,
+    )
+    canvas.save(output)
+
+
+def run(config_path: Path, *, run_id: str | None = None, update_latest: bool = True) -> Path:
+    run_dir = run_scale(config_path, run_id=run_id, update_latest=False)
+    config = yaml.safe_load((run_dir / "config.resolved.yaml").read_text(encoding="utf-8"))
+    summary = json.loads((run_dir / "summary.json").read_text(encoding="utf-8"))
+    target_cases = json.loads((run_dir / "target-layer-cases.json").read_text(encoding="utf-8"))
+    detector_comparisons = json.loads(
+        (run_dir / "detector-output-comparisons.json").read_text(encoding="utf-8")
+    )
+    transforms = [str(item["name"]) for item in config["transformations"] if item["name"] != "identity"]
+    records = build_output_coupling_records(
+        target_cases,
+        detector_comparisons,
+        transforms,
+        int(config["selected_image_count"]),
+        [int(value) for value in config["seeds"]],
+    )
+    analysis = analyze_output_coupling(
+        records, transforms, int(config["bootstrap_draws"]), int(config["bootstrap_seed"])
+    )
+    write_json(run_dir / "output-coupling-records.json", {"record_count": len(records), "records": records})
+    write_json(run_dir / "output-coupling-associations.json", analysis)
+    _save_overview(records, analysis, run_dir / "output-coupling-overview.png")
+    (run_dir / "command.txt").write_text("run_output_coupling.cmd\n", encoding="utf-8")
+
+    primary = {
+        transform: {
+            endpoint: values["observed_spearman_rho"]
+            for endpoint, values in result["detector_tensors"]["one2one_scores"]["route_endpoints"].items()
+        }
+        for transform, result in analysis["by_transform"].items()
+    }
+    association_results = [
+        endpoint
+        for transform in analysis["by_transform"].values()
+        for tensor in transform["detector_tensors"].values()
+        for endpoint in tensor["route_endpoints"].values()
+    ]
+    summary.update(
+        {
+            "scope": "CPU-only MoA target-router to detector-output image-level coupling audit",
+            "output_coupling_record_count": len(records),
+            "output_coupling_association_count": len(transforms) * len(DETECTOR_TENSORS) * len(ROUTE_FIELDS),
+            "defined_association_count": sum(item["status"] == "DEFINED" for item in association_results),
+            "undefined_constant_association_count": sum(
+                item["status"] == "UNDEFINED_CONSTANT_VECTOR" for item in association_results
+            ),
+            "primary_detector_endpoint": "one2one_scores mean absolute change",
+            "primary_observed_spearman_rho": primary,
+            "pass_gate": "complete finite evidence matrix and reproducibility; association sign/magnitude not gated",
+            "interpretation_boundary": "within-transform association on a deterministic coco128 subset under random initialization; no causal, learned-accuracy or population claim",
+        }
+    )
+    write_json(run_dir / "summary.json", summary)
+    evidence_bytes = sum(
+        path.stat().st_size
+        for path in run_dir.rglob("*")
+        if path.is_file() and path.name != "manifest.sha256.json"
+    )
+    if evidence_bytes > int(config["max_evidence_bytes"]):
+        raise RuntimeError(f"final evidence budget exceeded: {evidence_bytes} > {config['max_evidence_bytes']}")
+    summary["evidence_bytes_before_manifest"] = evidence_bytes
+    write_json(run_dir / "summary.json", summary)
+    write_manifest(run_dir)
+    if update_latest:
+        latest = PROJECT_ROOT / "artifacts" / "p2" / "OUTPUT_COUPLING_LATEST.txt"
+        latest.write_text(config["run_id"] + "\n", encoding="utf-8")
+    return run_dir

--- a/tools/e3_routing/src/e3_p2/plotting.py
+++ b/tools/e3_routing/src/e3_p2/plotting.py
@@ -1,0 +1,150 @@
+"""Dependency-light routing overlays and categorical expert maps."""
+
+from __future__ import annotations
+
+import numpy as np
+from PIL import Image, ImageDraw, ImageFont
+
+from .geometry import LetterboxMeta, restore_heatmap
+from .regions import YoloBox, box_xyxy_original
+
+COLORS = np.asarray(
+    [
+        [0, 229, 255],
+        [151, 71, 255],
+        [255, 196, 0],
+        [44, 224, 123],
+        [255, 82, 119],
+        [79, 121, 255],
+    ],
+    dtype=np.float32,
+)
+
+
+def _probability_color(field: np.ndarray, color: np.ndarray) -> np.ndarray:
+    clipped = np.clip(field, 0.0, 1.0)[..., None]
+    dark = np.asarray([7, 14, 32], dtype=np.float32)
+    return dark * (1.0 - clipped) + color * clipped
+
+
+def save_probability_overlay(
+    original: Image.Image,
+    feature_probability: np.ndarray,
+    meta: LetterboxMeta,
+    destination: str,
+    *,
+    expert_index: int,
+    alpha: float,
+) -> dict[str, float]:
+    """Blend a raw `[0,1]` expert probability with the original image using fixed scaling."""
+
+    restored = restore_heatmap(feature_probability, meta)
+    base = np.asarray(original.convert("RGB"), dtype=np.float32)
+    heat = _probability_color(restored, COLORS[expert_index % len(COLORS)])
+    strength = np.clip(restored, 0.0, 1.0)[..., None] * float(alpha)
+    blended = np.clip(base * (1.0 - strength) + heat * strength, 0, 255).astype(np.uint8)
+    Image.fromarray(blended).save(destination)
+    return {
+        "feature_min": float(np.min(feature_probability)),
+        "feature_max": float(np.max(feature_probability)),
+        "feature_mean": float(np.mean(feature_probability)),
+        "restored_min": float(restored.min()),
+        "restored_max": float(restored.max()),
+    }
+
+
+def save_metric_overlay(
+    original: Image.Image,
+    feature_field: np.ndarray,
+    meta: LetterboxMeta,
+    destination: str,
+    *,
+    color: tuple[int, int, int],
+    alpha: float,
+) -> dict[str, float]:
+    """Blend a bounded routing diagnostic while preserving its absolute ``[0,1]`` scale."""
+
+    values = np.asarray(feature_field, dtype=np.float32)
+    if values.ndim != 2 or not np.isfinite(values).all():
+        raise ValueError("metric field must be a finite 2D array")
+    if float(values.min()) < 0.0 or float(values.max()) > 1.0:
+        raise ValueError("metric field must stay within [0,1]")
+    restored = restore_heatmap(values, meta)
+    base = np.asarray(original.convert("RGB"), dtype=np.float32)
+    heat = _probability_color(restored, np.asarray(color, dtype=np.float32))
+    strength = restored[..., None] * float(alpha)
+    blended = np.clip(base * (1.0 - strength) + heat * strength, 0, 255).astype(np.uint8)
+    Image.fromarray(blended).save(destination)
+    return {
+        "feature_min": float(values.min()),
+        "feature_max": float(values.max()),
+        "feature_mean": float(values.mean()),
+        "restored_min": float(restored.min()),
+        "restored_max": float(restored.max()),
+    }
+
+
+def save_dominant_overlay(
+    original: Image.Image,
+    weights: np.ndarray,
+    meta: LetterboxMeta,
+    destination: str,
+    *,
+    alpha: float,
+) -> list[int]:
+    """Show the argmax expert at each token without inventing intermediate values."""
+
+    dominant = np.argmax(weights, axis=0).astype(np.int32)
+    restored_planes = np.stack(
+        [restore_heatmap((dominant == expert).astype(np.float32), meta) for expert in range(weights.shape[0])], axis=0
+    )
+    restored_dominant = np.argmax(restored_planes, axis=0)
+    palette = COLORS[restored_dominant % len(COLORS)]
+    base = np.asarray(original.convert("RGB"), dtype=np.float32)
+    blended = np.clip(base * (1.0 - alpha) + palette * alpha, 0, 255).astype(np.uint8)
+    Image.fromarray(blended).save(destination)
+    return [int(np.sum(dominant == expert)) for expert in range(weights.shape[0])]
+
+
+def save_overview(cards: list[dict[str, str]], destination: str) -> None:
+    """Create a compact evidence contact sheet from representative overlays."""
+
+    if not cards:
+        raise ValueError("at least one card is required")
+    thumb_width, thumb_height, caption_height = 360, 240, 54
+    columns = 2
+    rows = (len(cards) + columns - 1) // columns
+    sheet = Image.new("RGB", (columns * thumb_width, rows * (thumb_height + caption_height)), (7, 14, 32))
+    draw = ImageDraw.Draw(sheet)
+    font = ImageFont.load_default()
+    for index, card in enumerate(cards):
+        image = Image.open(card["path"]).convert("RGB")
+        image.thumbnail((thumb_width, thumb_height), Image.Resampling.LANCZOS)
+        x = (index % columns) * thumb_width
+        y = (index // columns) * (thumb_height + caption_height)
+        sheet.paste(image, (x + (thumb_width - image.width) // 2, y))
+        draw.text((x + 12, y + thumb_height + 8), card["caption"], fill=(230, 238, 255), font=font)
+    sheet.save(destination)
+
+
+def save_ground_truth_overlay(
+    original: Image.Image, boxes: list[YoloBox], meta: LetterboxMeta, destination: str
+) -> None:
+    """Draw archived dataset boxes on an original-size copy for demo inspection."""
+
+    rendered = original.convert("RGB").copy()
+    draw = ImageDraw.Draw(rendered)
+    line_width = max(2, round(min(rendered.size) / 220))
+    font = ImageFont.load_default()
+    for index, box in enumerate(boxes):
+        coordinates = box_xyxy_original(box, meta)
+        color = tuple(int(value) for value in COLORS[index % len(COLORS)])
+        draw.rectangle(coordinates, outline=color, width=line_width)
+        label = f"GT {box.class_id}"
+        x1, y1, _, _ = coordinates
+        text_box = draw.textbbox((x1, y1), label, font=font)
+        top = max(0.0, y1 - (text_box[3] - text_box[1]) - 4)
+        right = x1 + (text_box[2] - text_box[0]) + 6
+        draw.rectangle((x1, top, right, y1), fill=color)
+        draw.text((x1 + 3, top + 1), label, fill=(7, 14, 32), font=font)
+    rendered.save(destination)

--- a/tools/e3_routing/src/e3_p2/regions.py
+++ b/tools/e3_routing/src/e3_p2/regions.py
@@ -1,0 +1,318 @@
+"""Ground-truth region masks and region-conditioned routing diagnostics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from .capture import routing_metric_fields
+from .geometry import LetterboxMeta, validate_probability_grid
+
+
+@dataclass(frozen=True)
+class YoloBox:
+    class_id: int
+    center_x: float
+    center_y: float
+    width: float
+    height: float
+
+    def to_dict(self) -> dict[str, int | float]:
+        return {
+            "class_id": self.class_id,
+            "center_x": self.center_x,
+            "center_y": self.center_y,
+            "width": self.width,
+            "height": self.height,
+        }
+
+
+def label_path_for_image(image_path: Path) -> Path:
+    """Resolve the conventional YOLO ``images/...`` to ``labels/...`` path."""
+
+    resolved = image_path.resolve()
+    parts = list(resolved.parts)
+    image_positions = [index for index, part in enumerate(parts) if part.lower() == "images"]
+    if not image_positions:
+        raise ValueError(f"image path has no images directory component: {resolved}")
+    parts[image_positions[-1]] = "labels"
+    return Path(*parts).with_suffix(".txt")
+
+
+def parse_yolo_labels(path: Path) -> list[YoloBox]:
+    """Parse strict normalized detection labels without silently clipping invalid data."""
+
+    if not path.is_file():
+        raise FileNotFoundError(f"YOLO label file is missing: {path}")
+    boxes: list[YoloBox] = []
+    for line_number, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw.strip()
+        if not line:
+            continue
+        fields = line.split()
+        if len(fields) != 5:
+            raise ValueError(f"{path}:{line_number}: expected 5 fields, got {len(fields)}")
+        try:
+            class_value, center_x, center_y, width, height = (float(value) for value in fields)
+        except ValueError as error:
+            raise ValueError(f"{path}:{line_number}: non-numeric label field") from error
+        class_id = int(class_value)
+        if class_value != class_id or class_id < 0:
+            raise ValueError(f"{path}:{line_number}: class id must be a non-negative integer")
+        if not all(np.isfinite(value) for value in (center_x, center_y, width, height)):
+            raise ValueError(f"{path}:{line_number}: label values must be finite")
+        if not (0.0 <= center_x <= 1.0 and 0.0 <= center_y <= 1.0):
+            raise ValueError(f"{path}:{line_number}: box center must be within [0,1]")
+        if not (0.0 < width <= 1.0 and 0.0 < height <= 1.0):
+            raise ValueError(f"{path}:{line_number}: box size must be within (0,1]")
+        boxes.append(YoloBox(class_id, center_x, center_y, width, height))
+    return boxes
+
+
+def box_xyxy_original(box: YoloBox, meta: LetterboxMeta) -> tuple[float, float, float, float]:
+    """Return a normalized YOLO box as clipped original-image pixel coordinates."""
+
+    x1 = (box.center_x - box.width / 2.0) * meta.original_width
+    y1 = (box.center_y - box.height / 2.0) * meta.original_height
+    x2 = (box.center_x + box.width / 2.0) * meta.original_width
+    y2 = (box.center_y + box.height / 2.0) * meta.original_height
+    return (
+        max(0.0, min(float(meta.original_width), x1)),
+        max(0.0, min(float(meta.original_height), y1)),
+        max(0.0, min(float(meta.original_width), x2)),
+        max(0.0, min(float(meta.original_height), y2)),
+    )
+
+
+def token_region_masks(
+    boxes: list[YoloBox], meta: LetterboxMeta, height: int, width: int
+) -> dict[str, np.ndarray]:
+    """Classify feature-cell centers as foreground, background, or padding.
+
+    Foreground means the center of a valid (non-padding) token falls inside at
+    least one ground-truth box. Background includes only valid image tokens;
+    letterbox padding is intentionally excluded from both groups.
+    """
+
+    if height <= 0 or width <= 0:
+        raise ValueError("feature-grid dimensions must be positive")
+    x = (np.arange(width, dtype=np.float64) + 0.5) * meta.input_size / width
+    y = (np.arange(height, dtype=np.float64) + 0.5) * meta.input_size / height
+    xx, yy = np.meshgrid(x, y)
+    image_right = meta.pad_left + meta.resized_width
+    image_bottom = meta.pad_top + meta.resized_height
+    valid = (
+        (xx >= meta.pad_left)
+        & (xx < image_right)
+        & (yy >= meta.pad_top)
+        & (yy < image_bottom)
+    )
+    foreground = np.zeros((height, width), dtype=bool)
+    scale_x = meta.resized_width / meta.original_width
+    scale_y = meta.resized_height / meta.original_height
+    for box in boxes:
+        x1, y1, x2, y2 = box_xyxy_original(box, meta)
+        x1 = meta.pad_left + x1 * scale_x
+        x2 = meta.pad_left + x2 * scale_x
+        y1 = meta.pad_top + y1 * scale_y
+        y2 = meta.pad_top + y2 * scale_y
+        foreground |= valid & (xx >= x1) & (xx <= x2) & (yy >= y1) & (yy <= y2)
+    background = valid & ~foreground
+    padding = ~valid
+    if np.any(foreground & background) or np.any((foreground | background) & padding):
+        raise RuntimeError("region masks overlap")
+    if not np.array_equal(foreground | background | padding, np.ones_like(valid)):
+        raise RuntimeError("region masks do not partition the feature grid")
+    return {"foreground": foreground, "background": background, "padding": padding}
+
+
+def _masked_summary(weights: np.ndarray, mask: np.ndarray) -> dict[str, Any]:
+    token_count = int(mask.sum())
+    expert_count = int(weights.shape[0])
+    if token_count == 0:
+        return {
+            "token_count": 0,
+            "mean_expert_probability": None,
+            "dominant_token_count": [0] * expert_count,
+            "dominant_token_fraction": None,
+            "normalized_entropy_mean": None,
+            "top1_margin_mean": None,
+        }
+    fields = routing_metric_fields(weights)
+    dominant = np.argmax(weights, axis=0)
+    counts = [int(np.sum((dominant == expert) & mask)) for expert in range(expert_count)]
+    return {
+        "token_count": token_count,
+        "mean_expert_probability": [float(weights[expert][mask].mean()) for expert in range(expert_count)],
+        "dominant_token_count": counts,
+        "dominant_token_fraction": [count / token_count for count in counts],
+        "normalized_entropy_mean": float(fields["normalized_entropy"][mask].mean()),
+        "top1_margin_mean": float(fields["top1_margin"][mask].mean()),
+    }
+
+
+def region_routing_diagnostics(weights: np.ndarray, masks: dict[str, np.ndarray]) -> dict[str, Any]:
+    """Compare routing on labelled-object tokens with valid background tokens."""
+
+    values = np.asarray(weights, dtype=np.float32)
+    if values.ndim != 3:
+        raise ValueError(f"expected [E,H,W], got shape={list(values.shape)}")
+    validate_probability_grid(values[None, ...])
+    expected_shape = values.shape[1:]
+    for name in ("foreground", "background", "padding"):
+        if name not in masks or masks[name].shape != expected_shape or masks[name].dtype != np.bool_:
+            raise ValueError(f"{name} mask must be boolean with shape={list(expected_shape)}")
+    foreground = _masked_summary(values, masks["foreground"])
+    background = _masked_summary(values, masks["background"])
+    valid_count = foreground["token_count"] + background["token_count"]
+    status = "SUPPORTED" if foreground["token_count"] and background["token_count"] else "INSUFFICIENT_TOKENS"
+    contrast: dict[str, Any] | None = None
+    if status == "SUPPORTED":
+        fg_prob = np.asarray(foreground["mean_expert_probability"], dtype=np.float64)
+        bg_prob = np.asarray(background["mean_expert_probability"], dtype=np.float64)
+        mean_prob = 0.5 * (fg_prob + bg_prob)
+
+        def kl(left: np.ndarray, right: np.ndarray) -> float:
+            keep = left > 0
+            return float(np.sum(left[keep] * np.log(left[keep] / right[keep])))
+
+        contrast = {
+            "foreground_minus_background_expert_probability": [float(item) for item in fg_prob - bg_prob],
+            "total_variation_distance": float(0.5 * np.abs(fg_prob - bg_prob).sum()),
+            "jensen_shannon_divergence_nats": float(0.5 * kl(fg_prob, mean_prob) + 0.5 * kl(bg_prob, mean_prob)),
+            "foreground_minus_background_entropy": float(
+                foreground["normalized_entropy_mean"] - background["normalized_entropy_mean"]
+            ),
+            "foreground_minus_background_top1_margin": float(
+                foreground["top1_margin_mean"] - background["top1_margin_mean"]
+            ),
+        }
+    return {
+        "status": status,
+        "assignment_rule": "valid token center inside any ground-truth box",
+        "padding_policy": "excluded from both foreground and background",
+        "foreground": foreground,
+        "background": background,
+        "padding_token_count": int(masks["padding"].sum()),
+        "valid_token_count": valid_count,
+        "contrast": contrast,
+    }
+
+
+def aggregate_region_diagnostics(captures: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build token-weighted region summaries by family and module."""
+
+    def summarize(items: list[dict[str, Any]]) -> dict[str, Any]:
+        supported = [item for item in items if item["region_diagnostics"]["status"] == "SUPPORTED"]
+        expert_count = len(items[0]["region_diagnostics"]["foreground"]["dominant_token_count"])
+
+        def region(name: str) -> dict[str, Any]:
+            entries = [item["region_diagnostics"][name] for item in items]
+            count = sum(entry["token_count"] for entry in entries)
+            if not count:
+                return {"token_count": 0, "mean_expert_probability": None, "dominant_token_count": [0] * expert_count,
+                        "dominant_token_fraction": None, "normalized_entropy_mean": None, "top1_margin_mean": None}
+            probabilities = [
+                sum(entry["mean_expert_probability"][expert] * entry["token_count"] for entry in entries if entry["token_count"])
+                / count
+                for expert in range(expert_count)
+            ]
+            dominant = [sum(entry["dominant_token_count"][expert] for entry in entries) for expert in range(expert_count)]
+            return {
+                "token_count": count,
+                "mean_expert_probability": probabilities,
+                "dominant_token_count": dominant,
+                "dominant_token_fraction": [value / count for value in dominant],
+                "normalized_entropy_mean": sum(
+                    entry["normalized_entropy_mean"] * entry["token_count"] for entry in entries if entry["token_count"]
+                ) / count,
+                "top1_margin_mean": sum(
+                    entry["top1_margin_mean"] * entry["token_count"] for entry in entries if entry["token_count"]
+                ) / count,
+            }
+
+        foreground = region("foreground")
+        background = region("background")
+        pooled_contrast = None
+        if foreground["token_count"] and background["token_count"]:
+            fg_prob = np.asarray(foreground["mean_expert_probability"], dtype=np.float64)
+            bg_prob = np.asarray(background["mean_expert_probability"], dtype=np.float64)
+            mean_prob = 0.5 * (fg_prob + bg_prob)
+
+            def kl(left: np.ndarray, right: np.ndarray) -> float:
+                keep = left > 0
+                return float(np.sum(left[keep] * np.log(left[keep] / right[keep])))
+
+            pooled_contrast = {
+                "foreground_minus_background_expert_probability": [float(item) for item in fg_prob - bg_prob],
+                "total_variation_distance": float(0.5 * np.abs(fg_prob - bg_prob).sum()),
+                "jensen_shannon_divergence_nats": float(0.5 * kl(fg_prob, mean_prob) + 0.5 * kl(bg_prob, mean_prob)),
+                "foreground_minus_background_entropy": float(
+                    foreground["normalized_entropy_mean"] - background["normalized_entropy_mean"]
+                ),
+                "foreground_minus_background_top1_margin": float(
+                    foreground["top1_margin_mean"] - background["top1_margin_mean"]
+                ),
+            }
+        paired_contrast = None
+        if supported:
+            contrasts = [item["region_diagnostics"]["contrast"] for item in supported]
+
+            def distribution(key: str) -> dict[str, float]:
+                values = np.asarray([contrast[key] for contrast in contrasts], dtype=np.float64)
+                return {"mean": float(values.mean()), "min": float(values.min()), "max": float(values.max())}
+
+            paired_contrast = {
+                "capture_count": len(supported),
+                "weighting": "each supported capture receives equal weight",
+                "foreground_minus_background_expert_probability_mean": [
+                    float(
+                        np.mean(
+                            [contrast["foreground_minus_background_expert_probability"][expert] for contrast in contrasts]
+                        )
+                    )
+                    for expert in range(expert_count)
+                ],
+                "total_variation_distance": distribution("total_variation_distance"),
+                "jensen_shannon_divergence_nats": distribution("jensen_shannon_divergence_nats"),
+                "foreground_minus_background_entropy": distribution("foreground_minus_background_entropy"),
+                "foreground_minus_background_top1_margin": distribution(
+                    "foreground_minus_background_top1_margin"
+                ),
+            }
+        return {
+            "capture_count": len(items),
+            "supported_capture_count": len(supported),
+            "insufficient_capture_count": len(items) - len(supported),
+            "foreground": foreground,
+            "background": background,
+            "padding_token_count": sum(item["region_diagnostics"]["padding_token_count"] for item in items),
+            "pooled_contrast": pooled_contrast,
+            "paired_capture_contrast": paired_contrast,
+        }
+
+    families = sorted({item["family"] for item in captures})
+    modules = sorted({(item["family"], item["module"]) for item in captures})
+    return {
+        "method": {
+            "assignment_rule": "valid token center inside any ground-truth box",
+            "padding_policy": "excluded from both foreground and background",
+            "aggregation": "token-weighted within each family/module",
+            "contrast_reporting": "pooled token contrast plus equal-weight paired-capture descriptive distribution",
+            "primary_conclusion_basis": "paired_capture_contrast; pooled_contrast is diagnostic only",
+            "inference_boundary": "descriptive random-initialization baseline; no learned specialization claim",
+        },
+        "capture_count": len(captures),
+        "by_family": {
+            family: summarize([item for item in captures if item["family"] == family]) for family in families
+        },
+        "by_module": {
+            f"{family}:{module}": summarize(
+                [item for item in captures if item["family"] == family and item["module"] == module]
+            )
+            for family, module in modules
+        },
+    }

--- a/tools/e3_routing/src/e3_p2/robustness_runner.py
+++ b/tools/e3_routing/src/e3_p2/robustness_runner.py
@@ -1,0 +1,487 @@
+"""CPU-only resolution and horizontal-flip diagnostics for P2 spatial routers."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import random
+import shutil
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import yaml
+from PIL import Image, ImageDraw, ImageFont
+
+from .capture import SpatialRouterCollector, max_output_delta
+from .geometry import LetterboxMeta, letterbox
+from .io_utils import environment, sha256_file, write_json, write_manifest
+from .regions import label_path_for_image, parse_yolo_labels, token_region_masks
+from .runner import (
+    PROJECT_ROOT,
+    RUN_ID_PATTERN,
+    _detach_tree,
+    _resolve_images,
+    _slug,
+    _verify_project_source_state,
+    _verify_source,
+)
+from .stability import aggregate_stability_comparisons, probability_map_comparison, restore_probability_stack
+
+
+def _load_config(path: Path, run_id_override: str | None) -> dict[str, Any]:
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise TypeError(f"config must contain a mapping: {path}")
+    config = dict(loaded)
+    run_id = str(run_id_override if run_id_override is not None else config.get("run_id", "")).strip()
+    if not RUN_ID_PATTERN.fullmatch(run_id):
+        raise ValueError("run_id must be path-safe and at most 128 characters")
+    config["run_id"] = run_id
+    resolutions = [int(value) for value in config.get("resolutions", [])]
+    if len(resolutions) < 2 or len(set(resolutions)) != len(resolutions) or min(resolutions) < 32:
+        raise ValueError("resolutions must contain at least two unique integers >= 32")
+    config["resolutions"] = resolutions
+    reference = int(config.get("reference_resolution", 0))
+    if reference not in resolutions:
+        raise ValueError("reference_resolution must be present in resolutions")
+    config["reference_resolution"] = reference
+    seeds = [int(value) for value in config.get("seeds", [])]
+    if len(seeds) < 2 or len(set(seeds)) != len(seeds):
+        raise ValueError("seeds must contain at least two unique integers")
+    config["seeds"] = seeds
+    indices = [int(value) for value in config.get("sample_indices", [])]
+    if not indices or len(set(indices)) != len(indices):
+        raise ValueError("sample_indices must be non-empty and unique")
+    config["sample_indices"] = indices
+    if config.get("device") != "cpu":
+        raise ValueError("this evidence protocol is intentionally CPU-only")
+    if config.get("transformations") != ["identity", "horizontal_flip"]:
+        raise ValueError("transformations must be exactly identity and horizontal_flip")
+    if set(config.get("spatial_profiles", {})) != {"mot", "moa"}:
+        raise ValueError("spatial_profiles must be exactly MoT and MoA")
+    return config
+
+
+def _logger(path: Path) -> logging.Logger:
+    logger = logging.getLogger("e3_p2_robustness")
+    logger.handlers.clear()
+    logger.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
+    for handler in (logging.StreamHandler(sys.stdout), logging.FileHandler(path, encoding="utf-8", mode="w")):
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+    return logger
+
+
+def _tensor(image: Image.Image, resolution: int, flipped: bool, torch_module: Any) -> tuple[Any, LetterboxMeta]:
+    source = image.transpose(Image.Transpose.FLIP_LEFT_RIGHT) if flipped else image
+    canvas, meta = letterbox(source, resolution)
+    array = canvas.astype(np.float32).transpose(2, 0, 1) / 255.0
+    return torch_module.from_numpy(array).unsqueeze(0).contiguous(), meta
+
+
+def _capture_once(model: Any, family: str, router_class: str, tensor: Any, torch_module: Any) -> tuple[Any, list[Any], list[str]]:
+    collector = SpatialRouterCollector(family=family, router_class=router_class)
+    registered = collector.register(model)
+    try:
+        with torch_module.inference_mode():
+            output = model(tensor)
+    finally:
+        collector.remove()
+    if collector.handles or len(collector.records) != len(registered):
+        raise RuntimeError(f"capture count or hook cleanup failed for family={family}")
+    if [record.module_name for record in collector.records] != registered:
+        raise RuntimeError(f"capture module order changed for family={family}")
+    return _detach_tree(output), collector.records, registered
+
+
+def _archive_inputs(paths: list[Path], sample_indices: list[int], run_dir: Path) -> list[dict[str, Any]]:
+    destination = run_dir / "inputs"
+    destination.mkdir(parents=True, exist_ok=True)
+    records = []
+    for sample_index, path in zip(sample_indices, paths):
+        label = label_path_for_image(path)
+        image_relative = Path("inputs") / f"sample-{sample_index}--{path.name}"
+        label_relative = Path("inputs") / f"sample-{sample_index}--{label.name}"
+        shutil.copyfile(path, run_dir / image_relative)
+        shutil.copyfile(label, run_dir / label_relative)
+        with Image.open(path) as image:
+            width, height = image.size
+        boxes = parse_yolo_labels(label)
+        records.append(
+            {
+                "sample_index": sample_index,
+                "name": path.name,
+                "original_width": width,
+                "original_height": height,
+                "sha256": sha256_file(path),
+                "label_sha256": sha256_file(label),
+                "ground_truth_box_count": len(boxes),
+                "image_artifact": image_relative.as_posix(),
+                "label_artifact": label_relative.as_posix(),
+            }
+        )
+    return records
+
+
+def _coverage_summary(records: list[dict[str, Any]]) -> dict[str, Any]:
+    grouped: dict[tuple[str, int], list[dict[str, Any]]] = defaultdict(list)
+    for item in records:
+        grouped[(item["family"], int(item["resolution"]))].append(item)
+    return {
+        "method": {
+            "seed": "first configured seed only; geometry and annotations are seed-independent",
+            "assignment_rule": "valid token center inside any ground-truth box",
+            "padding_policy": "excluded from foreground and background",
+            "purpose": "measure whether higher input resolution reduces empty foreground/background comparisons",
+        },
+        "capture_count": len(records),
+        "by_family_resolution": {
+            f"{family}:{resolution}": {
+                "capture_count": len(items),
+                "supported_capture_count": sum(item["status"] == "SUPPORTED" for item in items),
+                "insufficient_capture_count": sum(item["status"] == "INSUFFICIENT_TOKENS" for item in items),
+                "foreground_token_count": sum(item["foreground_token_count"] for item in items),
+                "background_token_count": sum(item["background_token_count"] for item in items),
+                "padding_token_count": sum(item["padding_token_count"] for item in items),
+            }
+            for (family, resolution), items in sorted(grouped.items())
+        },
+        "records": records,
+    }
+
+
+def _save_overview(aggregate: dict[str, Any], coverage: dict[str, Any], path: Path) -> None:
+    canvas = Image.new("RGB", (1800, 1120), "#050c1b")
+    draw = ImageDraw.Draw(canvas)
+    def font(size: int, *, mono: bool = False) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+        candidates = ["C:/Windows/Fonts/consola.ttf"] if mono else ["C:/Windows/Fonts/segoeui.ttf"]
+        candidates += ["DejaVuSansMono.ttf"] if mono else ["DejaVuSans.ttf"]
+        for candidate in candidates:
+            try:
+                return ImageFont.truetype(candidate, size)
+            except OSError:
+                continue
+        return ImageFont.load_default()
+
+    title_font, section_font, body_font = font(38), font(23), font(18)
+    metric_font, small_font, mono_font = font(31, mono=True), font(15), font(16, mono=True)
+    draw.rounded_rectangle((42, 36, 1758, 1084), radius=30, fill="#09172d", outline="#21678d", width=3)
+    draw.text((82, 70), "E3 P2  /  CPU ROUTING STABILITY", fill="#00e5ff", font=title_font)
+    draw.text((84, 122), "3 seeds · 4 COCO8 images · 3 resolutions · identity + horizontal flip", fill="#9bb8d6", font=body_font)
+    draw.rounded_rectangle((1195, 66, 1708, 141), radius=16, fill="#221938", outline="#8f65db", width=2)
+    draw.text((1220, 83), "COLD-START DIAGNOSTIC", fill="#d5b7ff", font=section_font)
+    draw.text((1220, 113), "Not learned robustness", fill="#ffcc66", font=small_font)
+
+    cards = [("576", "true spatial captures"), ("480", "aligned comparisons"), ("0", "failed invariants")]
+    for index, (value, label) in enumerate(cards):
+        left = 82 + index * 340
+        draw.rounded_rectangle((left, 180, left + 310, 292), radius=18, fill="#0d223e", outline="#204d70", width=2)
+        draw.text((left + 22, 201), value, fill="#63e6a7", font=metric_font)
+        draw.text((left + 22, 252), label, fill="#a9c1da", font=small_font)
+
+    data = aggregate["by_type_family_resolution"]
+    flip = [data[f"horizontal_flip:moa:{size}"] for size in (64, 128, 256)]
+    cross = [data[f"resolution_vs_reference:moa:{size}"] for size in (128, 256)]
+    draw.text((82, 335), "MoA dominant-expert agreement", fill="#eaf4ff", font=section_font)
+    draw.text((82, 371), "Near-tie argmax sensitivity; inspect with probability MAE and margin", fill="#829fbd", font=small_font)
+    chart_left, chart_top, chart_width = 82, 418, 735
+    rows = [
+        ("flip 64", flip[0]), ("flip 128", flip[1]), ("flip 256", flip[2]),
+        ("64→128", cross[0]), ("64→256", cross[1]),
+    ]
+    for index, (label, item) in enumerate(rows):
+        y = chart_top + index * 67
+        agreement = item["dominant_expert_agreement_fraction"]["mean"]
+        draw.text((chart_left, y + 8), label, fill="#b5cce2", font=body_font)
+        draw.rounded_rectangle((chart_left + 135, y, chart_left + 135 + chart_width, y + 38), radius=9, fill="#10233c")
+        draw.rounded_rectangle(
+            (chart_left + 135, y, chart_left + 135 + int(chart_width * agreement), y + 38),
+            radius=9,
+            fill="#4d55d8" if "flip" in label else "#0e9fb0",
+        )
+        draw.text((chart_left + 150, y + 8), f"{agreement * 100:5.2f}%", fill="#ffffff", font=mono_font)
+        draw.text((chart_left + 890, y + 8), f"MAE {item['probability_mae']['mean']:.2e}", fill="#9bb8d6", font=mono_font)
+
+    draw.text((1050, 335), "GT region comparison coverage", fill="#eaf4ff", font=section_font)
+    draw.text((1050, 371), "Same geometry for MoT and MoA; 16 router captures per size", fill="#829fbd", font=small_font)
+    for index, size in enumerate((64, 128, 256)):
+        item = coverage["by_family_resolution"][f"moa:{size}"]
+        supported = item["supported_capture_count"]
+        y = 430 + index * 112
+        draw.text((1050, y), f"{size}px", fill="#b5cce2", font=body_font)
+        draw.rounded_rectangle((1140, y - 2, 1665, y + 42), radius=10, fill="#10233c")
+        draw.rounded_rectangle((1140, y - 2, 1140 + int(525 * supported / 16), y + 42), radius=10, fill="#00a879")
+        draw.text((1160, y + 8), f"{supported}/16 supported", fill="#ffffff", font=mono_font)
+        draw.text(
+            (1140, y + 58),
+            f"FG {item['foreground_token_count']}   BG {item['background_token_count']}   padding {item['padding_token_count']}",
+            fill="#8faecb",
+            font=small_font,
+        )
+
+    draw.rounded_rectangle((82, 820, 1710, 998), radius=18, fill="#081326", outline="#213c5a", width=2)
+    draw.text((110, 848), "Interpretation guardrails", fill="#a66cff", font=section_font)
+    notes = [
+        "MoA probability MAE stays below 7e-7 while mean top-1 margin is also about 1e-6: discrete argmax is tie-sensitive.",
+        "MoT maps are spatially constant at cold start: exact equality is real, but Pearson is undefined (0 defined / 144 undefined per group).",
+        "Raising input size from 64 to 128 removes all 5/16 INSUFFICIENT_TOKENS cases in this four-image mechanism test.",
+    ]
+    for index, note in enumerate(notes):
+        draw.text((115, 895 + index * 30), f"• {note}", fill="#c8d8e8", font=small_font)
+    draw.text((84, 1036), "SHA-256 manifest · locked upstream fingerprints · raw NPZ arrays · exact original-coordinate alignment", fill="#63e6a7", font=small_font)
+    canvas.save(path)
+
+
+def run(config_path: Path, *, run_id: str | None = None, update_latest: bool = True) -> Path:
+    config = _load_config(config_path, run_id)
+    project_source = _verify_project_source_state(bool(config.get("require_committed_source", False)))
+    run_dir = PROJECT_ROOT / "artifacts" / "p2" / config["run_id"]
+    if run_dir.exists() and any(run_dir.iterdir()):
+        raise FileExistsError(f"refusing to overwrite non-empty evidence directory: {run_dir}")
+    run_dir.mkdir(parents=True, exist_ok=True)
+    logger = _logger(run_dir / "full.log")
+    (run_dir / "config.resolved.yaml").write_text(
+        yaml.safe_dump(config, sort_keys=False, allow_unicode=True), encoding="utf-8"
+    )
+    (run_dir / "command.txt").write_text("run_robustness.cmd\n", encoding="utf-8")
+    started = time.perf_counter()
+
+    source_root = (PROJECT_ROOT / config["runtime_root"]).resolve()
+    checks = _verify_source(source_root, config["source_fingerprints"])
+    sys.path.insert(0, str(source_root))
+    os.chdir(PROJECT_ROOT)
+    import torch
+    from ultralytics import YOLO
+
+    paths, dataset_meta = _resolve_images(config["dataset"], config["dataset_split"], config["sample_indices"])
+    input_records = _archive_inputs(paths, config["sample_indices"], run_dir)
+    input_record = {
+        **dataset_meta,
+        "selected_image_count": len(paths),
+        "images": input_records,
+        "image_and_annotation_set_sha256": hashlib.sha256(
+            "\n".join(f"{item['sample_index']}:{item['sha256']}:{item['label_sha256']}" for item in input_records).encode("utf-8")
+        ).hexdigest(),
+    }
+    write_json(run_dir / "input.json", input_record)
+    write_json(run_dir / "source-fingerprint-checks.json", checks)
+
+    arrays: dict[str, np.ndarray] = {}
+    capture_metadata: list[dict[str, Any]] = []
+    comparisons: list[dict[str, Any]] = []
+    coverage_records: list[dict[str, Any]] = []
+    invariants: dict[str, Any] = {}
+    reference_resolution = config["reference_resolution"]
+    first_seed = config["seeds"][0]
+    logger.info(
+        "scope=CPU resolution and horizontal-flip diagnostics resolutions=%s seeds=%s samples=%s",
+        config["resolutions"],
+        config["seeds"],
+        config["sample_indices"],
+    )
+
+    for family, profile in config["spatial_profiles"].items():
+        for seed in config["seeds"]:
+            random.seed(seed)
+            np.random.seed(seed)
+            torch.manual_seed(seed)
+            wrapper = YOLO(source_root / profile["model_config"])
+            model = wrapper.model.to("cpu").eval()
+            representative, _ = _tensor(Image.open(paths[0]).convert("RGB"), reference_resolution, False, torch)
+            with torch.inference_mode():
+                baseline_output = _detach_tree(model(representative))
+            hooked_output, first_records, module_order = _capture_once(
+                model, family, profile["router_class"], representative, torch
+            )
+            hook_delta = max_output_delta(baseline_output, hooked_output)
+            _, repeat_records, repeat_order = _capture_once(model, family, profile["router_class"], representative, torch)
+            repeat_weight_delta = max(
+                float(np.max(np.abs(first.weights - second.weights)))
+                for first, second in zip(first_records, repeat_records)
+            )
+            repeat_logit_delta = max(
+                float(np.max(np.abs(first.logits - second.logits)))
+                for first, second in zip(first_records, repeat_records)
+            )
+            repeat_indices_equal = all(
+                first.indices is None or np.array_equal(first.indices, second.indices)
+                for first, second in zip(first_records, repeat_records)
+            )
+            if hook_delta != 0.0 or module_order != repeat_order or repeat_weight_delta != 0.0 or repeat_logit_delta != 0.0 or not repeat_indices_equal:
+                raise RuntimeError(f"representative invariants failed for family={family}, seed={seed}")
+            invariants[f"{family}:seed-{seed}"] = {
+                "hook_output_max_abs_delta": hook_delta,
+                "repeat_weight_max_abs_delta": repeat_weight_delta,
+                "repeat_logit_max_abs_delta": repeat_logit_delta,
+                "repeat_indices_equal": repeat_indices_equal if family == "mot" else None,
+                "module_order": module_order,
+                "hook_cleanup": True,
+                "status": "PASS",
+            }
+
+            for sample_index, path in zip(config["sample_indices"], paths):
+                with Image.open(path) as opened:
+                    original = opened.convert("RGB")
+                boxes = parse_yolo_labels(label_path_for_image(path))
+                restored: dict[tuple[int, bool, str], np.ndarray] = {}
+                observed_module_order = None
+                for resolution in config["resolutions"]:
+                    for flipped in (False, True):
+                        tensor, meta = _tensor(original, resolution, flipped, torch)
+                        _, records, registered = _capture_once(model, family, profile["router_class"], tensor, torch)
+                        if observed_module_order is None:
+                            observed_module_order = registered
+                        if registered != module_order or registered != observed_module_order:
+                            raise RuntimeError(f"module order changed across transformations for family={family}")
+                        for record in records:
+                            weights = record.weights[0]
+                            aligned, restoration_validation = restore_probability_stack(weights, meta)
+                            if flipped:
+                                aligned = np.flip(aligned, axis=2).copy()
+                            restored[(resolution, flipped, record.module_name)] = aligned
+                            prefix = (
+                                f"{family}__seed-{seed}__sample-{sample_index}__size-{resolution}__"
+                                f"{'hflip' if flipped else 'identity'}__{_slug(record.module_name)}"
+                            )
+                            weight_key = f"{prefix}__weights"
+                            logit_key = f"{prefix}__logits"
+                            arrays[weight_key] = record.weights
+                            arrays[logit_key] = record.logits
+                            index_key = None
+                            if record.indices is not None:
+                                index_key = f"{prefix}__indices"
+                                arrays[index_key] = record.indices
+                            capture_metadata.append(
+                                {
+                                    "family": family,
+                                    "seed": seed,
+                                    "sample_index": sample_index,
+                                    "sample_name": path.name,
+                                    "resolution": resolution,
+                                    "transformation": "horizontal_flip" if flipped else "identity",
+                                    "module": record.module_name,
+                                    "module_type": record.module_type,
+                                    "source_shape": record.validation["shape"],
+                                    "geometry": meta.to_dict(),
+                                    "router_validation": record.validation,
+                                    "restoration_validation": restoration_validation,
+                                    "aligned_to_original_coordinates": True,
+                                    "raw_keys": {"weights": weight_key, "logits": logit_key, "indices": index_key},
+                                }
+                            )
+                            if seed == first_seed and not flipped:
+                                masks = token_region_masks(boxes, meta, weights.shape[1], weights.shape[2])
+                                foreground = int(masks["foreground"].sum())
+                                background = int(masks["background"].sum())
+                                coverage_records.append(
+                                    {
+                                        "family": family,
+                                        "resolution": resolution,
+                                        "sample_index": sample_index,
+                                        "module": record.module_name,
+                                        "grid_height": int(weights.shape[1]),
+                                        "grid_width": int(weights.shape[2]),
+                                        "foreground_token_count": foreground,
+                                        "background_token_count": background,
+                                        "padding_token_count": int(masks["padding"].sum()),
+                                        "status": "SUPPORTED" if foreground and background else "INSUFFICIENT_TOKENS",
+                                    }
+                                )
+                for module in module_order:
+                    reference = restored[(reference_resolution, False, module)]
+                    for resolution in config["resolutions"]:
+                        identity = restored[(resolution, False, module)]
+                        flipped = restored[(resolution, True, module)]
+                        comparisons.append(
+                            {
+                                "comparison_type": "horizontal_flip",
+                                "family": family,
+                                "seed": seed,
+                                "sample_index": sample_index,
+                                "module": module,
+                                "reference_resolution": resolution,
+                                "candidate_resolution": resolution,
+                                "alignment": "restore both maps to original pixels; horizontally unflip candidate",
+                                "metrics": probability_map_comparison(identity, flipped),
+                            }
+                        )
+                        if resolution != reference_resolution:
+                            comparisons.append(
+                                {
+                                    "comparison_type": "resolution_vs_reference",
+                                    "family": family,
+                                    "seed": seed,
+                                    "sample_index": sample_index,
+                                    "module": module,
+                                    "reference_resolution": reference_resolution,
+                                    "candidate_resolution": resolution,
+                                    "alignment": "restore both identity maps to original-image pixels",
+                                    "metrics": probability_map_comparison(reference, identity),
+                                }
+                            )
+                logger.info("family=%s seed=%d sample=%d captures=%d", family, seed, sample_index, len(module_order) * 6)
+            del model, wrapper
+
+    np.savez_compressed(run_dir / "stability-routing-raw.npz", **arrays)
+    write_json(run_dir / "spatial-captures.json", capture_metadata)
+    write_json(run_dir / "stability-comparisons.json", comparisons)
+    aggregate = aggregate_stability_comparisons(comparisons)
+    write_json(run_dir / "stability-aggregate.json", aggregate)
+    coverage = _coverage_summary(coverage_records)
+    write_json(run_dir / "region-resolution-coverage.json", coverage)
+    write_json(run_dir / "invariants.json", invariants)
+    write_json(run_dir / "environment.json", environment(torch, source_root, PROJECT_ROOT))
+    _save_overview(aggregate, coverage, run_dir / "robustness-overview.png")
+
+    summary = {
+        "status": "PASS",
+        "scope": "CPU-only resolution and horizontal-flip diagnostics for true MoT/MoA spatial router probabilities",
+        "run_id": config["run_id"],
+        "official_locked_base_ref": config["official_locked_base_ref"],
+        "official_runtime_ref": config["official_runtime_ref"],
+        "tool_source": project_source,
+        "source_fingerprint_validation": "PASS",
+        "source_fingerprint_count": len(checks),
+        "device": "cpu",
+        "seeds": config["seeds"],
+        "resolutions": config["resolutions"],
+        "reference_resolution": reference_resolution,
+        "sample_count": len(paths),
+        "spatial_capture_count": len(capture_metadata),
+        "raw_array_count": len(arrays),
+        "aligned_comparison_count": len(comparisons),
+        "restoration_validation": {
+            "max_pre_normalization_expert_sum_error": max(
+                item["restoration_validation"]["pre_normalization_max_expert_sum_error"]
+                for item in capture_metadata
+            ),
+            "max_post_normalization_expert_sum_error": max(
+                item["restoration_validation"]["post_normalization_max_expert_sum_error"]
+                for item in capture_metadata
+            ),
+        },
+        "representative_invariants": invariants,
+        "region_resolution_coverage": coverage["by_family_resolution"],
+        "interpretation_boundary": "random initialization; pipeline and sensitivity evidence only, not learned robustness",
+        "status_semantics": "PASS means capture, geometry, alignment, determinism and evidence integrity checks completed",
+        "duration_seconds_observation_only": time.perf_counter() - started,
+    }
+    write_json(run_dir / "summary.json", summary)
+    for handler in logger.handlers:
+        handler.flush()
+    write_manifest(run_dir)
+    if update_latest:
+        latest = PROJECT_ROOT / "artifacts" / "p2" / "ROBUSTNESS_LATEST.txt"
+        latest.parent.mkdir(parents=True, exist_ok=True)
+        latest.write_text(config["run_id"] + "\n", encoding="utf-8")
+    logger.info("status=PASS captures=%d comparisons=%d arrays=%d", len(capture_metadata), len(comparisons), len(arrays))
+    for handler in logger.handlers:
+        handler.flush()
+    write_manifest(run_dir)
+    return run_dir

--- a/tools/e3_routing/src/e3_p2/runner.py
+++ b/tools/e3_routing/src/e3_p2/runner.py
@@ -1,0 +1,1085 @@
+"""Generate five-family feasibility evidence and truthful MoT/MoA overlays."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import logging
+import os
+import random
+import re
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import yaml
+from PIL import Image
+
+from .capture import SpatialRouterCollector, max_output_delta, routing_diagnostics, routing_metric_fields, tensor_shapes
+from .geometry import LetterboxMeta, letterbox
+from .io_utils import environment, sha256_file, write_json, write_manifest
+from .plotting import (
+    save_dominant_overlay,
+    save_ground_truth_overlay,
+    save_metric_overlay,
+    save_overview,
+    save_probability_overlay,
+)
+from .regions import (
+    YoloBox,
+    aggregate_region_diagnostics,
+    label_path_for_image,
+    parse_yolo_labels,
+    region_routing_diagnostics,
+    token_region_masks,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+RUN_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
+
+
+def _load_config(config_path: Path, run_id_override: str | None = None) -> dict[str, Any]:
+    loaded = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise TypeError(f"config must contain a mapping: {config_path}")
+    config = dict(loaded)
+    run_id = str(run_id_override if run_id_override is not None else config.get("run_id", "")).strip()
+    if not RUN_ID_PATTERN.fullmatch(run_id):
+        raise ValueError(
+            "run_id must be path-safe and contain at most 128 letters, digits, dots, dashes or underscores"
+        )
+    config["run_id"] = run_id
+    indices = config.get("sample_indices")
+    if not isinstance(indices, list) or not indices:
+        raise ValueError("sample_indices must be a non-empty list")
+    config["sample_indices"] = [int(index) for index in indices]
+    if len(set(config["sample_indices"])) != len(config["sample_indices"]):
+        raise ValueError("sample_indices must not contain duplicates")
+    if set(config.get("spatial_profiles", {})) != {"mot", "moa"}:
+        raise ValueError("P2 spatial_profiles must be exactly MoT and MoA")
+    if set(config.get("non_spatial_profiles", {})) != {"moe", "latent", "molora"}:
+        raise ValueError("P2 non_spatial_profiles must be exactly MoE, Latent and MoLoRA")
+    batch_sizes = config.get("batch_equivalence_sizes", [])
+    if not isinstance(batch_sizes, list) or any(int(size) < 2 for size in batch_sizes):
+        raise ValueError("batch_equivalence_sizes must contain integers >= 2")
+    config["batch_equivalence_sizes"] = [int(size) for size in batch_sizes]
+    region_analysis = config.get("region_analysis")
+    expected_region_analysis = {
+        "enabled": True,
+        "label_format": "yolo_detection_normalized_xywh",
+        "assignment_rule": "valid_token_center_inside_any_ground_truth_box",
+        "exclude_letterbox_padding": True,
+    }
+    if region_analysis != expected_region_analysis:
+        raise ValueError(f"region_analysis must preserve the audited contract: {expected_region_analysis}")
+    return config
+
+
+def _logger(path: Path) -> logging.Logger:
+    logger = logging.getLogger("e3_p2")
+    logger.handlers.clear()
+    logger.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
+    console = logging.StreamHandler(sys.stdout)
+    file_handler = logging.FileHandler(path, encoding="utf-8", mode="w")
+    console.setFormatter(formatter)
+    file_handler.setFormatter(formatter)
+    logger.addHandler(console)
+    logger.addHandler(file_handler)
+    return logger
+
+
+def _verify_source(source_root: Path, expected: dict[str, str]) -> list[dict[str, Any]]:
+    checks = []
+    for relative, digest in expected.items():
+        path = source_root / relative
+        actual = sha256_file(path) if path.is_file() else None
+        checks.append({"path": relative, "expected_sha256": digest, "actual_sha256": actual, "match": actual == digest})
+    mismatches = [item for item in checks if not item["match"]]
+    if mismatches:
+        raise RuntimeError(f"runtime source fingerprint mismatch: {mismatches[:1]}")
+    return checks
+
+
+def _verify_project_source_state(require_committed: bool) -> dict[str, Any]:
+    """Bind a formal evidence run to committed implementation files."""
+
+    def git(*args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", "-C", str(PROJECT_ROOT), *args],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=False,
+        )
+
+    commit_result = git("rev-parse", "HEAD")
+    tree_result = git("rev-parse", "HEAD^{tree}")
+    tracked_status = git(
+        "status",
+        "--porcelain",
+        "--",
+        "src",
+        "tests",
+        "configs",
+        "pyproject.toml",
+        "run_p2.cmd",
+        "run_robustness.cmd",
+        "run_appearance.cmd",
+        "run_layer_drilldown.cmd",
+        "run_image_scale.cmd",
+        "run_image_driver.cmd",
+        "run_dose_response.cmd",
+        "run_output_coupling.cmd",
+        "run_dose_holdout.cmd",
+        "run_blur_residual.cmd",
+        "run_demo.cmd",
+        "run_tests.cmd",
+    )
+    state = {
+        "commit": commit_result.stdout.strip() if commit_result.returncode == 0 else None,
+        "tree": tree_result.stdout.strip() if tree_result.returncode == 0 else None,
+        "implementation_status_porcelain": tracked_status.stdout.splitlines(),
+        "implementation_clean": tracked_status.returncode == 0 and not tracked_status.stdout.strip(),
+    }
+    if require_committed and (not state["commit"] or not state["implementation_clean"]):
+        raise RuntimeError(f"formal run requires committed implementation files: {state}")
+    return state
+
+
+def _resolve_images(dataset_name: str, split: str, sample_indices: list[int]) -> tuple[list[Path], dict[str, Any]]:
+    from ultralytics.data.utils import check_det_dataset
+
+    dataset = check_det_dataset(dataset_name, autodownload=True)
+    roots = dataset[split] if isinstance(dataset[split], list) else [dataset[split]]
+    extensions = {".bmp", ".jpeg", ".jpg", ".png", ".tif", ".tiff", ".webp"}
+    images: list[Path] = []
+    for item in roots:
+        root = Path(item)
+        if root.is_file() and root.suffix.lower() == ".txt":
+            images.extend(Path(line.strip()) for line in root.read_text(encoding="utf-8").splitlines() if line.strip())
+        elif root.is_file():
+            images.append(root)
+        elif root.is_dir():
+            images.extend(path for path in root.rglob("*") if path.suffix.lower() in extensions)
+    images = sorted(path.resolve() for path in images)
+    invalid = [index for index in sample_indices if not 0 <= index < len(images)]
+    if not images or invalid:
+        raise IndexError(f"dataset contains {len(images)} images; invalid sample indices={invalid}")
+    return [images[index] for index in sample_indices], {
+        "dataset": dataset_name,
+        "split": split,
+        "dataset_root": str(dataset.get("path")),
+        "split_image_count": len(images),
+    }
+
+
+def _prepare_inputs(
+    paths: list[Path], indices: list[int], image_size: int, torch_module: Any
+) -> tuple[list[Any], list[Any], list[dict[str, Any]]]:
+    tensors, originals, metadata = [], [], []
+    for sample_index, path in zip(indices, paths):
+        image = Image.open(path).convert("RGB")
+        canvas, geometry = letterbox(image, image_size)
+        array = canvas.astype(np.float32).transpose(2, 0, 1) / 255.0
+        tensors.append(torch_module.from_numpy(array).unsqueeze(0).contiguous())
+        originals.append(image.copy())
+        label_path = label_path_for_image(path)
+        boxes = parse_yolo_labels(label_path)
+        metadata.append(
+            {
+                "sample_index": sample_index,
+                "name": path.name,
+                "path": str(path),
+                "sha256": sha256_file(path),
+                "label_path": str(label_path),
+                "label_sha256": sha256_file(label_path),
+                "ground_truth_box_count": len(boxes),
+                "ground_truth_boxes": [box.to_dict() for box in boxes],
+                "geometry": geometry.to_dict(),
+                "normalization": "RGB uint8 / 255.0",
+            }
+        )
+    return tensors, originals, metadata
+
+
+def _detach_tree(value: Any) -> Any:
+    if hasattr(value, "detach") and hasattr(value, "shape"):
+        return value.detach().cpu().clone()
+    if isinstance(value, tuple):
+        return tuple(_detach_tree(child) for child in value)
+    if isinstance(value, list):
+        return [_detach_tree(child) for child in value]
+    if isinstance(value, dict):
+        return {key: _detach_tree(child) for key, child in value.items()}
+    return value
+
+
+def _slug(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-")
+
+
+def _archive_input_previews(
+    paths: list[Path], originals: list[Image.Image], inputs: list[dict[str, Any]], run_dir: Path
+) -> None:
+    destination_root = run_dir / "inputs"
+    destination_root.mkdir(parents=True, exist_ok=True)
+    for path, original, metadata in zip(paths, originals, inputs):
+        relative = Path("inputs") / f"sample-{metadata['sample_index']}--{path.name}"
+        shutil.copyfile(path, run_dir / relative)
+        metadata["artifact_path"] = relative.as_posix()
+        label_path = Path(metadata["label_path"])
+        label_relative = Path("inputs") / f"sample-{metadata['sample_index']}--{label_path.name}"
+        shutil.copyfile(label_path, run_dir / label_relative)
+        metadata["label_artifact_path"] = label_relative.as_posix()
+        annotated_relative = Path("inputs") / f"sample-{metadata['sample_index']}--ground-truth.png"
+        boxes = [YoloBox(**box) for box in metadata["ground_truth_boxes"]]
+        save_ground_truth_overlay(
+            original,
+            boxes,
+            LetterboxMeta(**metadata["geometry"]),
+            str(run_dir / annotated_relative),
+        )
+        metadata["annotated_artifact_path"] = annotated_relative.as_posix()
+
+
+def _aggregate_spatial_diagnostics(captures: list[dict[str, Any]]) -> dict[str, Any]:
+    def summarize(items: list[dict[str, Any]]) -> dict[str, Any]:
+        diagnostics = [item["diagnostics"] for item in items]
+        token_count = sum(item["token_count"] for item in diagnostics)
+        expert_count = len(diagnostics[0]["dominant_token_count"])
+        dominant_counts = [
+            sum(item["dominant_token_count"][expert] for item in diagnostics) for expert in range(expert_count)
+        ]
+        def weighted(key: str) -> float:
+            return sum(item[key]["mean"] * item["token_count"] for item in diagnostics) / token_count
+        return {
+            "capture_count": len(items),
+            "token_count": token_count,
+            "dominant_token_count": dominant_counts,
+            "dominant_token_fraction": [count / token_count for count in dominant_counts],
+            "active_dominant_experts": sum(count > 0 for count in dominant_counts),
+            "normalized_entropy_mean": weighted("normalized_entropy"),
+            "top1_margin_mean": weighted("top1_margin"),
+            "neighbor_probability_l1_mean": sum(
+                item["neighbor_probability_l1_mean"] * item["token_count"] for item in diagnostics
+            )
+            / token_count,
+        }
+
+    families = sorted({item["family"] for item in captures})
+    modules = sorted({(item["family"], item["module"]) for item in captures})
+    return {
+        "capture_count": len(captures),
+        "by_family": {
+            family: summarize([item for item in captures if item["family"] == family]) for family in families
+        },
+        "by_module": {
+            f"{family}:{module}": summarize(
+                [item for item in captures if item["family"] == family and item["module"] == module]
+            )
+            for family, module in modules
+        },
+    }
+
+
+def _validate_demo_assets(
+    run_dir: Path, entries: list[dict[str, Any]], inputs: list[dict[str, Any]]
+) -> dict[str, Any]:
+    expected_sizes = {
+        item["sample_index"]: (item["geometry"]["original_width"], item["geometry"]["original_height"])
+        for item in inputs
+    }
+    paths = [entry["path"] for entry in entries]
+    if len(paths) != len(set(paths)):
+        raise RuntimeError("demo contains duplicate rendered asset paths")
+    checked = 0
+    for entry in entries:
+        path = run_dir / entry["path"]
+        if not path.is_file():
+            raise FileNotFoundError(f"demo asset is missing: {path}")
+        with Image.open(path) as image:
+            if image.size != expected_sizes[entry["sample_index"]]:
+                raise RuntimeError(
+                    f"demo asset size mismatch: {entry['path']} has {image.size}, "
+                    f"expected {expected_sizes[entry['sample_index']]}"
+                )
+        original_path = run_dir / entry["original_path"]
+        if not original_path.is_file():
+            raise FileNotFoundError(f"demo original asset is missing: {original_path}")
+        annotated_path = run_dir / entry["annotated_original_path"]
+        if not annotated_path.is_file():
+            raise FileNotFoundError(f"demo annotated original asset is missing: {annotated_path}")
+        with Image.open(annotated_path) as image:
+            if image.size != expected_sizes[entry["sample_index"]]:
+                raise RuntimeError(
+                    f"demo annotated asset size mismatch: {entry['annotated_original_path']} has {image.size}, "
+                    f"expected {expected_sizes[entry['sample_index']]}"
+                )
+        checked += 1
+    return {
+        "status": "PASS",
+        "entry_count": checked,
+        "unique_rendered_asset_count": len(set(paths)),
+        "all_rendered_assets_match_original_size": True,
+        "all_original_assets_present": True,
+        "all_annotated_original_assets_present_and_match_original_size": True,
+    }
+
+
+def _batch_equivalence(
+    *,
+    model: Any,
+    family: str,
+    router_class: str,
+    tensors: list[Any],
+    records_per_sample: list[list[Any]],
+    batch_sizes: list[int],
+    torch_module: Any,
+    tolerance: float = 1e-5,
+) -> dict[str, Any]:
+    """Prove that the batch axis maps back to the same per-sample router grids."""
+
+    results = []
+    for batch_size in batch_sizes:
+        if batch_size > len(tensors):
+            raise ValueError(f"batch equivalence size {batch_size} exceeds {len(tensors)} selected samples")
+        weight_delta = 0.0
+        logit_delta = 0.0
+        indices_equal = True
+        compared_samples = 0
+        compared_records = 0
+        for start in range(0, len(tensors), batch_size):
+            stop = min(start + batch_size, len(tensors))
+            if stop - start != batch_size:
+                continue
+            collector = SpatialRouterCollector(family=family, router_class=router_class)
+            registered = collector.register(model)
+            try:
+                with torch_module.inference_mode():
+                    model(torch_module.cat(tensors[start:stop], dim=0))
+            finally:
+                collector.remove()
+            if collector.handles or len(collector.records) != len(registered):
+                raise RuntimeError(f"batch capture count or hook cleanup failed for family={family}, size={batch_size}")
+            for module_index, batched in enumerate(collector.records):
+                for offset, sample_index in enumerate(range(start, stop)):
+                    single = records_per_sample[sample_index][module_index]
+                    if batched.module_name != single.module_name:
+                        raise RuntimeError("batch and single module order differ")
+                    weight_delta = max(
+                        weight_delta,
+                        float(np.max(np.abs(batched.weights[offset] - single.weights[0]))),
+                    )
+                    logit_delta = max(
+                        logit_delta,
+                        float(np.max(np.abs(batched.logits[offset] - single.logits[0]))),
+                    )
+                    if batched.indices is not None:
+                        indices_equal = indices_equal and bool(
+                            np.array_equal(batched.indices[offset], single.indices[0])
+                        )
+                    compared_records += 1
+            compared_samples += stop - start
+        if not compared_samples:
+            raise RuntimeError(f"batch size {batch_size} produced no complete comparison group")
+        if weight_delta > tolerance or logit_delta > tolerance or not indices_equal:
+            raise RuntimeError(
+                f"single-vs-batch routing mismatch for family={family}, size={batch_size}: "
+                f"weights={weight_delta}, logits={logit_delta}, indices_equal={indices_equal}"
+            )
+        results.append(
+            {
+                "batch_size": batch_size,
+                "compared_samples": compared_samples,
+                "compared_router_records": compared_records,
+                "max_weight_abs_delta": weight_delta,
+                "max_logit_abs_delta": logit_delta,
+                "indices_equal": indices_equal if family == "mot" else None,
+                "tolerance": tolerance,
+                "status": "PASS",
+            }
+        )
+    return {"status": "PASS", "sizes": results}
+
+
+def _run_spatial_family(
+    *,
+    family: str,
+    profile: dict[str, Any],
+    source_root: Path,
+    tensors: list[Any],
+    originals: list[Image.Image],
+    inputs: list[dict[str, Any]],
+    run_dir: Path,
+    alpha: float,
+    torch_module: Any,
+    yolo_class: Any,
+    logger: logging.Logger,
+    batch_equivalence_sizes: list[int],
+) -> tuple[dict[str, Any], list[dict[str, Any]], dict[str, np.ndarray], list[dict[str, str]]]:
+    model_config = source_root / profile["model_config"]
+    wrapper = yolo_class(model_config)
+    model = wrapper.model.to("cpu").eval()
+    baseline_outputs = []
+    with torch_module.inference_mode():
+        for tensor in tensors:
+            baseline_outputs.append(_detach_tree(model(tensor)))
+
+    collector = SpatialRouterCollector(family=family, router_class=profile["router_class"])
+    registered = collector.register(model)
+    records_per_sample = []
+    deltas = []
+    try:
+        for tensor, baseline in zip(tensors, baseline_outputs):
+            before = len(collector.records)
+            with torch_module.inference_mode():
+                observed = model(tensor)
+            deltas.append(max_output_delta(baseline, observed))
+            records_per_sample.append(collector.records[before:])
+    finally:
+        collector.remove()
+    if collector.handles:
+        raise RuntimeError(f"hook leak for family={family}")
+    if any(len(records) != len(registered) for records in records_per_sample):
+        raise RuntimeError(f"capture count mismatch for family={family}")
+    if max(deltas, default=0.0) != 0.0:
+        raise RuntimeError(f"hook changed model output for family={family}: max_delta={max(deltas)}")
+
+    repeat_collector = SpatialRouterCollector(family=family, router_class=profile["router_class"])
+    repeat_registered = repeat_collector.register(model)
+    try:
+        with torch_module.inference_mode():
+            for tensor in tensors:
+                model(tensor)
+    finally:
+        repeat_collector.remove()
+    if repeat_registered != registered or len(repeat_collector.records) != len(collector.records):
+        raise RuntimeError(f"repeat discovery/capture mismatch for family={family}")
+    repeat_max_delta = 0.0
+    repeat_indices_equal = True
+    for first, second in zip(collector.records, repeat_collector.records):
+        if first.module_name != second.module_name:
+            raise RuntimeError(f"repeat module order changed for family={family}")
+        repeat_max_delta = max(
+            repeat_max_delta,
+            float(np.max(np.abs(first.weights - second.weights))),
+            float(np.max(np.abs(first.logits - second.logits))),
+        )
+        if first.indices is not None:
+            repeat_indices_equal = repeat_indices_equal and bool(np.array_equal(first.indices, second.indices))
+    if repeat_max_delta != 0.0 or not repeat_indices_equal:
+        raise RuntimeError(
+            f"deterministic repeat failed for family={family}: delta={repeat_max_delta}, "
+            f"indices_equal={repeat_indices_equal}"
+        )
+
+    batch_equivalence = _batch_equivalence(
+        model=model,
+        family=family,
+        router_class=profile["router_class"],
+        tensors=tensors,
+        records_per_sample=records_per_sample,
+        batch_sizes=batch_equivalence_sizes,
+        torch_module=torch_module,
+    )
+
+    arrays: dict[str, np.ndarray] = {}
+    demo_entries: list[dict[str, Any]] = []
+    overview_cards: list[dict[str, str]] = []
+    capture_metadata = []
+    overlay_root = run_dir / "overlays" / family
+    overlay_root.mkdir(parents=True, exist_ok=True)
+    expert_labels = profile["expert_labels"]
+    for sample_position, (sample_meta, original, records) in enumerate(zip(inputs, originals, records_per_sample)):
+        geometry = LetterboxMeta(**sample_meta["geometry"])
+        for layer_index, record in enumerate(records):
+            weights = record.weights[0]
+            module_slug = _slug(record.module_name)
+            key = f"sample{sample_meta['sample_index']}__{family}__{module_slug}"
+            arrays[f"{key}__weights"] = record.weights
+            arrays[f"{key}__logits"] = record.logits
+            if record.indices is not None:
+                arrays[f"{key}__indices"] = record.indices
+            metric_fields = routing_metric_fields(weights)
+            diagnostics = routing_diagnostics(weights)
+            masks = token_region_masks(
+                [YoloBox(**box) for box in sample_meta["ground_truth_boxes"]],
+                geometry,
+                int(weights.shape[1]),
+                int(weights.shape[2]),
+            )
+            region_diagnostics = region_routing_diagnostics(weights, masks)
+            arrays[f"{key}__foreground_mask"] = masks["foreground"]
+            arrays[f"{key}__background_mask"] = masks["background"]
+            arrays[f"{key}__padding_mask"] = masks["padding"]
+            arrays[f"{key}__normalized_entropy"] = metric_fields["normalized_entropy"]
+            arrays[f"{key}__top1_margin"] = metric_fields["top1_margin"]
+            dominant_relative = (
+                Path("overlays") / family / f"sample-{sample_meta['sample_index']}--{module_slug}--dominant.png"
+            )
+            counts = save_dominant_overlay(
+                original,
+                weights,
+                geometry,
+                str(run_dir / dominant_relative),
+                alpha=alpha,
+            )
+            demo_entries.append(
+                {
+                    "family": family,
+                    "sample_index": sample_meta["sample_index"],
+                    "sample_name": sample_meta["name"],
+                    "module": record.module_name,
+                    "layer_index": layer_index,
+                    "view": "dominant",
+                    "expert_index": None,
+                    "expert_label": "dominant expert",
+                    "path": dominant_relative.as_posix(),
+                    "source_shape": record.validation["shape"],
+                    "token_counts": counts,
+                }
+            )
+            if sample_position == 0 and layer_index < 2:
+                overview_cards.append(
+                    {
+                        "path": str(run_dir / dominant_relative),
+                        "caption": f"{family.upper()} | {record.module_name} | dominant",
+                    }
+                )
+            expert_stats = []
+            for expert_index in range(weights.shape[0]):
+                expert_label = (
+                    expert_labels[expert_index] if expert_index < len(expert_labels) else f"expert-{expert_index}"
+                )
+                relative = (
+                    Path("overlays")
+                    / family
+                    / f"sample-{sample_meta['sample_index']}--{module_slug}--expert-{expert_index}-{_slug(expert_label)}.png"
+                )
+                stats = save_probability_overlay(
+                    original,
+                    weights[expert_index],
+                    geometry,
+                    str(run_dir / relative),
+                    expert_index=expert_index,
+                    alpha=alpha,
+                )
+                expert_stats.append({"expert_index": expert_index, "expert_label": expert_label, **stats})
+                demo_entries.append(
+                    {
+                        "family": family,
+                        "sample_index": sample_meta["sample_index"],
+                        "sample_name": sample_meta["name"],
+                        "module": record.module_name,
+                        "layer_index": layer_index,
+                        "view": "probability",
+                        "expert_index": expert_index,
+                        "expert_label": expert_label,
+                        "path": relative.as_posix(),
+                        "source_shape": record.validation["shape"],
+                        "stats": stats,
+                    }
+                )
+            metric_stats = {}
+            metric_specs = {
+                "normalized_entropy": ("entropy", "normalized routing entropy", (166, 108, 255)),
+                "top1_margin": ("margin", "top-1 routing margin", (0, 229, 255)),
+            }
+            for field_name, (view_name, label, color) in metric_specs.items():
+                relative = (
+                    Path("overlays")
+                    / family
+                    / f"sample-{sample_meta['sample_index']}--{module_slug}--{view_name}.png"
+                )
+                stats = save_metric_overlay(
+                    original,
+                    metric_fields[field_name],
+                    geometry,
+                    str(run_dir / relative),
+                    color=color,
+                    alpha=alpha,
+                )
+                metric_stats[field_name] = stats
+                demo_entries.append(
+                    {
+                        "family": family,
+                        "sample_index": sample_meta["sample_index"],
+                        "sample_name": sample_meta["name"],
+                        "module": record.module_name,
+                        "layer_index": layer_index,
+                        "view": view_name,
+                        "expert_index": None,
+                        "expert_label": label,
+                        "path": relative.as_posix(),
+                        "source_shape": record.validation["shape"],
+                        "stats": stats,
+                    }
+                )
+            capture_metadata.append(
+                {
+                    "family": family,
+                    "sample_index": sample_meta["sample_index"],
+                    "module": record.module_name,
+                    "module_type": record.module_type,
+                    "weights_key": f"{key}__weights",
+                    "logits_key": f"{key}__logits",
+                    "indices_key": f"{key}__indices" if record.indices is not None else None,
+                    "validation": record.validation,
+                    "expert_stats": expert_stats,
+                    "metric_stats": metric_stats,
+                    "diagnostics": diagnostics,
+                    "region_mask_keys": {
+                        "foreground": f"{key}__foreground_mask",
+                        "background": f"{key}__background_mask",
+                        "padding": f"{key}__padding_mask",
+                    },
+                    "region_diagnostics": region_diagnostics,
+                }
+            )
+    grids = sorted({tuple(item["validation"]["shape"][2:]) for item in capture_metadata})
+    summary = {
+        "status": "SUPPORTED",
+        "token_overlay": "supported",
+        "evidence_kind": "full_detector_forward",
+        "model_config": profile["model_config"],
+        "model_parameters": sum(parameter.numel() for parameter in model.parameters()),
+        "router_class": profile["router_class"],
+        "registered_modules": registered,
+        "registered_module_count": len(registered),
+        "samples": len(tensors),
+        "capture_count": len(capture_metadata),
+        "feature_grids_hw": [list(grid) for grid in grids],
+        "expert_labels": expert_labels,
+        "probability_validation": "PASS",
+        "hook_output_equivalence": "PASS",
+        "max_output_abs_delta": max(deltas, default=0.0),
+        "deterministic_repeat": "PASS",
+        "repeat_max_weight_or_logit_abs_delta": repeat_max_delta,
+        "repeat_indices_equal": repeat_indices_equal,
+        "single_vs_batch_equivalence": batch_equivalence,
+        "hooks_removed": True,
+    }
+    logger.info(
+        "family=%s supported modules=%d samples=%d captures=%d grids=%s output_delta=%g repeat_delta=%g",
+        family,
+        len(registered),
+        len(tensors),
+        len(capture_metadata),
+        grids,
+        summary["max_output_abs_delta"],
+        repeat_max_delta,
+    )
+    del model, wrapper, baseline_outputs
+    return summary, capture_metadata, arrays, overview_cards
+
+
+def _audit_moe(source_root: Path, tensor: Any, torch_module: Any, yolo_class: Any) -> dict[str, Any]:
+    model_config = source_root / "ultralytics/cfg/models/26/yolo26-master-n.yaml"
+    wrapper = yolo_class(model_config)
+    model = wrapper.model.eval()
+    captures: list[dict[str, Any]] = []
+    handles = []
+    for name, module in model.named_modules():
+        module_path = module.__class__.__module__.lower()
+        routing = getattr(module, "routing", None)
+        if routing is None or ".moe." not in module_path or not hasattr(module, "num_experts"):
+            continue
+
+        def capture(current: Any, inputs: Any, output: Any, *, owner_name: str = name) -> None:
+            del current, inputs
+            captures.append({"module": owner_name, "router_output_shapes": tensor_shapes(output)})
+
+        handles.append(routing.register_forward_hook(capture))
+    try:
+        with torch_module.inference_mode():
+            model(tensor)
+    finally:
+        for handle in handles:
+            handle.remove()
+    shapes = [shape for item in captures for shape in item["router_output_shapes"]]
+    spatial = [shape for shape in shapes if len(shape) == 4 and shape[-2] > 1 and shape[-1] > 1]
+    if spatial:
+        raise RuntimeError(f"MoE audit unexpectedly found spatial router outputs: {spatial}")
+    result = {
+        "status": "UNSUPPORTED",
+        "token_overlay": "unsupported",
+        "evidence_kind": "full_detector_nested_router_forward",
+        "model_config": "ultralytics/cfg/models/26/yolo26-master-n.yaml",
+        "reason": "router decisions are image/sample-level; singleton H/W axes are broadcast containers, not token maps",
+        "captured_modules": captures,
+        "observed_shapes": shapes,
+        "spatial_shape_count": 0,
+    }
+    del model, wrapper
+    return result
+
+
+def _audit_latent(source_root: Path, tensor: Any, torch_module: Any, yolo_class: Any) -> dict[str, Any]:
+    model_config = source_root / "ultralytics/cfg/models/26/yolo26-master-latent-n.yaml"
+    wrapper = yolo_class(model_config)
+    model = wrapper.model.eval()
+    with torch_module.inference_mode():
+        model(tensor)
+    captures = []
+    for name, module in model.named_modules():
+        if module.__class__.__name__ not in {"LatentMixture", "MultiScaleLatentMixture"}:
+            continue
+        probs = getattr(module, "_last_routing_probs", None)
+        snapshot = getattr(module, "last_routing_snapshot", {})
+        captures.append(
+            {
+                "module": name,
+                "routing_probs_shape": [int(item) for item in probs.shape] if probs is not None else None,
+                "routing_axis": snapshot.get("routing_axis") if isinstance(snapshot, dict) else None,
+            }
+        )
+    if not captures:
+        raise RuntimeError("Latent audit found no routing modules")
+    result = {
+        "status": "UNSUPPORTED",
+        "token_overlay": "unsupported",
+        "evidence_kind": "full_detector_runtime_state",
+        "model_config": "ultralytics/cfg/models/26/yolo26-master-latent-n.yaml",
+        "reason": "routing axes are expert or scale-by-expert after spatial pooling; no reversible H/W token axis exists",
+        "captured_modules": captures,
+        "spatial_shape_count": 0,
+    }
+    del model, wrapper
+    return result
+
+
+def _audit_molora(torch_module: Any) -> dict[str, Any]:
+    from ultralytics.nn.peft.molora.router import HybridRouter, LinearRouter, SpatialRouter
+
+    probe = torch_module.linspace(-1.0, 1.0, steps=16 * 8 * 8).reshape(1, 16, 8, 8)
+    captures = []
+    for router_class in (LinearRouter, SpatialRouter, HybridRouter):
+        router = router_class(16, 4).eval()
+        with torch_module.inference_mode():
+            output = router(probe)
+        captures.append(
+            {"router_type": router_class.__name__, "input_shape": [1, 16, 8, 8], "output_shape": list(output.shape)}
+        )
+    if any(item["output_shape"] != [1, 4] for item in captures):
+        raise RuntimeError(f"unexpected MoLoRA router contract: {captures}")
+    return {
+        "status": "UNSUPPORTED",
+        "token_overlay": "unsupported",
+        "evidence_kind": "isolated_official_router_contract",
+        "reason": "all official MoLoRA router variants reduce spatial features and return one [B,E] decision per image",
+        "captured_router_variants": captures,
+        "spatial_shape_count": 0,
+    }
+
+
+def _demo_html() -> str:
+    return """<!doctype html>
+<html lang=\"en\"><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"><link rel=\"icon\" href=\"data:,\">
+<title>E3 P2 Routing Lens</title><style>
+:root{color-scheme:dark;--bg:#061022;--panel:#0b1932;--line:#1d4264;--cyan:#00e5ff;--violet:#a66cff;--text:#eaf4ff;--muted:#89a4c2}
+*{box-sizing:border-box}body{margin:0;background:radial-gradient(circle at 20% 0,#112b4d 0,var(--bg) 42%);font:15px system-ui;color:var(--text)}
+.shell{max-width:1440px;margin:auto;padding:28px}.hero{border:1px solid var(--line);background:linear-gradient(100deg,#07172cdd,#120c2add);padding:22px 26px;border-radius:18px;box-shadow:0 0 40px #00e5ff14}
+.eyebrow{color:var(--cyan);letter-spacing:.18em;font:700 12px ui-monospace}.hero h1{margin:8px 0 6px;font-size:30px}.hero p{margin:0;color:var(--muted)}
+.notice{margin-top:14px;padding:11px 14px;border-left:3px solid #ffc400;background:#ffc40012;color:#ffe7a0}.grid{display:grid;grid-template-columns:310px 1fr;gap:18px;margin-top:18px}
+.panel{border:1px solid var(--line);background:#09162bcc;border-radius:16px;padding:18px}.control{margin-bottom:14px}.control label{display:block;margin-bottom:6px;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.08em}
+select,button,a.button{width:100%;border:1px solid #285474;background:#0d203b;color:var(--text);padding:10px;border-radius:9px;text-decoration:none;display:block}button,a.button{cursor:pointer;text-align:center;margin-top:9px;background:linear-gradient(90deg,#006f8c,#53359a);font-weight:700}.toggle{display:flex;gap:8px;align-items:center;color:var(--muted);margin:2px 0 12px}.toggle input{accent-color:var(--cyan)}
+.compare{display:grid;grid-template-columns:1fr 1fr;gap:12px}.frame{margin:0}.frame figcaption{color:var(--muted);font:700 11px ui-monospace;letter-spacing:.1em;margin:0 0 7px}.frame img{display:block;width:100%;height:430px;object-fit:contain;background:#050b16;border-radius:12px;border:1px solid #173653}
+.meta{display:flex;gap:10px;flex-wrap:wrap;margin-top:12px}.chip{background:#102748;border:1px solid #214b70;border-radius:999px;padding:6px 10px;color:#bcd5ee;font-size:12px}.stats{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-top:12px}.stat{padding:10px 12px;border:1px solid #214b70;background:#08172d;border-radius:10px}.stat b{display:block;color:var(--cyan);font:700 17px ui-monospace}.stat small{color:var(--muted)}
+.matrix{margin-top:18px;display:grid;grid-template-columns:repeat(5,1fr);gap:10px}.family{padding:12px;border:1px solid var(--line);border-radius:12px;background:#08172d}.ok{color:#42e58c}.no{color:#ff889c}.status{margin-top:10px;color:#7ee8b2;font-size:12px}pre{max-height:210px;overflow:auto;white-space:pre-wrap;color:#aac4df;font-size:11px}@media(max-width:900px){.grid{grid-template-columns:1fr}.matrix{grid-template-columns:repeat(2,1fr)}}@media(max-width:620px){.shell{padding:14px}.hero h1{font-size:24px}.matrix,.compare,.stats{grid-template-columns:1fr}.frame img{height:auto}}
+</style></head><body><main class=\"shell\"><section class=\"hero\"><div class=\"eyebrow\">E3://SPATIAL ROUTING LENS</div><h1>Token routing, mapped back without distortion</h1><p>Original and overlay stay side by side. Switch sample, family, layer, probability, entropy or margin without losing the evidence source.</p>
+<div class=\"notice\">Interpretation boundary: this run uses random initialization. Uniform maps validate capture, batch identity and geometry; they do not demonstrate learned expert specialization.</div></section>
+<section class=\"matrix\" id=\"matrix\" aria-label=\"Five-family feasibility\"></section><section class=\"grid\"><aside class=\"panel\"><div class=\"control\"><label for=\"family\">Family</label><select id=\"family\"></select></div><div class=\"control\"><label for=\"sample\">Sample</label><select id=\"sample\"></select></div><div class=\"control\"><label for=\"layer\">Layer</label><select id=\"layer\"></select></div><div class=\"control\"><label for=\"view\">View / expert</label><select id=\"view\"></select></div><label class=\"toggle\"><input id=\"groundTruth\" type=\"checkbox\">Show archived ground-truth boxes</label><a class=\"button\" id=\"download\" download>Export current PNG</a><button id=\"copy\">Copy evidence metadata</button><div class=\"status\" id=\"status\" role=\"status\">Loading evidence…</div><pre id=\"detail\"></pre></aside><section class=\"panel\"><div class=\"compare\"><figure class=\"frame\"><figcaption>ORIGINAL / GROUND TRUTH</figcaption><img id=\"original\" alt=\"original coco8 input\"></figure><figure class=\"frame\"><figcaption>ROUTING OVERLAY</figcaption><img id=\"image\" alt=\"routing overlay\"></figure></div><div class=\"meta\" id=\"chips\"></div><div class=\"stats\" id=\"stats\"></div></section></section></main>
+<script>
+let entries;const q=id=>document.getElementById(id);const unique=xs=>[...new Set(xs)];
+function options(el,values,label){const old=el.value;el.innerHTML=values.map(v=>`<option value=\"${v}\">${label(v)}</option>`).join('');if(values.includes(old))el.value=old;}
+function viewLabel(x){if(x.view==='dominant')return'Dominant expert';if(x.view==='entropy')return'Normalized routing entropy';if(x.view==='margin')return'Top-1 routing margin';return`Expert ${x.expert_index} · ${x.expert_label}`;}
+function cascade(source){let family=q('family').value;if(source==='family'||!family){options(q('family'),unique(entries.map(x=>x.family)),x=>x.toUpperCase());family=q('family').value}let pool=entries.filter(x=>x.family===family);options(q('sample'),unique(pool.map(x=>String(x.sample_index))),x=>`${x} · ${pool.find(y=>String(y.sample_index)===x).sample_name}`);pool=pool.filter(x=>String(x.sample_index)===q('sample').value);options(q('layer'),unique(pool.map(x=>x.module)),x=>x);pool=pool.filter(x=>x.module===q('layer').value);options(q('view'),pool.map((_,i)=>String(i)),i=>viewLabel(pool[Number(i)]));render(pool[Number(q('view').value||0)]);}
+function renderStats(x){let values;if(x.stats){values=[['min',x.stats.feature_min],['mean',x.stats.feature_mean],['max',x.stats.feature_max]]}else{const d=x.diagnostics;values=[['entropy',d.normalized_entropy.mean],['top-1 margin',d.top1_margin.mean],['active experts',d.active_dominant_experts]]}const r=x.region_diagnostics;if(r){values.push(['foreground tokens',r.foreground.token_count],['background tokens',r.background.token_count],['FG/BG TV',r.contrast?r.contrast.total_variation_distance:'n/a'])}q('stats').innerHTML=values.map(([label,value])=>`<div class=\"stat\"><b>${typeof value==='number'?value.toFixed(6):value}</b><small>${label}</small></div>`).join('');}
+function renderOriginal(x){q('original').src=q('groundTruth').checked?x.annotated_original_path:x.original_path;}
+function render(x){if(!x)return;renderOriginal(x);q('image').src=x.path;q('download').href=x.path;q('chips').innerHTML=[x.family.toUpperCase(),x.sample_name,x.module,`shape ${x.source_shape.join('×')}`,x.expert_label].map(v=>`<span class=\"chip\">${v}</span>`).join('');renderStats(x);q('detail').textContent=JSON.stringify(x,null,2);q('status').textContent=`Ready · ${viewLabel(x)} · original-size export`;q('copy').onclick=async()=>{try{await navigator.clipboard.writeText(q('detail').textContent);q('status').textContent='Evidence metadata copied'}catch(error){q('status').textContent=`Copy failed: ${error.message}`}};q('groundTruth').onchange=()=>renderOriginal(x);}
+fetch('demo-index.json').then(response=>{if(!response.ok)throw new Error(`HTTP ${response.status}`);return response.json()}).then(data=>{entries=data.entries;q('matrix').innerHTML=Object.entries(data.feasibility).map(([key,value])=>`<div class=\"family\"><b>${key.toUpperCase()}</b><div class=\"${value.token_overlay==='supported'?'ok':'no'}\">${value.token_overlay}</div><small>${value.reason||value.evidence_kind}</small></div>`).join('');['family','sample','layer','view'].forEach(id=>q(id).onchange=()=>cascade(id));cascade('family');document.body.dataset.ready='true'}).catch(error=>{q('status').textContent=`Evidence failed to load: ${error.message}`;q('status').style.color='#ff889c'});
+</script></body></html>"""
+
+
+def run(config_path: Path, *, run_id: str | None = None, update_latest: bool = True) -> Path:
+    config = _load_config(config_path, run_id)
+    project_source = _verify_project_source_state(bool(config.get("require_committed_source", False)))
+    run_dir = PROJECT_ROOT / "artifacts" / "p2" / config["run_id"]
+    if run_dir.exists() and any(run_dir.iterdir()):
+        raise FileExistsError(f"refusing to overwrite non-empty evidence directory: {run_dir}")
+    run_dir.mkdir(parents=True, exist_ok=True)
+    logger = _logger(run_dir / "full.log")
+    (run_dir / "config.resolved.yaml").write_text(
+        yaml.safe_dump(config, sort_keys=False, allow_unicode=True), encoding="utf-8"
+    )
+    (run_dir / "command.txt").write_text("run_p2.cmd\n", encoding="utf-8")
+    started = time.perf_counter()
+
+    source_root = (PROJECT_ROOT / config["runtime_root"]).resolve()
+    if not source_root.is_dir():
+        raise FileNotFoundError(f"runtime_root does not exist: {source_root}")
+    checks = _verify_source(source_root, config["source_fingerprints"])
+    sys.path.insert(0, str(source_root))
+    os.chdir(PROJECT_ROOT)
+    import torch
+    from ultralytics import YOLO
+
+    seed = int(config["seed"])
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    logger.info("scope=E3 P2 five-family feasibility and truthful spatial overlay")
+    logger.info("source_ref=%s source_tree=%s", config["official_runtime_ref"], config["official_runtime_tree"])
+    logger.info("device=cpu cuda_available=%s seed=%d", torch.cuda.is_available(), seed)
+
+    paths, dataset_meta = _resolve_images(config["dataset"], config["dataset_split"], config["sample_indices"])
+    tensors, originals, inputs = _prepare_inputs(paths, config["sample_indices"], int(config["image_size"]), torch)
+    _archive_input_previews(paths, originals, inputs, run_dir)
+    input_record = {**dataset_meta, "selected_image_count": len(inputs), "images": inputs}
+    input_record["input_set_sha256"] = hashlib.sha256(
+        "\n".join(f"{item['sample_index']}:{item['sha256']}" for item in inputs).encode("utf-8")
+    ).hexdigest()
+    input_record["annotation_set_sha256"] = hashlib.sha256(
+        "\n".join(f"{item['sample_index']}:{item['label_sha256']}" for item in inputs).encode("utf-8")
+    ).hexdigest()
+    input_record["image_and_annotation_set_sha256"] = hashlib.sha256(
+        "\n".join(
+            f"{item['sample_index']}:{item['sha256']}:{item['label_sha256']}" for item in inputs
+        ).encode("utf-8")
+    ).hexdigest()
+    write_json(run_dir / "input.json", input_record)
+    write_json(run_dir / "source-fingerprint-checks.json", checks)
+
+    feasibility: dict[str, Any] = {}
+    capture_metadata: list[dict[str, Any]] = []
+    arrays: dict[str, np.ndarray] = {}
+    overview_cards: list[dict[str, str]] = []
+    for family, profile in config["spatial_profiles"].items():
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
+        family_summary, family_metadata, family_arrays, family_cards = _run_spatial_family(
+            family=family,
+            profile=profile,
+            source_root=source_root,
+            tensors=tensors,
+            originals=originals,
+            inputs=inputs,
+            run_dir=run_dir,
+            alpha=float(config["overlay_alpha"]),
+            torch_module=torch,
+            yolo_class=YOLO,
+            logger=logger,
+            batch_equivalence_sizes=config["batch_equivalence_sizes"],
+        )
+        feasibility[family] = family_summary
+        capture_metadata.extend(family_metadata)
+        arrays.update(family_arrays)
+        overview_cards.extend(family_cards)
+
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    feasibility["moe"] = _audit_moe(source_root, tensors[0], torch, YOLO)
+    logger.info("family=moe unsupported observed_shapes=%s", feasibility["moe"]["observed_shapes"])
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    feasibility["latent"] = _audit_latent(source_root, tensors[0], torch, YOLO)
+    logger.info("family=latent unsupported captures=%s", feasibility["latent"]["captured_modules"])
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    feasibility["molora"] = _audit_molora(torch)
+    logger.info("family=molora unsupported variants=%s", feasibility["molora"]["captured_router_variants"])
+
+    np.savez_compressed(run_dir / "spatial-routing-raw.npz", **arrays)
+    write_json(run_dir / "spatial-captures.json", capture_metadata)
+    write_json(run_dir / "spatial-diagnostics.json", _aggregate_spatial_diagnostics(capture_metadata))
+    region_analysis = aggregate_region_diagnostics(capture_metadata)
+    write_json(run_dir / "region-routing-analysis.json", region_analysis)
+    write_json(run_dir / "family-feasibility.json", feasibility)
+    save_overview(overview_cards, str(run_dir / "routing-overview.png"))
+
+    demo_entries = []
+    for metadata in capture_metadata:
+        family = metadata["family"]
+        sample_index = metadata["sample_index"]
+        sample_name = next(item["name"] for item in inputs if item["sample_index"] == sample_index)
+        module = metadata["module"]
+        module_slug = _slug(module)
+        shape = metadata["validation"]["shape"]
+        dominant_path = Path("overlays") / family / f"sample-{sample_index}--{module_slug}--dominant.png"
+        dominant_entry = {
+            "family": family,
+            "sample_index": sample_index,
+            "sample_name": sample_name,
+            "module": module,
+            "view": "dominant",
+            "expert_index": None,
+            "expert_label": "dominant expert",
+            "path": dominant_path.as_posix(),
+            "source_shape": shape,
+            "original_path": next(
+                item["artifact_path"] for item in inputs if item["sample_index"] == sample_index
+            ),
+            "annotated_original_path": next(
+                item["annotated_artifact_path"] for item in inputs if item["sample_index"] == sample_index
+            ),
+            "diagnostics": metadata["diagnostics"],
+            "region_diagnostics": metadata["region_diagnostics"],
+        }
+        if dominant_path.is_file() or (run_dir / dominant_path).is_file():
+            demo_entries.append(dominant_entry)
+        labels = config["spatial_profiles"][family]["expert_labels"]
+        for stats in metadata["expert_stats"]:
+            expert_index = stats["expert_index"]
+            label = labels[expert_index]
+            relative = (
+                Path("overlays")
+                / family
+                / f"sample-{sample_index}--{module_slug}--expert-{expert_index}-{_slug(label)}.png"
+            )
+            demo_entries.append(
+                {
+                    "family": family,
+                    "sample_index": sample_index,
+                    "sample_name": sample_name,
+                    "module": module,
+                    "view": "probability",
+                    "expert_index": expert_index,
+                    "expert_label": label,
+                    "path": relative.as_posix(),
+                    "source_shape": shape,
+                    "stats": stats,
+                    "original_path": next(
+                        item["artifact_path"] for item in inputs if item["sample_index"] == sample_index
+                    ),
+                    "annotated_original_path": next(
+                        item["annotated_artifact_path"]
+                        for item in inputs
+                        if item["sample_index"] == sample_index
+                    ),
+                    "region_diagnostics": metadata["region_diagnostics"],
+                }
+            )
+        metric_specs = {
+            "normalized_entropy": ("entropy", "normalized routing entropy"),
+            "top1_margin": ("margin", "top-1 routing margin"),
+        }
+        for field_name, (view_name, label) in metric_specs.items():
+            relative = Path("overlays") / family / f"sample-{sample_index}--{module_slug}--{view_name}.png"
+            demo_entries.append(
+                {
+                    "family": family,
+                    "sample_index": sample_index,
+                    "sample_name": sample_name,
+                    "module": module,
+                    "view": view_name,
+                    "expert_index": None,
+                    "expert_label": label,
+                    "path": relative.as_posix(),
+                    "source_shape": shape,
+                    "stats": metadata["metric_stats"][field_name],
+                    "original_path": next(
+                        item["artifact_path"] for item in inputs if item["sample_index"] == sample_index
+                    ),
+                    "annotated_original_path": next(
+                        item["annotated_artifact_path"]
+                        for item in inputs
+                        if item["sample_index"] == sample_index
+                    ),
+                    "region_diagnostics": metadata["region_diagnostics"],
+                }
+            )
+    demo_asset_validation = _validate_demo_assets(run_dir, demo_entries, inputs)
+    demo_index = {
+        "schema_version": config["schema_version"],
+        "run_id": config["run_id"],
+        "interpretation": "random initialization validates capture and geometry only; it does not prove learned specialization",
+        "feasibility": feasibility,
+        "evidence_counts": {
+            "spatial_captures": len(capture_metadata),
+            "raw_arrays": len(arrays),
+            "demo_views": len(demo_entries),
+        },
+        "asset_validation": demo_asset_validation,
+        "entries": demo_entries,
+    }
+    write_json(run_dir / "demo-index.json", demo_index)
+    (run_dir / "demo.html").write_text(_demo_html(), encoding="utf-8")
+    write_json(run_dir / "environment.json", environment(torch, source_root, PROJECT_ROOT))
+
+    supported = sorted(family for family, item in feasibility.items() if item["token_overlay"] == "supported")
+    unsupported = sorted(family for family, item in feasibility.items() if item["token_overlay"] == "unsupported")
+    summary = {
+        "status": "PASS",
+        "scope": "E3 P2 five-family feasibility audit plus true MoT/MoA spatial overlays and local demo",
+        "run_id": config["run_id"],
+        "schema_version": config["schema_version"],
+        "official_locked_base_ref": config["official_locked_base_ref"],
+        "official_runtime_ref": config["official_runtime_ref"],
+        "official_runtime_tree": config["official_runtime_tree"],
+        "official_source_archive_url": config["official_source_archive_url"],
+        "official_source_archive_sha256": config["official_source_archive_sha256"],
+        "input": input_record,
+        "source_fingerprint_validation": "PASS",
+        "source_fingerprint_count": len(checks),
+        "tool_source": project_source,
+        "families_audited": sorted(feasibility),
+        "token_overlay_supported": supported,
+        "token_overlay_unsupported": unsupported,
+        "true_spatial_capture_count": len(capture_metadata),
+        "raw_array_count": len(arrays),
+        "demo_entry_count": len(demo_entries),
+        "demo_asset_validation": demo_asset_validation,
+        "single_vs_batch_equivalence": {
+            family: feasibility[family]["single_vs_batch_equivalence"] for family in supported
+        },
+        "hook_output_equivalence": "PASS",
+        "geometry_contract": "letterbox upsample -> exact integer unpad -> original-size bilinear mapping",
+        "region_analysis": {
+            "status": "PASS",
+            "artifact": "region-routing-analysis.json",
+            "assignment_rule": region_analysis["method"]["assignment_rule"],
+            "padding_policy": region_analysis["method"]["padding_policy"],
+            "primary_conclusion_basis": region_analysis["method"]["primary_conclusion_basis"],
+        },
+        "interpretation_boundary": "random initialization; pipeline evidence only, not learned specialization",
+        "duration_seconds_observation_only": time.perf_counter() - started,
+    }
+    write_json(run_dir / "summary.json", summary)
+    write_manifest(run_dir)
+    logger.info(
+        "status=PASS supported=%s unsupported=%s captures=%d demo_entries=%d",
+        supported,
+        unsupported,
+        len(capture_metadata),
+        len(demo_entries),
+    )
+    for handler in logger.handlers:
+        handler.flush()
+    write_manifest(run_dir)
+    if update_latest:
+        latest = PROJECT_ROOT / "artifacts" / "p2" / "LATEST.txt"
+        latest.parent.mkdir(parents=True, exist_ok=True)
+        latest.write_text(config["run_id"] + "\n", encoding="utf-8")
+    return run_dir
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=Path, default=PROJECT_ROOT / "configs" / "p2" / "p2.yaml")
+    parser.add_argument("--run-id")
+    parser.add_argument("--no-latest", action="store_true")
+    args = parser.parse_args(argv)
+    print(run(args.config, run_id=args.run_id, update_latest=not args.no_latest))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/e3_routing/src/e3_p2/scale_runner.py
+++ b/tools/e3_routing/src/e3_p2/scale_runner.py
@@ -1,0 +1,805 @@
+"""CPU-only image-level scaling study for MoA appearance routing."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import random
+import shutil
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import yaml
+from PIL import Image, ImageDraw
+
+from .appearance_runner import _apply_transform, _font, _summarize_input_effects, _tensor
+from .capture import max_output_delta
+from .detector_output import detector_output_comparison
+from .geometry import LetterboxMeta, letterbox
+from .io_utils import environment, sha256_file, write_json, write_manifest
+from .layer_drilldown import margin_bin_summary
+from .regions import label_path_for_image, parse_yolo_labels, token_region_masks
+from .robustness_runner import _capture_once
+from .runner import (
+    PROJECT_ROOT,
+    RUN_ID_PATTERN,
+    _detach_tree,
+    _logger,
+    _resolve_images,
+    _slug,
+    _verify_project_source_state,
+    _verify_source,
+)
+from .stability import probability_map_comparison, restore_probability_stack
+
+
+def _load_config(path: Path, run_id_override: str | None) -> dict[str, Any]:
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise TypeError(f"config must contain a mapping: {path}")
+    config = dict(loaded)
+    run_id = str(run_id_override if run_id_override is not None else config.get("run_id", "")).strip()
+    if not RUN_ID_PATTERN.fullmatch(run_id):
+        raise ValueError("run_id must be path-safe and at most 128 characters")
+    config["run_id"] = run_id
+    if config.get("device") != "cpu" or int(config.get("resolution", 0)) < 32:
+        raise ValueError("scale study requires CPU and resolution >= 32")
+    if config.get("family") != "moa" or not str(config.get("target_module", "")).strip():
+        raise ValueError("scale study is intentionally scoped to MoA and requires target_module")
+    seeds = [int(value) for value in config.get("seeds", [])]
+    if len(seeds) < 2 or len(set(seeds)) != len(seeds):
+        raise ValueError("seeds must contain at least two unique integers")
+    config["seeds"] = seeds
+    image_count = int(config.get("selected_image_count", 0))
+    dataset_count = int(config.get("expected_dataset_image_count", 0))
+    if image_count < 16 or dataset_count < image_count:
+        raise ValueError("selected_image_count must be >=16 and <= expected_dataset_image_count")
+    if not str(config.get("selection_salt", "")):
+        raise ValueError("selection_salt is required")
+    transforms = config.get("transformations")
+    study_kind = str(config.get("study_kind", "image_scale"))
+    if not isinstance(transforms, list) or len(transforms) < 4:
+        raise ValueError("scale study requires identity plus at least three perturbations")
+    names = [str(item.get("name", "")) for item in transforms if isinstance(item, dict)]
+    if len(names) != len(transforms) or len(set(names)) != len(names) or names[0] != "identity":
+        raise ValueError("transform names must be unique and identity must be first")
+    expected_transforms = [
+        {"name": "identity", "kind": "identity"},
+        {"name": "brightness_090", "kind": "brightness", "factor": 0.9},
+        {"name": "contrast_090", "kind": "contrast", "factor": 0.9},
+        {"name": "gaussian_blur_075", "kind": "gaussian_blur", "radius": 0.75},
+    ]
+    if study_kind == "image_scale" and transforms != expected_transforms:
+        raise ValueError(f"transform contract must remain fixed: {expected_transforms}")
+    if study_kind not in {"image_scale", "dose_response", "output_coupling"}:
+        raise ValueError(f"unsupported scale study_kind: {study_kind}")
+    if study_kind == "dose_response" and len(transforms) < 10:
+        raise ValueError("dose_response requires identity plus at least nine predeclared conditions")
+    if study_kind == "output_coupling" and (len(transforms) != 4 or not config.get("record_detector_outputs")):
+        raise ValueError("output_coupling requires identity plus three conditions and detector-output recording")
+    if int(config.get("bootstrap_draws", 0)) < 1000:
+        raise ValueError("bootstrap_draws must be at least 1000")
+    if int(config.get("max_evidence_bytes", 0)) < 1_000_000:
+        raise ValueError("max_evidence_bytes must be at least 1 MB")
+    return config
+
+
+def deterministic_image_selection(
+    paths: list[Path], count: int, salt: str
+) -> tuple[list[Path], list[dict[str, Any]]]:
+    """Select a stable subset without looking at image contents or model outputs."""
+
+    if count <= 0 or count > len(paths) or not salt:
+        raise ValueError("invalid deterministic selection request")
+    if len({path.name for path in paths}) != len(paths):
+        raise ValueError("dataset image names must be unique for path-independent selection")
+    ranked = []
+    for dataset_index, path in enumerate(paths):
+        key = hashlib.sha256(f"{salt}\0{path.name}".encode()).hexdigest()
+        ranked.append((key, path.name, dataset_index, path))
+    ranked.sort()
+    selected = ranked[:count]
+    records = [
+        {
+            "sample_index": sample_index,
+            "dataset_sorted_index": dataset_index,
+            "name": name,
+            "selection_sha256": key,
+        }
+        for sample_index, (key, name, dataset_index, _) in enumerate(selected)
+    ]
+    return [item[3] for item in selected], records
+
+
+def bootstrap_mean_interval(values: np.ndarray, draws: int, seed: int) -> dict[str, Any]:
+    array = np.asarray(values, dtype=np.float64).reshape(-1)
+    if array.size < 2 or not np.isfinite(array).all() or draws < 100:
+        raise ValueError("bootstrap requires finite values, at least two units and at least 100 draws")
+    rng = np.random.default_rng(seed)
+    indices = rng.integers(0, array.size, size=(draws, array.size))
+    estimates = array[indices].mean(axis=1)
+    return {
+        "unit_count": int(array.size),
+        "draws": draws,
+        "seed": seed,
+        "observed_mean": float(array.mean()),
+        "percentile_95_interval": [float(value) for value in np.percentile(estimates, [2.5, 97.5])],
+        "bootstrap_median": float(np.median(estimates)),
+    }
+
+
+def bootstrap_layer_share_interval(
+    image_by_layer: np.ndarray, target_index: int, draws: int, seed: int
+) -> dict[str, Any]:
+    matrix = np.asarray(image_by_layer, dtype=np.float64)
+    if matrix.ndim != 2 or matrix.shape[0] < 2 or not 0 <= target_index < matrix.shape[1]:
+        raise ValueError("image_by_layer must be [image,layer] with a valid target index")
+    if not np.isfinite(matrix).all() or (matrix < 0.0).any():
+        raise ValueError("layer values must be finite and non-negative")
+    rng = np.random.default_rng(seed)
+    indices = rng.integers(0, matrix.shape[0], size=(draws, matrix.shape[0]))
+    estimates = matrix[indices].mean(axis=1)
+    denominators = estimates.sum(axis=1)
+    if (denominators <= 0.0).any():
+        raise ValueError("bootstrap produced a non-positive layer sum")
+    shares = estimates[:, target_index] / denominators
+    ranks_first = estimates[:, target_index] >= estimates.max(axis=1)
+    observed = matrix.mean(axis=0)
+    return {
+        "image_unit_count": int(matrix.shape[0]),
+        "draws": draws,
+        "seed": seed,
+        "observed_target_share": float(observed[target_index] / observed.sum()),
+        "percentile_95_interval": [float(value) for value in np.percentile(shares, [2.5, 97.5])],
+        "bootstrap_median": float(np.median(shares)),
+        "target_rank_one_draw_fraction": float(ranks_first.mean()),
+    }
+
+
+def summarize_image_level_attribution(
+    comparisons: list[dict[str, Any]],
+    transforms: list[str],
+    target_module: str,
+    bootstrap_draws: int,
+    bootstrap_seed: int,
+) -> dict[str, Any]:
+    """Keep images as the inferential unit for ranks, leave-one-out and bootstrap."""
+
+    selected = [
+        item
+        for item in comparisons
+        if item["family"] == "moa"
+        and item["comparison_type"].removeprefix("appearance_") in transforms
+    ]
+    images = sorted({int(item["sample_index"]) for item in selected})
+    seeds = sorted({int(item["seed"]) for item in selected})
+    modules = sorted({item["module"] for item in selected})
+    if target_module not in modules or not images or not seeds:
+        raise ValueError("comparison matrix is missing images, seeds or target module")
+    lookup = {
+        (
+            int(item["sample_index"]),
+            item["comparison_type"].removeprefix("appearance_"),
+            int(item["seed"]),
+            item["module"],
+        ): float(item["metrics"]["probability_mae"])
+        for item in selected
+    }
+    expected = len(images) * len(transforms) * len(seeds) * len(modules)
+    if len(lookup) != expected:
+        raise ValueError(f"incomplete image-level comparison matrix: {len(lookup)} != {expected}")
+    target_index = modules.index(target_module)
+
+    case_rankings = []
+    image_transform_rankings = []
+    image_rankings = []
+    for image in images:
+        for transform in transforms:
+            for seed in seeds:
+                values = np.asarray([lookup[(image, transform, seed, module)] for module in modules])
+                ranking = np.argsort(-values, kind="stable")
+                case_rankings.append(
+                    {
+                        "sample_index": image,
+                        "transform": transform,
+                        "seed": seed,
+                        "target_rank": int(np.where(ranking == target_index)[0][0]) + 1,
+                        "rank_one_module": modules[int(ranking[0])],
+                    }
+                )
+            means = np.asarray(
+                [np.mean([lookup[(image, transform, seed, module)] for seed in seeds]) for module in modules]
+            )
+            ranking = np.argsort(-means, kind="stable")
+            image_transform_rankings.append(
+                {
+                    "sample_index": image,
+                    "transform": transform,
+                    "target_rank": int(np.where(ranking == target_index)[0][0]) + 1,
+                    "rank_one_module": modules[int(ranking[0])],
+                    "target_share_of_layer_mean_mae_sum": float(means[target_index] / means.sum()),
+                }
+            )
+        means = np.asarray(
+            [
+                np.mean([lookup[(image, transform, seed, module)] for transform in transforms for seed in seeds])
+                for module in modules
+            ]
+        )
+        ranking = np.argsort(-means, kind="stable")
+        image_rankings.append(
+            {
+                "sample_index": image,
+                "target_rank": int(np.where(ranking == target_index)[0][0]) + 1,
+                "rank_one_module": modules[int(ranking[0])],
+                "target_share_of_layer_mean_mae_sum": float(means[target_index] / means.sum()),
+            }
+        )
+
+    leave_one_out = []
+    bootstrap = {}
+    for transform_index, transform in enumerate(transforms):
+        matrix = np.asarray(
+            [
+                [np.mean([lookup[(image, transform, seed, module)] for seed in seeds]) for module in modules]
+                for image in images
+            ],
+            dtype=np.float64,
+        )
+        for omitted_index, image in enumerate(images):
+            means = np.delete(matrix, omitted_index, axis=0).mean(axis=0)
+            ranking = np.argsort(-means, kind="stable")
+            leave_one_out.append(
+                {
+                    "transform": transform,
+                    "omitted_sample_index": image,
+                    "target_rank": int(np.where(ranking == target_index)[0][0]) + 1,
+                    "rank_one_module": modules[int(ranking[0])],
+                    "target_share_of_layer_mean_mae_sum": float(means[target_index] / means.sum()),
+                }
+            )
+        bootstrap[transform] = bootstrap_layer_share_interval(
+            matrix, target_index, bootstrap_draws, bootstrap_seed + transform_index
+        )
+
+    return {
+        "method": {
+            "metric": "original-coordinate probability MAE",
+            "primary_unit": "image",
+            "within_image_aggregation": "equal mean across configured seeds and/or transforms",
+            "bootstrap": "non-parametric resampling of images with replacement; descriptive for selected coco128 subset",
+            "rank_tie_policy": "stable module order",
+        },
+        "image_count": len(images),
+        "seed_count": len(seeds),
+        "transform_count": len(transforms),
+        "module_order": modules,
+        "case_rankings": case_rankings,
+        "target_rank_one_case_count": sum(item["target_rank"] == 1 for item in case_rankings),
+        "case_count": len(case_rankings),
+        "image_transform_rankings": image_transform_rankings,
+        "target_rank_one_image_transform_count": sum(
+            item["target_rank"] == 1 for item in image_transform_rankings
+        ),
+        "image_transform_count": len(image_transform_rankings),
+        "image_rankings": image_rankings,
+        "target_rank_one_image_count": sum(item["target_rank"] == 1 for item in image_rankings),
+        "leave_one_image_out": leave_one_out,
+        "target_rank_one_leave_one_out_count": sum(item["target_rank"] == 1 for item in leave_one_out),
+        "leave_one_out_count": len(leave_one_out),
+        "bootstrap_target_share_by_transform": bootstrap,
+    }
+
+
+def summarize_image_level_switches(
+    cases: list[dict[str, Any]], transforms: list[str], draws: int, seed: int
+) -> dict[str, Any]:
+    images = sorted({int(item["sample_index"]) for item in cases})
+    by_transform = {}
+    for index, transform in enumerate(transforms):
+        image_values = []
+        for image in images:
+            values = [
+                item["dominant_switch_fraction"]
+                for item in cases
+                if item["transform"] == transform and item["sample_index"] == image
+            ]
+            if not values:
+                raise ValueError(f"missing target-layer switch cases for {transform}, image={image}")
+            image_values.append(float(np.mean(values)))
+        by_transform[transform] = {
+            "image_level_mean_switch_fraction": bootstrap_mean_interval(
+                np.asarray(image_values), draws, seed + index
+            ),
+            "image_min": float(np.min(image_values)),
+            "image_max": float(np.max(image_values)),
+            "zero_switch_image_count": sum(value == 0.0 for value in image_values),
+            "image_values": [
+                {"sample_index": image, "mean_across_seeds": value}
+                for image, value in zip(images, image_values)
+            ],
+        }
+    return {
+        "method": {
+            "unit": "image",
+            "within_image_aggregation": "equal mean across seeds",
+            "bootstrap": "images resampled with replacement",
+        },
+        "by_transform": by_transform,
+    }
+
+
+def _prepare_inputs(
+    paths: list[Path], transforms: list[dict[str, Any]], resolution: int
+) -> tuple[dict[tuple[int, str], dict[str, Any]], list[dict[str, Any]]]:
+    prepared = {}
+    audit = []
+    for sample_index, path in enumerate(paths):
+        with Image.open(path) as opened:
+            original = opened.convert("RGB")
+        for spec in transforms:
+            transformed = _apply_transform(original, spec)
+            canvas, meta = letterbox(transformed, resolution)
+            record = {
+                "sample_index": sample_index,
+                "sample_name": path.name,
+                "transform": spec["name"],
+                "spec": spec,
+                "geometry": meta.to_dict(),
+                "model_input_rgb_bytes_sha256": hashlib.sha256(canvas.tobytes()).hexdigest(),
+                "model_input_shape_hwc": [int(value) for value in canvas.shape],
+                "normalization": "RGB uint8 / 255.0",
+            }
+            prepared[(sample_index, spec["name"])] = {"canvas": canvas, "meta": meta}
+            audit.append(record)
+    return prepared, audit
+
+
+def archive_selected_inputs(paths: list[Path], run_dir: Path) -> list[dict[str, Any]]:
+    """Archive selected images and explicitly retain label-missing background samples."""
+
+    destination = run_dir / "inputs"
+    destination.mkdir(parents=True, exist_ok=True)
+    records = []
+    for sample_index, path in enumerate(paths):
+        label = label_path_for_image(path)
+        image_relative = Path("inputs") / f"sample-{sample_index}--{path.name}"
+        shutil.copyfile(path, run_dir / image_relative)
+        with Image.open(path) as image:
+            width, height = image.size
+        label_exists = label.is_file()
+        label_relative = Path("inputs") / f"sample-{sample_index}--{label.name}" if label_exists else None
+        if label_relative is not None:
+            shutil.copyfile(label, run_dir / label_relative)
+        boxes = parse_yolo_labels(label) if label_exists else []
+        records.append(
+            {
+                "sample_index": sample_index,
+                "name": path.name,
+                "original_width": width,
+                "original_height": height,
+                "sha256": sha256_file(path),
+                "label_status": "PRESENT" if label_exists else "MISSING_DATASET_LABEL",
+                "label_sha256": sha256_file(label) if label_exists else None,
+                "ground_truth_box_count": len(boxes),
+                "image_artifact": image_relative.as_posix(),
+                "label_artifact": label_relative.as_posix() if label_relative is not None else None,
+            }
+        )
+    return records
+
+
+def _save_overview(
+    attribution: dict[str, Any], switches: dict[str, Any], target_cases: list[dict[str, Any]], output: Path
+) -> None:
+    width, height = 1800, 1160
+    canvas = Image.new("RGB", (width, height), "#050c1b")
+    draw = ImageDraw.Draw(canvas)
+    title, section, body, small, metric = _font(38), _font(24), _font(18), _font(15), _font(30, mono=True)
+    draw.rounded_rectangle((40, 34, width - 40, height - 34), radius=30, fill="#09172d", outline="#21678d", width=3)
+    draw.text((80, 68), "E3 P2  /  COCO128 IMAGE-LEVEL AUDIT", fill="#00e5ff", font=title)
+    draw.text((82, 120), "32 hash-selected images · 3 seeds · 3 appearance families · CPU", fill="#9bb8d6", font=body)
+    cards = [
+        ("32", "image-level units"),
+        (
+            f"{attribution['target_rank_one_case_count']}/{attribution['case_count']}",
+            "model.16 rank #1 · image×seed×transform",
+        ),
+        (
+            f"{attribution['target_rank_one_leave_one_out_count']}/{attribution['leave_one_out_count']}",
+            "rank #1 · leave-one-image-out",
+        ),
+        ("10,000", "image-bootstrap draws / transform"),
+    ]
+    for index, (value, label) in enumerate(cards):
+        left = 82 + index * 410
+        draw.rounded_rectangle((left, 170, left + 375, 286), radius=18, fill="#0d223e", outline="#204d70", width=2)
+        draw.text((left + 20, 191), value, fill="#63e6a7", font=metric)
+        draw.text((left + 20, 247), label, fill="#a9c1da", font=small)
+
+    transforms = list(attribution["bootstrap_target_share_by_transform"])
+    draw.text((82, 340), "Model.16 share · image bootstrap", fill="#eaf4ff", font=section)
+    draw.text((82, 377), "Share of four layer-level image-mean MAEs; 95% percentile interval", fill="#829fbd", font=small)
+    for row, transform in enumerate(transforms):
+        item = attribution["bootstrap_target_share_by_transform"][transform]
+        y = 438 + row * 116
+        mean = item["observed_target_share"]
+        low, high = item["percentile_95_interval"]
+        draw.text((82, y), transform.replace("_", " "), fill="#b5cce2", font=body)
+        draw.rounded_rectangle((305, y - 2, 925, y + 40), radius=9, fill="#10233c")
+        draw.rounded_rectangle((305, y - 2, 305 + int(620 * mean), y + 40), radius=9, fill="#05bdd4")
+        draw.text((330, y + 8), f"{mean * 100:5.2f}%", fill="#ffffff", font=body)
+        draw.text((305, y + 58), f"95% [{low * 100:.2f}%, {high * 100:.2f}%]", fill="#d5b7ff", font=body)
+
+    draw.text((1050, 340), "Target-layer switch rate · image bootstrap", fill="#eaf4ff", font=section)
+    draw.text((1050, 377), "Per image: equal mean across three seeds", fill="#829fbd", font=small)
+    max_rate = max(
+        item["image_level_mean_switch_fraction"]["percentile_95_interval"][1]
+        for item in switches["by_transform"].values()
+    )
+    for row, transform in enumerate(transforms):
+        item = switches["by_transform"][transform]["image_level_mean_switch_fraction"]
+        y = 438 + row * 116
+        mean = item["observed_mean"]
+        low, high = item["percentile_95_interval"]
+        draw.text((1050, y), transform.replace("_", " "), fill="#b5cce2", font=body)
+        draw.rounded_rectangle((1280, y - 2, 1660, y + 40), radius=9, fill="#10233c")
+        if max_rate > 0.0:
+            draw.rounded_rectangle((1280, y - 2, 1280 + int(380 * mean / max_rate), y + 40), radius=9, fill="#d65c8a")
+        draw.text((1300, y + 8), f"{mean * 100:5.2f}%", fill="#ffffff", font=body)
+        draw.text((1280, y + 58), f"95% [{low * 100:.2f}%, {high * 100:.2f}%]", fill="#d5b7ff", font=body)
+
+    worst = sorted(target_cases, key=lambda item: item["dominant_switch_fraction"], reverse=True)[:5]
+    draw.text((82, 815), "Highest target-layer case switch rates", fill="#eaf4ff", font=section)
+    for index, item in enumerate(worst):
+        left = 82 + index * 330
+        draw.rounded_rectangle((left, 865, left + 300, 974), radius=14, fill="#0d223e", outline="#204d70", width=2)
+        draw.text((left + 15, 883), item["transform"].replace("_", " "), fill="#d5b7ff", font=small)
+        draw.text((left + 15, 914), f"image {item['sample_index']} · seed {item['seed']}", fill="#dcecff", font=small)
+        draw.text((left + 15, 943), f"switch {item['dominant_switch_fraction'] * 100:.2f}%", fill="#63e6a7", font=body)
+    draw.rounded_rectangle((82, 1018, 1710, 1095), radius=16, fill="#081326", outline="#213c5a", width=2)
+    draw.text(
+        (108, 1041),
+        "Guardrail: deterministic coco128 subset and random initialization; intervals describe image heterogeneity, not learned accuracy.",
+        fill="#ffcc66",
+        font=small,
+    )
+    canvas.save(output)
+
+
+def run(config_path: Path, *, run_id: str | None = None, update_latest: bool = True) -> Path:
+    config = _load_config(config_path, run_id)
+    project_source = _verify_project_source_state(bool(config.get("require_committed_source", False)))
+    run_dir = PROJECT_ROOT / "artifacts" / "p2" / config["run_id"]
+    if run_dir.exists() and any(run_dir.iterdir()):
+        raise FileExistsError(f"refusing to overwrite non-empty evidence directory: {run_dir}")
+    run_dir.mkdir(parents=True, exist_ok=True)
+    logger = _logger(run_dir / "full.log")
+    (run_dir / "config.resolved.yaml").write_text(
+        yaml.safe_dump(config, sort_keys=False, allow_unicode=True), encoding="utf-8"
+    )
+    (run_dir / "command.txt").write_text("run_image_scale.cmd\n", encoding="utf-8")
+    started = time.perf_counter()
+    source_root = (PROJECT_ROOT / config["runtime_root"]).resolve()
+    checks = _verify_source(source_root, config["source_fingerprints"])
+    sys.path.insert(0, str(source_root))
+    os.chdir(PROJECT_ROOT)
+    import torch
+    from ultralytics import YOLO
+
+    expected_count = int(config["expected_dataset_image_count"])
+    all_paths, dataset_meta = _resolve_images(config["dataset"], config["dataset_split"], list(range(expected_count)))
+    if dataset_meta["split_image_count"] != expected_count:
+        raise RuntimeError(
+            f"dataset image count drift: {dataset_meta['split_image_count']} != {expected_count}"
+        )
+    paths, selection = deterministic_image_selection(
+        all_paths, int(config["selected_image_count"]), config["selection_salt"]
+    )
+    sample_indices = list(range(len(paths)))
+    archived_inputs = archive_selected_inputs(paths, run_dir)
+    prepared, canvas_audit = _prepare_inputs(paths, config["transformations"], int(config["resolution"]))
+    transform_names = [item["name"] for item in config["transformations"]]
+    candidate_names = transform_names[1:]
+    effects = _summarize_input_effects(prepared, sample_indices, transform_names)
+    for item, selected in zip(archived_inputs, selection):
+        item.update(
+            {
+                "dataset_sorted_index": selected["dataset_sorted_index"],
+                "selection_sha256": selected["selection_sha256"],
+            }
+        )
+    input_record = {
+        **dataset_meta,
+        "selection_method": "ascending SHA-256(selection_salt + NUL + unique filename)",
+        "selection_salt": config["selection_salt"],
+        "selected_image_count": len(paths),
+        "selection": selection,
+        "images": archived_inputs,
+        "selected_image_and_label_set_sha256": hashlib.sha256(
+            "\n".join(
+                f"{item['sample_index']}:{item['sha256']}:{item['label_sha256'] or 'NO_LABEL'}"
+                for item in archived_inputs
+            ).encode("utf-8")
+        ).hexdigest(),
+    }
+    write_json(run_dir / "input.json", input_record)
+    write_json(run_dir / "model-input-audit.json", canvas_audit)
+    write_json(run_dir / "transformation-effect.json", effects)
+    write_json(run_dir / "source-fingerprint-checks.json", checks)
+
+    family = config["family"]
+    target_module = config["target_module"]
+    resolution = int(config["resolution"])
+    profile = config["profile"]
+    arrays: dict[str, np.ndarray] = {}
+    captures = []
+    comparisons = []
+    target_cases = []
+    detector_comparisons = []
+    all_margins: dict[str, list[np.ndarray]] = defaultdict(list)
+    all_switches: dict[str, list[np.ndarray]] = defaultdict(list)
+    invariants = {}
+    module_order: list[str] | None = None
+    logger.info(
+        "scope=MoA image-level scale dataset=%s images=%d transforms=%s seeds=%s",
+        config["dataset"], len(paths), transform_names, config["seeds"],
+    )
+
+    for seed in config["seeds"]:
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
+        wrapper = YOLO(source_root / profile["model_config"])
+        model = wrapper.model.to("cpu").eval()
+        representative = _tensor(prepared[(0, "identity")]["canvas"], torch)
+        with torch.inference_mode():
+            baseline_output = _detach_tree(model(representative))
+        hooked_output, first_records, current_order = _capture_once(
+            model, family, profile["router_class"], representative, torch
+        )
+        _, repeat_records, repeat_order = _capture_once(
+            model, family, profile["router_class"], representative, torch
+        )
+        hook_delta = max_output_delta(baseline_output, hooked_output)
+        repeat_weight_delta = max(
+            float(np.max(np.abs(first.weights - second.weights)))
+            for first, second in zip(first_records, repeat_records)
+        )
+        repeat_logit_delta = max(
+            float(np.max(np.abs(first.logits - second.logits)))
+            for first, second in zip(first_records, repeat_records)
+        )
+        if hook_delta != 0.0 or repeat_weight_delta != 0.0 or repeat_logit_delta != 0.0 or current_order != repeat_order:
+            raise RuntimeError(f"representative invariant failure for seed={seed}")
+        if target_module not in current_order or (module_order is not None and current_order != module_order):
+            raise RuntimeError(f"router module order or target changed for seed={seed}")
+        module_order = current_order
+        invariants[f"seed-{seed}"] = {
+            "hook_output_max_abs_delta": hook_delta,
+            "repeat_weight_max_abs_delta": repeat_weight_delta,
+            "repeat_logit_max_abs_delta": repeat_logit_delta,
+            "module_order": current_order,
+            "hook_cleanup": True,
+            "status": "PASS",
+        }
+
+        for sample_index, path in enumerate(paths):
+            restored = {}
+            raw_weights = {}
+            detector_outputs = {}
+            for transform in transform_names:
+                prepared_item = prepared[(sample_index, transform)]
+                tensor = _tensor(prepared_item["canvas"], torch)
+                current_output, records, registered = _capture_once(
+                    model, family, profile["router_class"], tensor, torch
+                )
+                if config.get("record_detector_outputs"):
+                    detector_outputs[transform] = current_output
+                if registered != module_order:
+                    raise RuntimeError("module order changed during image-level capture")
+                meta: LetterboxMeta = prepared_item["meta"]
+                for record in records:
+                    weights = record.weights[0]
+                    aligned, restoration = restore_probability_stack(weights, meta)
+                    restored[(transform, record.module_name)] = aligned
+                    raw_weights[(transform, record.module_name)] = weights
+                    key = (
+                        f"{family}__seed-{seed}__sample-{sample_index}__{transform}__"
+                        f"{_slug(record.module_name)}__weights"
+                    )
+                    arrays[key] = record.weights
+                    captures.append(
+                        {
+                            "family": family,
+                            "seed": seed,
+                            "sample_index": sample_index,
+                            "sample_name": path.name,
+                            "resolution": resolution,
+                            "transformation": transform,
+                            "module": record.module_name,
+                            "module_type": record.module_type,
+                            "source_shape": record.validation["shape"],
+                            "geometry": meta.to_dict(),
+                            "router_validation": record.validation,
+                            "restoration_validation": restoration,
+                            "raw_weights_key": key,
+                        }
+                    )
+            for module in module_order:
+                reference = restored[("identity", module)]
+                for transform in candidate_names:
+                    comparisons.append(
+                        {
+                            "comparison_type": f"appearance_{transform}",
+                            "family": family,
+                            "seed": seed,
+                            "sample_index": sample_index,
+                            "module": module,
+                            "reference_resolution": resolution,
+                            "candidate_resolution": resolution,
+                            "alignment": "same geometry; both maps restored to original-image pixels",
+                            "metrics": probability_map_comparison(reference, restored[(transform, module)]),
+                        }
+                    )
+            if config.get("record_detector_outputs"):
+                for transform in candidate_names:
+                    detector_comparisons.append(
+                        {
+                            "seed": seed,
+                            "sample_index": sample_index,
+                            "transform": transform,
+                            "reference": "identity",
+                            "metrics": detector_output_comparison(
+                                detector_outputs["identity"], detector_outputs[transform]
+                            ),
+                        }
+                    )
+            reference_target = raw_weights[("identity", target_module)]
+            target_meta: LetterboxMeta = prepared[(sample_index, "identity")]["meta"]
+            label_path = label_path_for_image(path)
+            boxes = parse_yolo_labels(label_path) if label_path.is_file() else []
+            masks = token_region_masks(
+                boxes, target_meta, reference_target.shape[1], reference_target.shape[2]
+            )
+            valid = ~masks["padding"]
+            if seed == config["seeds"][0]:
+                arrays[f"{family}__sample-{sample_index}__{_slug(target_module)}__mask-padding"] = masks[
+                    "padding"
+                ]
+            ordered = np.sort(reference_target.astype(np.float64), axis=0)
+            margin = ordered[-1] - ordered[-2]
+            for transform in candidate_names:
+                candidate_target = raw_weights[(transform, target_module)]
+                difference = np.abs(reference_target.astype(np.float64) - candidate_target.astype(np.float64))
+                switched = np.argmax(reference_target, axis=0) != np.argmax(candidate_target, axis=0)
+                valid_margin = margin[valid]
+                valid_switched = switched[valid]
+                threshold_30 = float(np.quantile(valid_margin, 0.30))
+                low_30 = valid_margin <= threshold_30
+                record = {
+                    "transform": transform,
+                    "seed": seed,
+                    "sample_index": sample_index,
+                    "valid_token_count": int(valid.sum()),
+                    "padding_token_count": int(masks["padding"].sum()),
+                    "probability_mae": float(difference[:, valid].mean()),
+                    "dominant_switch_count": int(valid_switched.sum()),
+                    "dominant_switch_fraction": float(valid_switched.mean()),
+                    "reference_margin_mean": float(valid_margin.mean()),
+                    "within_case_margin_p30": threshold_30,
+                    "switch_count_at_or_below_margin_p30": int(valid_switched[low_30].sum()),
+                    "switch_count_above_margin_p30": int(valid_switched[~low_30].sum()),
+                }
+                target_cases.append(record)
+                all_margins[transform].append(valid_margin)
+                all_switches[transform].append(valid_switched)
+                all_margins["overall"].append(valid_margin)
+                all_switches["overall"].append(valid_switched)
+            if (sample_index + 1) % 8 == 0:
+                logger.info("seed=%d progress=%d/%d", seed, sample_index + 1, len(paths))
+        del model, wrapper
+
+    np.savez_compressed(run_dir / "image-scale-routing-raw.npz", **arrays)
+    write_json(run_dir / "spatial-captures.json", captures)
+    write_json(run_dir / "image-scale-comparisons.json", comparisons)
+    write_json(run_dir / "target-layer-cases.json", target_cases)
+    if config.get("record_detector_outputs"):
+        write_json(run_dir / "detector-output-comparisons.json", detector_comparisons)
+    attribution = summarize_image_level_attribution(
+        comparisons,
+        candidate_names,
+        target_module,
+        int(config["bootstrap_draws"]),
+        int(config["bootstrap_seed"]),
+    )
+    switch_summary = summarize_image_level_switches(
+        target_cases, candidate_names, int(config["bootstrap_draws"]), int(config["bootstrap_seed"]) + 100
+    )
+    margin_deciles = {
+        key: margin_bin_summary(np.concatenate(all_margins[key]), np.concatenate(all_switches[key]))
+        for key in [*candidate_names, "overall"]
+    }
+    write_json(run_dir / "image-level-attribution.json", attribution)
+    write_json(run_dir / "image-level-switches.json", switch_summary)
+    write_json(
+        run_dir / "margin-deciles.json",
+        {
+            "method": {
+                "scope": "target-module raw tokens; letterbox padding excluded",
+                "unit": "token-comparison exposure; descriptive localization only",
+            },
+            "by_transform_and_overall": margin_deciles,
+        },
+    )
+    write_json(run_dir / "invariants.json", invariants)
+    write_json(run_dir / "environment.json", environment(torch, source_root, PROJECT_ROOT))
+    _save_overview(attribution, switch_summary, target_cases, run_dir / "image-level-overview.png")
+    summary = {
+        "status": "PASS",
+        "scope": "CPU-only 32-image MoA appearance audit with image-level resampling",
+        "run_id": config["run_id"],
+        "tool_source": project_source,
+        "official_locked_base_ref": config["official_locked_base_ref"],
+        "official_runtime_ref": config["official_runtime_ref"],
+        "source_fingerprint_validation": "PASS",
+        "source_fingerprint_count": len(checks),
+        "device": "cpu",
+        "dataset": config["dataset"],
+        "dataset_split_image_count": dataset_meta["split_image_count"],
+        "selected_image_count": len(paths),
+        "selection_salt": config["selection_salt"],
+        "seeds": config["seeds"],
+        "resolution": resolution,
+        "transformations": config["transformations"],
+        "transformation_effect": effects["by_transform"],
+        "spatial_capture_count": len(captures),
+        "raw_array_count": len(arrays),
+        "aligned_comparison_count": len(comparisons),
+        "target_case_count": len(target_cases),
+        "detector_output_comparison_count": len(detector_comparisons),
+        "image_level_attribution": {
+            "target_rank_one_case_count": attribution["target_rank_one_case_count"],
+            "case_count": attribution["case_count"],
+            "target_rank_one_image_count": attribution["target_rank_one_image_count"],
+            "image_count": attribution["image_count"],
+            "target_rank_one_leave_one_out_count": attribution["target_rank_one_leave_one_out_count"],
+            "leave_one_out_count": attribution["leave_one_out_count"],
+        },
+        "representative_invariants": invariants,
+        "restoration_validation": {
+            "max_pre_normalization_expert_sum_error": max(
+                item["restoration_validation"]["pre_normalization_max_expert_sum_error"] for item in captures
+            ),
+            "max_post_normalization_expert_sum_error": max(
+                item["restoration_validation"]["post_normalization_max_expert_sum_error"] for item in captures
+            ),
+        },
+        "interpretation_boundary": "deterministic coco128 subset and random initialization; no learned accuracy claim",
+        "duration_seconds_observation_only": time.perf_counter() - started,
+    }
+    write_json(run_dir / "summary.json", summary)
+    logger.info(
+        "status=PASS images=%d captures=%d comparisons=%d target_cases=%d",
+        len(paths), len(captures), len(comparisons), len(target_cases),
+    )
+    for handler in logger.handlers:
+        handler.flush()
+    evidence_bytes = sum(path.stat().st_size for path in run_dir.rglob("*") if path.is_file())
+    if evidence_bytes > int(config["max_evidence_bytes"]):
+        raise RuntimeError(f"evidence budget exceeded: {evidence_bytes} > {config['max_evidence_bytes']}")
+    summary["evidence_bytes_before_manifest"] = evidence_bytes
+    write_json(run_dir / "summary.json", summary)
+    final_bytes = sum(path.stat().st_size for path in run_dir.rglob("*") if path.is_file())
+    if final_bytes > int(config["max_evidence_bytes"]):
+        raise RuntimeError(f"final evidence budget exceeded: {final_bytes} > {config['max_evidence_bytes']}")
+    write_manifest(run_dir)
+    if update_latest:
+        latest = PROJECT_ROOT / "artifacts" / "p2" / "IMAGE_SCALE_LATEST.txt"
+        latest.parent.mkdir(parents=True, exist_ok=True)
+        latest.write_text(config["run_id"] + "\n", encoding="utf-8")
+    return run_dir

--- a/tools/e3_routing/src/e3_p2/stability.py
+++ b/tools/e3_routing/src/e3_p2/stability.py
@@ -1,0 +1,236 @@
+"""Probability-map restoration and transformation-stability metrics."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+import numpy as np
+
+from .geometry import LetterboxMeta, restore_heatmap, validate_probability_grid
+
+
+def restore_probability_stack(weights: np.ndarray, meta: LetterboxMeta) -> tuple[np.ndarray, dict[str, float]]:
+    """Restore ``[E,H,W]`` probabilities to original pixels and re-normalize experts.
+
+    Bilinear interpolation is applied to each expert independently. Floating-point
+    interpolation can move the expert sum slightly away from one, so the restored
+    stack is explicitly normalized and both pre/post errors are retained as evidence.
+    """
+
+    values = np.asarray(weights, dtype=np.float32)
+    if values.ndim != 3:
+        raise ValueError(f"expected [E,H,W], got shape={list(values.shape)}")
+    validate_probability_grid(values[None, ...])
+    restored = np.stack([restore_heatmap(field, meta) for field in values], axis=0).astype(np.float32)
+    if not np.isfinite(restored).all() or float(restored.min()) < -1e-6:
+        raise ValueError("restored probability stack is not finite and non-negative")
+    sums = restored.sum(axis=0, keepdims=True)
+    pre_error = float(np.max(np.abs(sums - 1.0)))
+    if float(sums.min()) <= 0.0:
+        raise ValueError("restored expert sum contains a non-positive pixel")
+    normalized = restored / sums
+    post_error = float(np.max(np.abs(normalized.sum(axis=0) - 1.0)))
+    return normalized.astype(np.float32), {
+        "pre_normalization_max_expert_sum_error": pre_error,
+        "post_normalization_max_expert_sum_error": post_error,
+    }
+
+
+def _validate_probability_stack(value: np.ndarray, name: str) -> np.ndarray:
+    values = np.asarray(value, dtype=np.float32)
+    if values.ndim != 3 or min(values.shape) <= 0:
+        raise ValueError(f"{name} must be a non-empty [E,H,W] stack")
+    if not np.isfinite(values).all() or float(values.min()) < -1e-6:
+        raise ValueError(f"{name} must contain finite non-negative probabilities")
+    error = float(np.max(np.abs(values.sum(axis=0) - 1.0)))
+    if error > 1e-5:
+        raise ValueError(f"{name} probabilities do not sum to one: max_error={error}")
+    return values
+
+
+def probability_map_comparison(reference: np.ndarray, candidate: np.ndarray) -> dict[str, Any]:
+    """Compare aligned expert-probability maps without inventing constant-map correlation."""
+
+    left = _validate_probability_stack(reference, "reference")
+    right = _validate_probability_stack(candidate, "candidate")
+    if left.shape != right.shape:
+        raise ValueError(f"probability map shapes differ: {list(left.shape)} != {list(right.shape)}")
+    left64 = left.astype(np.float64)
+    right64 = right.astype(np.float64)
+    difference = np.abs(left64 - right64)
+    midpoint = 0.5 * (left64 + right64)
+    tiny = np.finfo(np.float64).tiny
+
+    def kl(first: np.ndarray, second: np.ndarray) -> np.ndarray:
+        return np.where(first > 0.0, first * np.log(np.clip(first, tiny, None) / np.clip(second, tiny, None)), 0.0)
+
+    js_per_pixel = np.maximum(0.0, 0.5 * np.sum(kl(left64, midpoint) + kl(right64, midpoint), axis=0))
+    tv_per_pixel = 0.5 * np.sum(difference, axis=0)
+    ordered_left = np.sort(left64, axis=0)
+    ordered_right = np.sort(right64, axis=0)
+    reference_margin = ordered_left[-1] - ordered_left[-2] if left.shape[0] > 1 else np.ones(left.shape[1:])
+    candidate_margin = ordered_right[-1] - ordered_right[-2] if right.shape[0] > 1 else np.ones(right.shape[1:])
+    correlations = []
+    for expert in range(left.shape[0]):
+        first = left64[expert].reshape(-1)
+        second = right64[expert].reshape(-1)
+        first_std = float(first.std())
+        second_std = float(second.std())
+        if first_std <= 1e-12 or second_std <= 1e-12:
+            correlations.append(
+                {
+                    "expert_index": expert,
+                    "pearson": None,
+                    "status": "UNDEFINED_CONSTANT_INPUT",
+                    "reference_constant": first_std <= 1e-12,
+                    "candidate_constant": second_std <= 1e-12,
+                    "constant_maps_equal": bool(np.array_equal(first, second)),
+                }
+            )
+        else:
+            correlations.append(
+                {
+                    "expert_index": expert,
+                    "pearson": float(np.corrcoef(first, second)[0, 1]),
+                    "status": "DEFINED",
+                    "reference_constant": False,
+                    "candidate_constant": False,
+                    "constant_maps_equal": None,
+                }
+            )
+    defined = [item["pearson"] for item in correlations if item["pearson"] is not None]
+    dominant_agreement = np.argmax(left, axis=0) == np.argmax(right, axis=0)
+    margin_curve = []
+    for percentile in (0, 25, 50, 75, 90):
+        threshold = float(np.percentile(reference_margin, percentile))
+        selected = reference_margin >= threshold
+        margin_curve.append(
+            {
+                "reference_margin_percentile": percentile,
+                "threshold": threshold,
+                "pixel_count": int(selected.sum()),
+                "dominant_expert_agreement_fraction": float(dominant_agreement[selected].mean()),
+            }
+        )
+    changed = ~dominant_agreement
+    return {
+        "shape": [int(item) for item in left.shape],
+        "probability_mae": float(difference.mean()),
+        "probability_rmse": float(np.sqrt(np.mean((left64 - right64) ** 2))),
+        "probability_max_abs_error": float(difference.max()),
+        "mean_total_variation_distance": float(tv_per_pixel.mean()),
+        "max_total_variation_distance": float(tv_per_pixel.max()),
+        "mean_jensen_shannon_divergence_nats": float(js_per_pixel.mean()),
+        "max_jensen_shannon_divergence_nats": float(js_per_pixel.max()),
+        "dominant_expert_agreement_fraction": float(dominant_agreement.mean()),
+        "reference_top1_margin_mean": float(reference_margin.mean()),
+        "reference_top1_margin_max": float(reference_margin.max()),
+        "candidate_top1_margin_mean": float(candidate_margin.mean()),
+        "candidate_top1_margin_max": float(candidate_margin.max()),
+        "changed_pixel_reference_margin_mean": float(reference_margin[changed].mean()) if changed.any() else None,
+        "unchanged_pixel_reference_margin_mean": (
+            float(reference_margin[dominant_agreement].mean()) if dominant_agreement.any() else None
+        ),
+        "agreement_at_or_above_reference_margin_percentiles": margin_curve,
+        "expert_pearson": correlations,
+        "defined_pearson_count": len(defined),
+        "undefined_pearson_count": len(correlations) - len(defined),
+        "defined_pearson_mean": float(np.mean(defined)) if defined else None,
+    }
+
+
+def aggregate_stability_comparisons(comparisons: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate equal-weight comparison records by type, family and target size."""
+
+    metrics = (
+        "probability_mae",
+        "probability_rmse",
+        "probability_max_abs_error",
+        "mean_total_variation_distance",
+        "mean_jensen_shannon_divergence_nats",
+        "dominant_expert_agreement_fraction",
+        "reference_top1_margin_mean",
+        "candidate_top1_margin_mean",
+    )
+
+    def summarize(items: list[dict[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {"comparison_count": len(items)}
+        for metric in metrics:
+            values = np.asarray([item["metrics"][metric] for item in items], dtype=np.float64)
+            result[metric] = {"mean": float(values.mean()), "min": float(values.min()), "max": float(values.max())}
+        correlations = [
+            correlation["pearson"]
+            for item in items
+            for correlation in item["metrics"]["expert_pearson"]
+            if correlation["pearson"] is not None
+        ]
+        total_correlations = sum(len(item["metrics"]["expert_pearson"]) for item in items)
+        result["expert_pearson"] = {
+            "defined_count": len(correlations),
+            "undefined_count": total_correlations - len(correlations),
+            "defined_mean": float(np.mean(correlations)) if correlations else None,
+            "defined_min": float(np.min(correlations)) if correlations else None,
+            "defined_max": float(np.max(correlations)) if correlations else None,
+        }
+        for key in ("changed_pixel_reference_margin_mean", "unchanged_pixel_reference_margin_mean"):
+            values = [item["metrics"][key] for item in items if item["metrics"][key] is not None]
+            result[key] = {
+                "defined_comparison_count": len(values),
+                "mean": float(np.mean(values)) if values else None,
+                "min": float(np.min(values)) if values else None,
+                "max": float(np.max(values)) if values else None,
+            }
+        curve = {}
+        for percentile in (0, 25, 50, 75, 90):
+            entries = [
+                next(
+                    entry
+                    for entry in item["metrics"]["agreement_at_or_above_reference_margin_percentiles"]
+                    if entry["reference_margin_percentile"] == percentile
+                )
+                for item in items
+            ]
+            agreements = np.asarray(
+                [entry["dominant_expert_agreement_fraction"] for entry in entries], dtype=np.float64
+            )
+            curve[str(percentile)] = {
+                "comparison_count": len(entries),
+                "mean_threshold": float(np.mean([entry["threshold"] for entry in entries])),
+                "selected_pixel_count_total": sum(entry["pixel_count"] for entry in entries),
+                "agreement_mean": float(agreements.mean()),
+                "agreement_min": float(agreements.min()),
+                "agreement_max": float(agreements.max()),
+            }
+        result["agreement_at_or_above_reference_margin_percentiles"] = curve
+        return result
+
+    by_resolution: dict[tuple[str, str, int], list[dict[str, Any]]] = defaultdict(list)
+    by_module: dict[tuple[str, str, str], list[dict[str, Any]]] = defaultdict(list)
+    by_seed: dict[tuple[str, str, int], list[dict[str, Any]]] = defaultdict(list)
+    for item in comparisons:
+        by_resolution[(item["comparison_type"], item["family"], int(item["candidate_resolution"]))].append(item)
+        by_module[(item["comparison_type"], item["family"], item["module"])].append(item)
+        by_seed[(item["comparison_type"], item["family"], int(item["seed"]))].append(item)
+    return {
+        "method": {
+            "unit": "one seed x sample x router-module aligned comparison",
+            "weighting": "each comparison receives equal weight",
+            "probability_space": "original-image pixels after exact letterbox inverse and expert re-normalization",
+            "correlation_policy": "undefined when either aligned expert map is constant",
+            "interpretation_boundary": "random-initialization pipeline diagnostic; no learned robustness claim",
+        },
+        "comparison_count": len(comparisons),
+        "by_type_family_resolution": {
+            f"{kind}:{family}:{resolution}": summarize(items)
+            for (kind, family, resolution), items in sorted(by_resolution.items())
+        },
+        "by_type_family_module": {
+            f"{kind}:{family}:{module}": summarize(items)
+            for (kind, family, module), items in sorted(by_module.items())
+        },
+        "by_type_family_seed": {
+            f"{kind}:{family}:seed-{seed}": summarize(items)
+            for (kind, family, seed), items in sorted(by_seed.items())
+        },
+    }

--- a/tools/e3_routing/tests/p0/test_adapters.py
+++ b/tools/e3_routing/tests/p0/test_adapters.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import jsonschema
+import pytest
+import torch
+
+from e3_p0.adapters import SCHEMA_VERSION, adapt_snapshot, routing_metrics
+
+
+class FakeMoE(torch.nn.Module):
+    __module__ = "ultralytics.nn.modules.moe.fake"
+
+    def __init__(self, usage=(0.7, 0.2, 0.1)):
+        super().__init__()
+        self.num_experts = 3
+        self.top_k = 2
+        self.register_buffer("aux_loss", torch.tensor(0.125))
+        self.usage = usage
+        self.last_routing_snapshot = {}
+
+    def forward(self, value):
+        self.last_routing_snapshot = {
+            "num_experts": self.num_experts,
+            "top_k": self.top_k,
+            "expert_usage": torch.tensor(self.usage),
+            "mean_router_probs": torch.tensor(self.usage),
+            "mean_topk_weight": torch.tensor([0.6, 0.4]),
+            "aux_loss": self.aux_loss,
+        }
+        return value * 2
+
+
+@pytest.mark.parametrize(
+    ("usage", "expected_entropy", "expected_gini"),
+    [
+        ([0.25, 0.25, 0.25, 0.25], 1.0, 0.0),
+        ([1.0, 0.0, 0.0, 0.0], 0.0, 0.75),
+    ],
+)
+def test_known_routing_metrics(usage, expected_entropy, expected_gini):
+    metrics = routing_metrics(usage)
+    assert metrics["expert_load_sum"] == pytest.approx(1.0)
+    assert metrics["entropy_normalized"] == pytest.approx(expected_entropy)
+    assert metrics["load_gini"] == pytest.approx(expected_gini)
+
+
+def test_snapshot_normalizes_and_validates_against_json_schema():
+    module = FakeMoE()
+    output = module(torch.ones(1, 3, 2, 2))
+    event = adapt_snapshot(
+        family="moe",
+        run_id="unit-test",
+        sequence=0,
+        module_name="route",
+        module=module,
+        snapshot=module.last_routing_snapshot,
+        input_shape=[1, 3, 2, 2],
+        output_shapes=[list(output.shape)],
+    )
+    schema_path = Path(__file__).resolve().parents[2] / "schemas" / "routing-event.schema.json"
+    jsonschema.Draft202012Validator(json.loads(schema_path.read_text(encoding="utf-8"))).validate(event)
+    assert event["schema_version"] == SCHEMA_VERSION
+    assert event["routing"]["expert_load"] == pytest.approx([0.7, 0.2, 0.1])
+    assert event["routing"]["mixing_weights"]["source"] == "mean_topk_weight"
+    assert event["aux_loss"]["finite"] is True
+    assert math.isfinite(event["routing"]["entropy_nats"])
+
+
+def test_missing_aux_loss_is_explicit_not_silently_zero():
+    module = FakeMoE()
+    module.last_routing_snapshot = {
+        "num_experts": 3,
+        "top_k": 2,
+        "expert_usage": torch.tensor([0.4, 0.3, 0.3]),
+    }
+    event = adapt_snapshot(
+        family="moe",
+        run_id="unit-test",
+        sequence=0,
+        module_name="route",
+        module=module,
+        snapshot=module.last_routing_snapshot,
+        input_shape=None,
+        output_shapes=[],
+    )
+    assert event["aux_loss"] == {
+        "state": "unavailable",
+        "source": None,
+        "value": None,
+        "finite": None,
+        "mode": "eval_observation",
+    }

--- a/tools/e3_routing/tests/p0/test_aggregation.py
+++ b/tools/e3_routing/tests/p0/test_aggregation.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from e3_p0.aggregation import aggregate_events, compare_batch_aggregates, compare_repeated_runs
+
+
+def _event(load, *, sample_indices, pass_name="primary"):
+    return {
+        "schema_version": "e3.routing/v1.0.0",
+        "run_id": "test",
+        "sequence": 0,
+        "captured_at": "ignored",
+        "family": "moe",
+        "module": {"name": "route", "type": "Fake", "python_module": "fake"},
+        "routing": {
+            "num_experts": 2,
+            "top_k": 1,
+            "granularity": "test",
+            "expert_load": load,
+            "expert_load_sum": 1.0,
+            "entropy_nats": 0.0,
+            "entropy_normalized": 0.0,
+            "load_gini": abs(load[0] - load[1]) / 2,
+            "dominant_expert_share": max(load),
+            "mixing_weights": {"state": "derived", "source": "expert_load", "value": load},
+        },
+        "aux_loss": {
+            "state": "unavailable",
+            "source": None,
+            "value": None,
+            "finite": None,
+            "mode": "eval_observation",
+        },
+        "runtime": {
+            "training": False,
+            "input_shape": [len(sample_indices), 3, 2, 2],
+            "output_shapes": [[len(sample_indices), 2]],
+            "pass_name": pass_name,
+            "batch_size": len(sample_indices),
+            "batch_index": 0,
+            "sample_indices": sample_indices,
+            "input_ids": [str(index) for index in sample_indices],
+        },
+        "provenance": {"adapter_version": "test"},
+        "source_snapshot": {"expert_usage": load},
+    }
+
+
+def test_aggregate_events_uses_batch_size_weighting():
+    aggregate = aggregate_events([_event([1.0, 0.0], sample_indices=[0]), _event([0.0, 1.0], sample_indices=[1, 2, 3])])[0]
+
+    assert aggregate["sample_observations"] == 4
+    assert aggregate["expert_load_mean"] == pytest.approx([0.25, 0.75])
+
+
+def test_repeated_run_ignores_time_run_sequence_and_pass_name():
+    reference = _event([0.4, 0.6], sample_indices=[0])
+    repeated = deepcopy(reference)
+    repeated.update(run_id="other", sequence=99, captured_at="later")
+    repeated["runtime"]["pass_name"] = "repeat-2"
+
+    comparison = compare_repeated_runs([reference], [repeated])
+
+    assert comparison["status"] == "PASS"
+    assert comparison["matching_events"] == 1
+
+
+def test_batch_consistency_compares_weighted_module_loads():
+    reference = [_event([0.8, 0.2], sample_indices=[0]), _event([0.2, 0.8], sample_indices=[1])]
+    candidate = [_event([0.5, 0.5], sample_indices=[0, 1], pass_name="batch-2")]
+
+    comparison = compare_batch_aggregates(reference, candidate, candidate_batch_size=2, tolerance=1e-9)
+
+    assert comparison["status"] == "PASS"
+    assert comparison["max_abs_load_delta"] == pytest.approx(0.0)

--- a/tools/e3_routing/tests/p0/test_collector.py
+++ b/tools/e3_routing/tests/p0/test_collector.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+
+import torch
+
+from e3_p0.collector import RoutingCollector, discover_routed_modules
+
+
+def routed_predicate(module):
+    return all(hasattr(module, name) for name in ("num_experts", "top_k", "last_routing_snapshot"))
+
+
+def _routed_class(name: str, module_path: str):
+    class Routed(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.num_experts = 2
+            self.top_k = 1
+            self.last_routing_snapshot = {}
+
+        def forward(self, value):
+            self.last_routing_snapshot = {
+                "num_experts": 2,
+                "top_k": 1,
+                "expert_usage": value.new_tensor([0.6, 0.4]),
+                "aux_loss": value.new_zeros(()),
+            }
+            return value + 1
+
+    Routed.__name__ = name
+    Routed.__module__ = module_path
+    return Routed
+
+
+FakeMoE = _routed_class("FakeMoE", "ultralytics.nn.modules.moe.fake")
+FakeMoT = _routed_class("MoTBlock", "ultralytics.nn.modules.mot.fake")
+FakeLatent = _routed_class("LatentMixture", "ultralytics.nn.modules.latent_mixture")
+
+
+class ThreeFamilyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.moe = FakeMoE()
+        self.mot = FakeMoT()
+        self.latent = FakeLatent()
+
+    def forward(self, value):
+        return self.latent(self.mot(self.moe(value)))
+
+
+def test_each_family_is_discovered_by_metadata():
+    model = ThreeFamilyModel()
+    assert [name for name, _ in discover_routed_modules(model, "moe", predicate=routed_predicate)] == ["moe"]
+    assert [name for name, _ in discover_routed_modules(model, "mot", predicate=routed_predicate)] == ["mot"]
+    assert [name for name, _ in discover_routed_modules(model, "latent", predicate=routed_predicate)] == ["latent"]
+
+
+def test_hook_does_not_change_output_and_is_removed():
+    model = ThreeFamilyModel().eval()
+    sample = torch.zeros(1, 3, 2, 2)
+    expected = model(sample.clone())
+    collector = RoutingCollector("mot", "unit-test")
+    names = collector.register(model, predicate=routed_predicate)
+    collector.set_context(pass_name="primary", batch_index=0, batch_size=1, sample_indices=[3], input_ids=["abc"])
+    observed = model(sample.clone())
+    collector.remove()
+    assert names == ["mot"]
+    assert torch.equal(observed, expected)
+    assert len(collector.events) == 1
+    assert collector.handles == []
+    assert json.dumps(collector.events[0])
+    assert collector.events[0]["runtime"]["sample_indices"] == [3]
+    assert collector.events[0]["runtime"]["batch_size"] == 1
+    assert not any(hasattr(value, "grad_fn") for value in collector.events[0]["source_snapshot"].values())
+
+
+def test_leaf_policy_prevents_parent_child_double_counting():
+    Parent = _routed_class("C2fMoE", "ultralytics.nn.modules.moe.fake")
+    parent = Parent()
+    parent.child = FakeMoE()
+    model = torch.nn.Sequential(parent)
+    discovered = discover_routed_modules(model, "moe", predicate=routed_predicate, leaf_only=True)
+    assert [name for name, _ in discovered] == ["0.child"]
+
+
+def test_moe_eval_buffer_fallback_is_explicitly_labelled():
+    module = FakeMoE().eval()
+    module.register_buffer("expert_usage_counts", torch.tensor([0.8, 0.2]))
+    module.register_buffer("load_balancing_loss", torch.tensor(0.36))
+
+    def forward_without_snapshot(value):
+        return value
+
+    module.forward = forward_without_snapshot
+    model = torch.nn.Sequential(module)
+    collector = RoutingCollector("moe", "unit-test")
+    collector.register(model, predicate=routed_predicate)
+    model(torch.zeros(1, 2))
+    collector.remove()
+    assert collector.events[0]["source_snapshot"]["diagnostic_transport"] == "official_eval_runtime_buffers"
+    assert collector.events[0]["routing"]["expert_load"] == [0.8, 0.2]
+
+
+def test_nested_moe_router_hook_captures_eval_weights_and_indices():
+    class Router(torch.nn.Module):
+        def forward(self, value):
+            batch = value.shape[0]
+            return (
+                value.new_tensor([[0.75, 0.25]]).repeat(batch, 1),
+                torch.tensor([[2, 0]], dtype=torch.long).repeat(batch, 1),
+                {},
+            )
+
+    module = FakeMoE().eval()
+    module.num_experts = 3
+    module.top_k = 2
+    module.routing = Router()
+
+    def routed_forward(value):
+        module.routing(value)
+        return value
+
+    module.forward = routed_forward
+    model = torch.nn.Sequential(module)
+    collector = RoutingCollector("moe", "unit-test")
+    collector.register(model, predicate=routed_predicate)
+    model(torch.zeros(1, 2))
+    collector.remove()
+    event = collector.events[0]
+    assert event["source_snapshot"]["diagnostic_transport"] == "nested_router_forward_hook"
+    assert event["routing"]["expert_load"] == [0.5, 0.0, 0.5]
+    assert event["routing"]["mixing_weights"]["value"] == [0.75, 0.25]
+    assert event["aux_loss"]["state"] == "unavailable"

--- a/tools/e3_routing/tests/p0/test_runner.py
+++ b/tools/e3_routing/tests/p0/test_runner.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from e3_p0.runner import _load_config
+
+
+def test_run_id_override_is_written_to_resolved_config(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("run_id: archived-evidence\nseed: 0\nsample_indices: [0]\n", encoding="utf-8")
+
+    config = _load_config(config_path, "repro-local-001")
+
+    assert config["run_id"] == "repro-local-001"
+    assert config["seed"] == 0
+
+
+def test_run_id_rejects_path_traversal_and_separators(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("run_id: archived-evidence\nsample_indices: [0]\n", encoding="utf-8")
+
+    for invalid in ("", ".", "../escape", "nested/run", r"nested\run"):
+        with pytest.raises(ValueError, match="run_id"):
+            _load_config(config_path, invalid)
+
+
+def test_config_rejects_duplicate_sample_indices(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("run_id: test\nsample_indices: [0, 0]\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="duplicates"):
+        _load_config(config_path)
+
+
+def test_legacy_single_sample_config_is_upgraded(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("run_id: test\nsample_index: 2\n", encoding="utf-8")
+
+    config = _load_config(config_path)
+
+    assert config["sample_indices"] == [2]
+    assert config["primary_batch_size"] == 1

--- a/tools/e3_routing/tests/p1/test_p1_benchmark.py
+++ b/tools/e3_routing/tests/p1/test_p1_benchmark.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from e3_p1.benchmark import _bootstrap_median_ci, _load_config, _stats, _surrogate_training_loss
+
+
+def test_surrogate_loss_reaches_nested_differentiable_tensors():
+    value = torch.tensor([2.0], requires_grad=True)
+
+    loss = _surrogate_training_loss({"one": [value], "ignored": torch.tensor([4])})
+    loss.backward()
+
+    assert float(loss.detach()) == pytest.approx(4.0)
+    assert value.grad.tolist() == pytest.approx([4.0])
+
+
+def test_benchmark_statistics_are_deterministic():
+    stats = _stats([1.0, 2.0, 3.0])
+    first = _bootstrap_median_ci([1.0, 2.0, 3.0], resamples=100, seed=7)
+    second = _bootstrap_median_ci([1.0, 2.0, 3.0], resamples=100, seed=7)
+
+    assert stats["median"] == 2.0
+    assert first == second
+
+
+def test_p1_config_requires_one_fixed_full_batch(tmp_path: Path):
+    config_path = tmp_path / "p1.yaml"
+    config_path.write_text(
+        "run_id: test\nbatch_size: 2\nwarmup_pairs: 1\nmeasured_pairs: 5\n"
+        "bootstrap_resamples: 10\nsample_indices: [0]\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="equal batch_size"):
+        _load_config(config_path)

--- a/tools/e3_routing/tests/p1/test_p1_dashboard.py
+++ b/tools/e3_routing/tests/p1/test_p1_dashboard.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from e3_p1.dashboard import build_snapshot, load_jsonl, load_jsonl_window, render_dashboard_html, smoke_test_server
+
+
+def _event(family="mot"):
+    return {
+        "family": family,
+        "module": {"name": "route"},
+        "routing": {
+            "expert_load": [0.6, 0.4],
+            "entropy_normalized": 0.9,
+            "load_gini": 0.1,
+            "dominant_expert_share": 0.6,
+            "mixing_weights": {"state": "observed"},
+        },
+        "aux_loss": {"state": "observed"},
+        "runtime": {"batch_size": 1, "sample_indices": [0]},
+    }
+
+
+def test_jsonl_loader_ignores_partial_tail_and_dashboard_updates(tmp_path):
+    source = tmp_path / "events.jsonl"
+    source.write_text(json.dumps(_event()) + "\n{partial", encoding="utf-8")
+
+    first = build_snapshot(load_jsonl(source))
+    source.write_text(json.dumps(_event()) + "\n" + json.dumps(_event("moe")) + "\n", encoding="utf-8")
+    second = build_snapshot(load_jsonl(source))
+
+    assert first["event_count"] == 1
+    assert second["event_count"] == 2
+    assert sorted(second["families"]) == ["moe", "mot"]
+
+
+def test_dashboard_html_and_real_http_smoke(tmp_path):
+    source = tmp_path / "events.jsonl"
+    source.write_text(json.dumps(_event()) + "\n", encoding="utf-8")
+
+    html = render_dashboard_html(refresh_ms=250)
+    smoke = smoke_test_server(source)
+
+    assert "fetch('/api/snapshot'" in html
+    assert "refresh 250 ms" in html
+    assert smoke == {
+        "status": "PASS",
+        "health_status": 200,
+        "html_contains_dashboard": True,
+        "api_event_count": 1,
+        "api_source_event_count": 1,
+        "api_window_limit": 1000,
+        "api_truncated": False,
+        "api_families": ["mot"],
+    }
+
+
+def test_jsonl_window_reports_truncation_without_losing_source_count(tmp_path):
+    source = tmp_path / "events.jsonl"
+    source.write_text("".join(json.dumps(_event()) + "\n" for _ in range(1001)), encoding="utf-8")
+
+    window, source_count = load_jsonl_window(source)
+    snapshot = build_snapshot(window, source_event_count=source_count, window_limit=1000)
+
+    assert len(window) == 1000
+    assert snapshot["event_count"] == 1000
+    assert snapshot["source_event_count"] == 1001
+    assert snapshot["truncated"] is True
+
+
+def test_jsonl_loader_rejects_corruption_before_final_line(tmp_path):
+    source = tmp_path / "events.jsonl"
+    source.write_text(json.dumps(_event()) + "\n{broken}\n" + json.dumps(_event()) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Invalid JSONL before final line"):
+        load_jsonl(source)

--- a/tools/e3_routing/tests/p1/test_p1_engine_crosscheck.py
+++ b/tools/e3_routing/tests/p1/test_p1_engine_crosscheck.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from e3_p1.engine_crosscheck import (
+    _assert_pair_equivalence,
+    _clear_nonleaf_latent_transients,
+    _condition_order,
+    _hash_value,
+    _load_engine_config,
+    _verify_runtime_inputs,
+)
+
+
+def test_engine_order_is_balanced_ab_ba():
+    assert _condition_order(0) == ["off", "capture_jsonl"]
+    assert _condition_order(1) == ["capture_jsonl", "off"]
+
+
+def test_engine_config_requires_even_measured_pairs(tmp_path: Path):
+    path = tmp_path / "engine.yaml"
+    path.write_text(
+        "run_id: test\nbatch_size: 2\nimage_size: 64\nepochs: 5\nwarmup_pairs: 0\nmeasured_pairs: 3\nprofiles:\n  mot: {}\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="even"):
+        _load_engine_config(path)
+
+
+def test_recursive_hash_is_order_stable_and_tensor_sensitive():
+    first = {"b": [2, torch.tensor([1.0])], "a": 1}
+    second = {"a": 1, "b": [2, torch.tensor([1.0])]}
+    changed = {"a": 1, "b": [2, torch.tensor([2.0])]}
+    assert _hash_value(first) == _hash_value(second)
+    assert _hash_value(first) != _hash_value(changed)
+
+
+def test_extracted_runtime_requires_matching_preregistered_hash(tmp_path: Path):
+    source = tmp_path / "source.py"
+    source.write_bytes(b"stable\n")
+    config = {
+        "official_runtime_ref": "ref",
+        "official_runtime_tree": "tree",
+        "runtime_input_sha256": {"source.py": "2b92ea252be0fbc26f70317cdaa7b6411ea634b50d55338cd8c495e4dbf25d1d"},
+    }
+    result = _verify_runtime_inputs(tmp_path, config)
+    assert result["mode"] == "extracted_snapshot_file_hashes"
+    source.write_bytes(b"changed\n")
+    with pytest.raises(RuntimeError, match="hash differs"):
+        _verify_runtime_inputs(tmp_path, config)
+
+
+def test_runtime_identity_policy_is_explicit(tmp_path: Path):
+    source = tmp_path / "source.py"
+    source.write_bytes(b"stable\n")
+    config = {
+        "official_runtime_ref": "ref",
+        "official_runtime_tree": "tree",
+        "runtime_identity_policy": "guess",
+        "runtime_input_sha256": {"source.py": "2b92ea252be0fbc26f70317cdaa7b6411ea634b50d55338cd8c495e4dbf25d1d"},
+    }
+    with pytest.raises(ValueError, match="runtime_identity_policy"):
+        _verify_runtime_inputs(tmp_path, config)
+
+
+def _row() -> dict:
+    return {
+        "initial_model_sha256": "a",
+        "initial_optimizer_sha256": "b",
+        "final_model_sha256": "c",
+        "final_optimizer_sha256": "d",
+        "final_ema_sha256": "e",
+        "optimizer_steps": 2,
+        "batch_count": 2,
+        "epochs_completed": 1,
+        "sanitized_transients": [],
+        "batches": [{"raw_batch_sha256": "f"}, {"raw_batch_sha256": "g"}],
+        "loss_items": [1.0, 2.0],
+    }
+
+
+def test_pair_equivalence_hard_fails_on_final_state_change():
+    off = _row()
+    observed = _row()
+    _assert_pair_equivalence(off, observed, family="toy", pair_index=0)
+    observed["final_model_sha256"] = "changed"
+    with pytest.raises(RuntimeError, match="final_model_sha256"):
+        _assert_pair_equivalence(off, observed, family="toy", pair_index=0)
+
+
+class _TransientModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.tensor([2.0]))
+        self._last_routing_logits = self.weight * 2
+        self._last_routing_probs = None
+        self._last_routing_summary = None
+
+
+def test_latent_setup_guard_only_clears_nonleaf_snapshot_fields():
+    model = _TransientModule()
+    before = dict(model.state_dict())
+    records = _clear_nonleaf_latent_transients(model)
+    assert records == [
+        {
+            "module": "",
+            "type": "_TransientModule",
+            "field": "_last_routing_logits",
+            "shape": [1],
+            "state_dict_member": False,
+        }
+    ]
+    assert model._last_routing_logits is None
+    assert model.state_dict().keys() == before.keys()
+    assert torch.equal(model.state_dict()["weight"], before["weight"])

--- a/tools/e3_routing/tests/p1/test_p1_strengthened.py
+++ b/tools/e3_routing/tests/p1/test_p1_strengthened.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from e3_p1.strengthened import (
+    CONDITIONS,
+    _assert_step_equivalence,
+    _condition_order,
+    _full_detection_step,
+    _label_path,
+    _load_strengthened_config,
+    _load_yolo_labels,
+    _validate_event_stream,
+)
+
+
+def test_three_condition_order_is_position_balanced():
+    orders = [_condition_order(index) for index in range(6)]
+
+    assert len({tuple(order) for order in orders}) == 6
+    for condition in CONDITIONS:
+        assert [sum(order[position] == condition for order in orders) for position in range(3)] == [2, 2, 2]
+
+
+def test_strengthened_config_requires_balanced_measured_pairs(tmp_path: Path):
+    config_path = tmp_path / "strengthened.yaml"
+    config_path.write_text(
+        "run_id: test\nbatch_size: 2\nwarmup_pairs: 6\nbootstrap_resamples: 10\n"
+        "sample_batches: [[0, 1], [2, 3]]\nprofiles:\n  mot:\n    measured_pairs: 31\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="divisible by 6"):
+        _load_strengthened_config(config_path)
+
+
+def test_yolo_label_path_and_parser(tmp_path: Path):
+    image_path = tmp_path / "images" / "val" / "sample.jpg"
+    label_path = tmp_path / "labels" / "val" / "sample.txt"
+    label_path.parent.mkdir(parents=True)
+    label_path.write_text("2 0.5 0.5 0.25 0.75\n", encoding="utf-8")
+
+    assert _label_path(image_path) == label_path
+    labels = _load_yolo_labels(label_path, num_classes=3)
+    assert labels.shape == (1, 5)
+    assert labels.tolist()[0] == pytest.approx([2.0, 0.5, 0.5, 0.25, 0.75])
+
+
+def test_yolo_label_parser_rejects_out_of_range_class(tmp_path: Path):
+    label_path = tmp_path / "bad.txt"
+    label_path.write_text("3 0.5 0.5 0.2 0.2\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Invalid class id"):
+        _load_yolo_labels(label_path, num_classes=3)
+
+
+def test_event_stream_requires_contiguous_global_sequence():
+    result = _validate_event_stream(
+        [{"sequence": 0}, {"sequence": 1}, {"sequence": 2}], expected_count=3, label="test"
+    )
+    assert result["contiguous_from_zero"] is True
+    assert result["last_sequence"] == 2
+
+    with pytest.raises(RuntimeError, match="not contiguous"):
+        _validate_event_stream(
+            [{"sequence": 0}, {"sequence": 1}, {"sequence": 0}], expected_count=3, label="test"
+        )
+
+
+class _ToyDetectionModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.tensor([2.0]))
+
+    def loss(self, batch):
+        value = ((self.weight * batch["img"]) - batch["target"]).square().mean()
+        losses = torch.stack((value, value * 0.5, value * 0.25))
+        return losses, losses.detach()
+
+
+def test_full_detection_step_updates_identical_models_equivalently():
+    first = _ToyDetectionModel()
+    second = _ToyDetectionModel()
+    second.load_state_dict(first.state_dict())
+    first_optimizer = torch.optim.SGD(first.parameters(), lr=0.01, momentum=0.9)
+    second_optimizer = torch.optim.SGD(second.parameters(), lr=0.01, momentum=0.9)
+    batch = {"img": torch.tensor([1.0, 2.0]), "target": torch.tensor([0.0, 1.0])}
+
+    first_result = _full_detection_step(
+        first, first_optimizer, batch, seed=7, torch_module=torch, gradient_clip_norm=10.0
+    )
+    second_result = _full_detection_step(
+        second, second_optimizer, batch, seed=7, torch_module=torch, gradient_clip_norm=10.0
+    )
+    _assert_step_equivalence(
+        [first_result],
+        [second_result],
+        family="toy",
+        condition="capture",
+        config={
+            "loss_match_rtol": 1e-6,
+            "loss_match_atol": 1e-6,
+            "gradient_match_rtol": 1e-6,
+            "gradient_match_atol": 1e-6,
+        },
+    )
+
+    assert first.weight.detach().tolist() == pytest.approx(second.weight.detach().tolist())

--- a/tools/e3_routing/tests/p2/test_appearance.py
+++ b/tools/e3_routing/tests/p2/test_appearance.py
@@ -1,0 +1,118 @@
+import hashlib
+from pathlib import Path
+
+import numpy as np
+import pytest
+import yaml
+from PIL import Image
+
+from e3_p2.appearance_runner import (
+    _aggregate_region_comparisons,
+    _apply_transform,
+    _load_config,
+    _prepare_inputs,
+    _summarize_input_effects,
+)
+from e3_p2.stability import probability_map_comparison
+
+
+def test_appearance_transforms_are_deterministic_and_preserve_geometry():
+    image = Image.new("RGB", (8, 4), (100, 120, 140))
+    identity = np.asarray(_apply_transform(image, {"name": "identity", "kind": "identity"}))
+    brighter = np.asarray(
+        _apply_transform(image, {"name": "brightness_110", "kind": "brightness", "factor": 1.1})
+    )
+    blurred = np.asarray(
+        _apply_transform(image, {"name": "gaussian_blur_075", "kind": "gaussian_blur", "radius": 0.75})
+    )
+    assert identity.shape == brighter.shape == blurred.shape == (4, 8, 3)
+    assert np.array_equal(identity, np.asarray(image))
+    assert brighter.mean() > identity.mean()
+    assert np.array_equal(blurred, identity)  # a solid-color image is unchanged by blur
+
+
+def test_config_rejects_identity_or_factor_contract_drift(tmp_path: Path):
+    base = {
+        "run_id": "run",
+        "device": "cpu",
+        "resolution": 128,
+        "seeds": [0, 1],
+        "sample_indices": [0],
+        "spatial_profiles": {"mot": {}, "moa": {}},
+        "transformations": [
+            {"name": "identity", "kind": "identity"},
+            {"name": "brightness", "kind": "brightness", "factor": 1.1},
+        ],
+    }
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(base), encoding="utf-8")
+    assert _load_config(path, None)["resolution"] == 128
+    base["transformations"][1]["factor"] = 1.0
+    path.write_text(yaml.safe_dump(base), encoding="utf-8")
+    with pytest.raises(ValueError, match="factor"):
+        _load_config(path, None)
+
+
+def test_prepared_inputs_archive_exact_model_canvas_and_hash(tmp_path: Path):
+    source = tmp_path / "source.png"
+    gradient = np.zeros((5, 10, 3), dtype=np.uint8)
+    gradient[:, :, 0] = np.arange(10, dtype=np.uint8) * 20
+    gradient[:, :, 1] = np.arange(5, dtype=np.uint8)[:, None] * 30
+    gradient[:, :, 2] = 80
+    Image.fromarray(gradient).save(source)
+    prepared, audit = _prepare_inputs(
+        [source],
+        [7],
+        [
+            {"name": "identity", "kind": "identity"},
+            {"name": "contrast_110", "kind": "contrast", "factor": 1.1},
+        ],
+        32,
+        tmp_path,
+    )
+    assert len(audit) == 2
+    identity = prepared[(7, "identity")]
+    assert identity["canvas"].shape == (32, 32, 3)
+    assert audit[0]["model_input_rgb_bytes_sha256"] == hashlib.sha256(identity["canvas"].tobytes()).hexdigest()
+    assert (tmp_path / audit[0]["transformed_artifact"]).is_file()
+    assert (tmp_path / audit[0]["model_input_artifact"]).is_file()
+    effects = _summarize_input_effects(prepared, [7], ["identity", "contrast_110"])
+    assert effects["all_candidate_samples_changed"] is True
+    assert effects["by_transform"]["contrast_110"]["changed_sample_count"] == 1
+
+
+def test_input_effect_gate_rejects_a_noop_candidate():
+    canvas = np.zeros((4, 4, 3), dtype=np.uint8)
+    prepared = {
+        (0, "identity"): {"canvas": canvas},
+        (0, "noop"): {"canvas": canvas.copy()},
+    }
+    with pytest.raises(RuntimeError, match="no-op"):
+        _summarize_input_effects(prepared, [0], ["identity", "noop"])
+
+
+def test_region_aggregate_keeps_foreground_and_background_separate():
+    reference = np.asarray([[[0.8, 0.6]], [[0.2, 0.4]]], dtype=np.float32)
+    candidate = np.asarray([[[0.7, 0.5]], [[0.3, 0.5]]], dtype=np.float32)
+    metrics = probability_map_comparison(reference, candidate)
+    records = [
+        {
+            "comparison_type": "appearance_brightness_090",
+            "family": "moa",
+            "seed": 0,
+            "sample_index": 0,
+            "module": "router",
+            "region": region,
+            "token_count": 2,
+            "metrics": metrics,
+        }
+        for region in ("foreground", "background")
+    ]
+    aggregate = _aggregate_region_comparisons(records)
+    assert aggregate["comparison_count"] == 2
+    assert aggregate["by_type_family_region"]["appearance_brightness_090:moa:foreground"][
+        "comparison_count"
+    ] == 1
+    assert aggregate["by_type_family_region"]["appearance_brightness_090:moa:background"][
+        "probability_mae"
+    ]["mean"] == pytest.approx(0.1)

--- a/tools/e3_routing/tests/p2/test_blur_residual_runner.py
+++ b/tools/e3_routing/tests/p2/test_blur_residual_runner.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+import yaml
+from PIL import Image
+
+from e3_p2.blur_residual_runner import (
+    FEATURES,
+    _load_config,
+    analyze_records,
+    extract_input_features,
+    holm_adjust,
+    permutation_p_value,
+)
+
+
+def test_input_features_distinguish_uniform_and_checkerboard(tmp_path: Path):
+    uniform = np.full((10, 20, 3), 100, dtype=np.uint8)
+    checker = ((np.indices((10, 20)).sum(axis=0) % 2) * 255).astype(np.uint8)
+    checker = np.repeat(checker[..., None], 3, axis=2)
+    uniform_path, checker_path = tmp_path / "uniform.png", tmp_path / "checker.png"
+    Image.fromarray(uniform).save(uniform_path)
+    Image.fromarray(checker).save(checker_path)
+
+    plain = extract_input_features(uniform_path, canvas_size=128)
+    textured = extract_input_features(checker_path, canvas_size=128)
+    assert plain["letterbox_content_fraction"] == pytest.approx(0.5)
+    assert plain["luminance_mean_0_255"] == pytest.approx(100.0)
+    assert plain["edge_total_variation_0_1"] == pytest.approx(0.0)
+    assert textured["edge_total_variation_0_1"] == pytest.approx(1.0)
+
+
+def test_permutation_is_reproducible_and_detects_perfect_order():
+    x = np.arange(12, dtype=np.float64)
+    y = x**2
+    first = permutation_p_value(x, y, 5000, 17)
+    second = permutation_p_value(x, y, 5000, 17)
+    assert first == second
+    assert first["two_sided_p_value"] < 0.01
+
+
+def test_constant_feature_is_explicitly_undefined():
+    result = permutation_p_value(np.ones(8), np.arange(8, dtype=np.float64), 5000, 3)
+    assert result["status"] == "UNDEFINED_CONSTANT_VECTOR"
+    assert result["two_sided_p_value"] is None
+
+
+def test_holm_adjustment_is_monotone_and_keeps_undefined():
+    result = holm_adjust({"a": 0.01, "b": 0.03, "c": None}, 0.05)
+    assert result["a"]["holm_adjusted_p_value"] == pytest.approx(0.02)
+    assert result["b"]["holm_adjusted_p_value"] == pytest.approx(0.03)
+    assert result["a"]["reject_at_alpha"] is True
+    assert result["b"]["reject_at_alpha"] is True
+    assert result["c"]["holm_adjusted_p_value"] is None
+
+
+def test_analysis_is_deterministic_and_uses_all_predeclared_features():
+    records = []
+    for index in range(16):
+        records.append(
+            {
+                "sample_index": index,
+                "image_name": f"{index}.jpg",
+                "normalized_absolute_residual": (index + 1) / 100.0,
+                "features": {
+                    "letterbox_content_fraction": 0.5 + index / 100.0,
+                    "luminance_mean_0_255": 100.0 - index,
+                    "edge_total_variation_0_1": 0.1 + (index % 5) / 100.0,
+                },
+            }
+        )
+    kwargs = {
+        "features": FEATURES,
+        "bootstrap_draws": 1000,
+        "bootstrap_seed": 5,
+        "permutation_draws": 5000,
+        "permutation_seed": 9,
+        "alpha": 0.05,
+        "top_k": 4,
+    }
+    first = analyze_records(records, **kwargs)
+    second = analyze_records(records, **kwargs)
+    assert first == second
+    assert set(first["associations"]) == set(FEATURES)
+    assert len(first["top_residual_images_descriptive_only"]) == 4
+
+
+def _valid_config() -> dict:
+    return {
+        "run_id": "p2x-test",
+        "features": list(FEATURES),
+        "family": "gaussian_blur",
+        "endpoint": "probability_mae",
+        "expected_image_count": 16,
+        "bootstrap_draws": 1000,
+        "permutation_draws": 5000,
+        "alpha": 0.05,
+        "top_k": 4,
+        "expected_holdout_manifest_sha256": "a" * 64,
+        "expected_image_source_manifest_sha256": "b" * 64,
+        "expected_selected_image_and_label_set_sha256": "c" * 64,
+        "max_evidence_bytes": 100_000,
+    }
+
+
+def test_config_rejects_feature_order_change(tmp_path: Path):
+    config = _valid_config()
+    config["features"] = list(reversed(FEATURES))
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    with pytest.raises(ValueError, match="predeclared order"):
+        _load_config(path, None)
+
+
+def test_config_accepts_locked_contract(tmp_path: Path):
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(_valid_config()), encoding="utf-8")
+    loaded = _load_config(path, None)
+    assert loaded["run_id"] == "p2x-test"
+    assert tuple(loaded["features"]) == FEATURES

--- a/tools/e3_routing/tests/p2/test_capture.py
+++ b/tools/e3_routing/tests/p2/test_capture.py
@@ -1,0 +1,115 @@
+import pytest
+import torch
+from torch import nn
+
+from e3_p2.capture import SpatialRouterCollector, max_output_delta, routing_diagnostics, routing_metric_fields
+from e3_p2.runner import _batch_equivalence
+
+
+class _MoTRouter(nn.Module):
+    def forward(self, x, return_logits=True):
+        del return_logits
+        logits = torch.stack((x[:, 0], -x[:, 0], x[:, 0] * 0), dim=1)
+        dense = torch.softmax(logits, dim=1)
+        top_weights, indices = torch.topk(dense, 2, dim=1)
+        top_weights = top_weights / top_weights.sum(dim=1, keepdim=True)
+        weights = torch.zeros_like(dense).scatter(1, indices, top_weights)
+        return weights, indices, logits
+
+
+class TinyMoT(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.router = _MoTRouter()
+
+    def forward(self, x):
+        weights, _, _ = self.router(x, return_logits=True)
+        return x * weights[:, :1]
+
+
+def test_hook_captures_real_spatial_grid_without_changing_output():
+    model = TinyMoT().eval()
+    value = torch.randn(1, 2, 4, 5)
+    reference = model(value)
+    collector = SpatialRouterCollector(family="mot", router_class="_MoTRouter")
+    assert collector.register(model) == ["router"]
+    observed = model(value)
+    collector.remove()
+    assert max_output_delta(reference, observed) == 0.0
+    assert not collector.handles
+    assert len(collector.records) == 1
+    assert collector.records[0].weights.shape == (1, 3, 4, 5)
+    assert collector.records[0].indices.shape == (1, 2, 4, 5)
+    assert collector.records[0].validation["indices_in_range"] is True
+    assert collector.records[0].validation["selected_mass_error"] < 1e-5
+
+
+def test_output_equivalence_detects_structure_shape_and_value_changes():
+    value = torch.zeros(1, 2)
+    assert max_output_delta((value,), (value.clone(),)) == 0.0
+    assert max_output_delta((value,), (value + 1,)) == 1.0
+    with pytest.raises(ValueError, match="tensor count"):
+        max_output_delta((value,), (value, value))
+    with pytest.raises(ValueError, match="shape changed"):
+        max_output_delta((value,), (torch.zeros(2, 1),))
+
+
+def test_collector_rejects_non_spatial_router_output():
+    class _MoARouter(nn.Module):
+        def forward(self, x):
+            weights = torch.softmax(x.mean((2, 3)), dim=1)
+            return weights, weights
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.router = _MoARouter()
+
+        def forward(self, x):
+            return self.router(x)
+
+    model = Model()
+    collector = SpatialRouterCollector(family="moa", router_class="_MoARouter")
+    collector.register(model)
+    with pytest.raises(ValueError, match="expected"):
+        model(torch.randn(1, 3, 4, 4))
+    collector.remove()
+
+
+def test_routing_metrics_have_fixed_interpretable_scale():
+    uniform = torch.full((3, 2, 4), 1 / 3).numpy()
+    uniform_fields = routing_metric_fields(uniform)
+    assert uniform_fields["normalized_entropy"] == pytest.approx(1.0)
+    assert uniform_fields["top1_margin"] == pytest.approx(0.0)
+
+    one_hot = torch.zeros(3, 2, 4).numpy()
+    one_hot[1] = 1.0
+    diagnostics = routing_diagnostics(one_hot)
+    assert diagnostics["normalized_entropy"]["mean"] == pytest.approx(0.0)
+    assert diagnostics["top1_margin"]["mean"] == pytest.approx(1.0)
+    assert diagnostics["dominant_token_count"] == [0, 8, 0]
+    assert diagnostics["active_dominant_experts"] == 1
+
+
+def test_single_and_batched_router_grids_keep_sample_identity():
+    model = TinyMoT().eval()
+    tensors = [torch.randn(1, 2, 4, 5) for _ in range(4)]
+    records_per_sample = []
+    for tensor in tensors:
+        collector = SpatialRouterCollector(family="mot", router_class="_MoTRouter")
+        collector.register(model)
+        model(tensor)
+        collector.remove()
+        records_per_sample.append(collector.records)
+    result = _batch_equivalence(
+        model=model,
+        family="mot",
+        router_class="_MoTRouter",
+        tensors=tensors,
+        records_per_sample=records_per_sample,
+        batch_sizes=[2, 4],
+        torch_module=torch,
+    )
+    assert result["status"] == "PASS"
+    assert [item["compared_samples"] for item in result["sizes"]] == [4, 4]
+    assert all(item["indices_equal"] for item in result["sizes"])

--- a/tools/e3_routing/tests/p2/test_detector_output.py
+++ b/tools/e3_routing/tests/p2/test_detector_output.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pytest
+
+from e3_p2.detector_output import detector_output_comparison, detector_output_tensors
+
+
+def _output(offset: float = 0.0):
+    return (
+        np.full((1, 300, 6), 1.0 + offset),
+        {
+            "one2one": {
+                "scores": np.full((1, 4, 8), 2.0 + offset),
+                "boxes": np.full((1, 4, 4), 3.0 + offset),
+            },
+            "one2many": {
+                "scores": np.full((1, 7, 8), 4.0 + offset),
+                "boxes": np.full((1, 7, 4), 5.0 + offset),
+            },
+        },
+    )
+
+
+def test_detector_output_comparison_has_fixed_primary_and_known_delta():
+    comparison = detector_output_comparison(_output(), _output(0.25))
+    assert comparison["primary_tensor"] == "one2one_scores"
+    assert set(comparison["tensors"]) == {
+        "decoded_top300",
+        "one2one_scores",
+        "one2one_boxes",
+        "one2many_scores",
+        "one2many_boxes",
+    }
+    for metrics in comparison["tensors"].values():
+        assert metrics["mean_absolute_change"] == pytest.approx(0.25)
+        assert metrics["root_mean_square_change"] == pytest.approx(0.25)
+        assert metrics["maximum_absolute_change"] == pytest.approx(0.25)
+
+
+def test_detector_output_extraction_rejects_missing_field_and_shape_change():
+    missing = _output()
+    del missing[1]["one2one"]["scores"]
+    with pytest.raises(TypeError, match="missing one2one.scores"):
+        detector_output_tensors(missing)
+    changed = _output()
+    changed[1]["one2one"]["scores"] = np.zeros((1, 5, 8))
+    with pytest.raises(RuntimeError, match="shape changed"):
+        detector_output_comparison(_output(), changed)

--- a/tools/e3_routing/tests/p2/test_dose_holdout_runner.py
+++ b/tools/e3_routing/tests/p2/test_dose_holdout_runner.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+from e3_p2.dose_holdout_runner import _load_config, _slope_association, analyze_holdout, build_holdout_records
+
+FAMILIES = [{"name": "brightness", "transforms": ["low", "middle", "high"]}]
+
+
+def _parent_records(*, zero_switch_span: bool = False):
+    records = []
+    for image in range(4):
+        x_values = [1.0 + image, 2.0 + 2 * image, 4.0 + 4 * image]
+        for level, (transform, x) in enumerate(zip(("low", "middle", "high"), x_values)):
+            probability = 2.0 * x + image
+            switch = 0.2 if zero_switch_span else probability / 100.0
+            records.append(
+                {
+                    "family": "brightness",
+                    "transform": transform,
+                    "sample_index": image,
+                    "input_rgb_mae_0_255": x,
+                    "target_probability_mae_mean_across_seeds": probability,
+                    "target_dominant_switch_fraction_mean_across_seeds": switch,
+                    "seed_values": [
+                        {
+                            "seed": seed,
+                            "probability_mae": probability * (seed + 1),
+                            "dominant_switch_fraction": switch,
+                        }
+                        for seed in (0, 1, 2)
+                    ],
+                }
+            )
+    return records
+
+
+def test_holdout_prediction_is_exact_for_linear_response_and_reproducible():
+    records = build_holdout_records(_parent_records(), FAMILIES, 4, [0, 1, 2])
+    assert len(records) == 4
+    assert records[0]["endpoints"]["probability_mae"]["absolute_residual_input_weighted"] == pytest.approx(0.0)
+    first = analyze_holdout(records, FAMILIES, [0, 1, 2], 1000, 7)
+    second = analyze_holdout(records, FAMILIES, [0, 1, 2], 1000, 7)
+    assert first == second
+    metric = first["by_family"]["brightness"]["endpoints"]["probability_mae"]
+    assert metric["input_weighted_absolute_error"]["observed_mean"] == pytest.approx(0.0)
+
+
+def test_zero_endpoint_span_keeps_null_normalized_error():
+    records = build_holdout_records(_parent_records(zero_switch_span=True), FAMILIES, 4, [0, 1, 2])
+    for item in records:
+        assert item["endpoints"]["dominant_switch_fraction"]["normalized_absolute_residual"] is None
+    result = analyze_holdout(records, FAMILIES, [0, 1, 2], 1000, 11)
+    normalized = result["by_family"]["brightness"]["endpoints"]["dominant_switch_fraction"][
+        "normalized_absolute_error"
+    ]
+    assert normalized["defined_image_count"] == 0
+    assert normalized["zero_span_image_count"] == 4
+
+
+def test_sparse_slope_resampling_counts_undefined_draws_without_crashing():
+    import numpy as np
+
+    x = np.asarray([0.0, 0.0, 0.0, 1.0])
+    y = np.asarray([0.0, 0.0, 0.0, 2.0])
+    result = _slope_association(x, y, 1000, 23)
+    assert result["status"] == "DEFINED"
+    assert result["bootstrap"]["undefined_draw_count"] > 0
+    assert result["leave_one_image_out"]["undefined_count"] == 1
+
+
+def test_holdout_rejects_incomplete_matrix_and_unordered_input():
+    parent = _parent_records()
+    with pytest.raises(ValueError, match="parent dose matrix mismatch"):
+        build_holdout_records(parent[:-1], FAMILIES, 4, [0, 1, 2])
+    parent[1]["input_rgb_mae_0_255"] = parent[0]["input_rgb_mae_0_255"]
+    with pytest.raises(ValueError, match="strictly ordered"):
+        build_holdout_records(parent, FAMILIES, 4, [0, 1, 2])
+
+
+def test_config_rejects_reused_transform(tmp_path: Path):
+    config = {
+        "run_id": "holdout-test",
+        "expected_image_count": 4,
+        "expected_seeds": [0, 1],
+        "bootstrap_draws": 1000,
+        "max_evidence_bytes": 100_000,
+        "expected_parent_manifest_sha256": "0" * 64,
+        "families": [
+            {"name": name, "low_transform": "same", "middle_transform": f"{name}-m", "high_transform": f"{name}-h"}
+            for name in ("a", "b", "c")
+        ],
+    }
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    with pytest.raises(ValueError, match="globally unique"):
+        _load_config(path, None)

--- a/tools/e3_routing/tests/p2/test_dose_response_runner.py
+++ b/tools/e3_routing/tests/p2/test_dose_response_runner.py
@@ -1,0 +1,78 @@
+import numpy as np
+import pytest
+
+from e3_p2.dose_response_runner import (
+    build_dose_records,
+    summarize_dose_response,
+)
+
+FAMILIES = [
+    {
+        "name": "brightness",
+        "conditions": [
+            {"transform": "low", "severity": 1.0, "label": "low"},
+            {"transform": "mid", "severity": 2.0, "label": "mid"},
+            {"transform": "high", "severity": 3.0, "label": "high"},
+        ],
+    }
+]
+
+
+def _fixtures(nonmonotone_switch: bool = False):
+    effects, cases = [], []
+    for image in range(4):
+        for level, transform in enumerate(("low", "mid", "high"), start=1):
+            effects.append(
+                {
+                    "transform": transform,
+                    "sample_index": image,
+                    "rgb_mae_0_255": float(level * (image + 1)),
+                    "model_input_changed": True,
+                }
+            )
+            for seed in (0, 1):
+                switch = float((4 - level if nonmonotone_switch else level) + image) / 20.0
+                cases.append(
+                    {
+                        "transform": transform,
+                        "sample_index": image,
+                        "seed": seed,
+                        "probability_mae": float(level * (image + 1) + seed),
+                        "dominant_switch_fraction": switch,
+                    }
+                )
+    return effects, cases
+
+
+def test_dose_summary_preserves_primary_and_negative_secondary_results():
+    effects, cases = _fixtures(nonmonotone_switch=True)
+    records = build_dose_records(effects, cases, FAMILIES, 4, [0, 1])
+    result = summarize_dose_response(records, FAMILIES, 4, [0, 1], 1000, 7)
+    family = result["by_family"]["brightness"]
+    assert family["monotonicity"]["input_rgb_mae_0_255"]["nondecreasing_image_count"] == 4
+    assert family["monotonicity"]["target_probability_mae"]["nondecreasing_image_count"] == 4
+    assert family["monotonicity"]["target_dominant_switch_fraction"]["nondecreasing_image_count"] == 0
+    assert family["high_minus_low_paired_difference"]["target_probability_mae"]["observed_mean"] > 0
+
+
+def test_dose_records_reject_incomplete_seed_matrix():
+    effects, cases = _fixtures()
+    with pytest.raises(ValueError, match="incomplete or duplicate dose seed matrix"):
+        build_dose_records(effects, cases[:-1], FAMILIES, 4, [0, 1])
+
+
+def test_dose_summary_rejects_nonmonotone_input_ladder():
+    effects, cases = _fixtures()
+    effects[-1]["rgb_mae_0_255"] = 0.0
+    records = build_dose_records(effects, cases, FAMILIES, 4, [0, 1])
+    with pytest.raises(RuntimeError, match="input severity ladder is not monotone"):
+        summarize_dose_response(records, FAMILIES, 4, [0, 1], 1000, 7)
+
+
+def test_high_minus_low_bootstrap_is_image_paired():
+    effects, cases = _fixtures()
+    records = build_dose_records(effects, cases, FAMILIES, 4, [0, 1])
+    result = summarize_dose_response(records, FAMILIES, 4, [0, 1], 1000, 11)
+    difference = result["by_family"]["brightness"]["high_minus_low_paired_difference"]
+    assert difference["input_rgb_mae_0_255"]["unit_count"] == 4
+    assert np.isfinite(difference["target_probability_mae"]["observed_mean"])

--- a/tools/e3_routing/tests/p2/test_geometry.py
+++ b/tools/e3_routing/tests/p2/test_geometry.py
@@ -1,0 +1,52 @@
+import numpy as np
+import pytest
+from PIL import Image
+
+from e3_p2.geometry import LetterboxMeta, letterbox, restore_heatmap, validate_probability_grid
+
+
+def test_letterbox_records_exact_padding_and_restores_original_shape():
+    image = Image.new("RGB", (80, 40), "white")
+    canvas, meta = letterbox(image, 64)
+    assert canvas.shape == (64, 64, 3)
+    assert (meta.resized_width, meta.resized_height) == (64, 32)
+    assert (meta.pad_left, meta.pad_top, meta.pad_right, meta.pad_bottom) == (0, 16, 0, 16)
+    restored = restore_heatmap(np.arange(32, dtype=np.float32).reshape(4, 8), meta)
+    assert restored.shape == (40, 80)
+    assert np.isfinite(restored).all()
+
+
+def test_odd_padding_round_trip_shape_is_unambiguous():
+    image = Image.new("RGB", (63, 40), "white")
+    _, meta = letterbox(image, 64)
+    assert meta.pad_left + meta.resized_width + meta.pad_right == 64
+    assert meta.pad_top + meta.resized_height + meta.pad_bottom == 64
+    restored = restore_heatmap(np.ones((5, 7), dtype=np.float32), meta)
+    assert restored.shape == (40, 63)
+    assert np.allclose(restored, 1.0)
+
+
+def test_restore_heatmap_removes_letterbox_padding_before_resizing():
+    image = Image.new("RGB", (80, 40), "white")
+    _, meta = letterbox(image, 64)
+    field = np.zeros((64, 64), dtype=np.float32)
+    field[meta.pad_top : 64 - meta.pad_bottom, meta.pad_left : 64 - meta.pad_right] = 1.0
+    restored = restore_heatmap(field, meta)
+    assert np.allclose(restored, 1.0)
+
+
+def test_probability_grid_requires_real_spatial_axes_and_normalization():
+    valid = np.full((1, 4, 3, 5), 0.25, dtype=np.float32)
+    result = validate_probability_grid(valid)
+    assert result["shape"] == [1, 4, 3, 5]
+    assert result["max_expert_sum_error"] == 0.0
+    with pytest.raises(ValueError, match="not a token/spatial grid"):
+        validate_probability_grid(np.full((1, 4, 1, 1), 0.25, dtype=np.float32))
+    with pytest.raises(ValueError, match="sum to one"):
+        validate_probability_grid(np.full((1, 4, 3, 5), 0.20, dtype=np.float32))
+
+
+def test_invalid_crop_metadata_fails_closed():
+    meta = LetterboxMeta(10, 10, 8, 0, 0, 4, 4, 4, 4, 0.8)
+    with pytest.raises(ValueError, match="empty crop"):
+        restore_heatmap(np.ones((2, 2), dtype=np.float32), meta)

--- a/tools/e3_routing/tests/p2/test_image_driver_analysis.py
+++ b/tools/e3_routing/tests/p2/test_image_driver_analysis.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pytest
+
+from e3_p2.image_driver_analysis import (
+    average_ranks,
+    bootstrap_spearman,
+    build_image_records,
+    leave_one_out_spearman,
+    spearman,
+)
+
+
+def test_average_ranks_and_spearman_handle_ties_and_constants():
+    assert average_ranks(np.array([30.0, 10.0, 10.0, 20.0])).tolist() == [4.0, 1.5, 1.5, 3.0]
+    assert spearman(np.arange(5), np.arange(5)) == pytest.approx(1.0)
+    assert spearman(np.arange(5), -np.arange(5)) == pytest.approx(-1.0)
+    assert spearman(np.ones(5), np.arange(5)) is None
+
+
+def test_bootstrap_and_leave_one_out_are_deterministic():
+    x = np.arange(12, dtype=np.float64)
+    y = x**2 + np.array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
+    first = bootstrap_spearman(x, y, 1000, 7)
+    second = bootstrap_spearman(x, y, 1000, 7)
+    assert first == second
+    assert first["defined_draw_count"] == 1000
+    leave_one_out = leave_one_out_spearman(x, y)
+    assert leave_one_out["count"] == 12
+    assert leave_one_out["minimum"] > 0.9
+
+
+def _effect(transform: str, sample: int) -> dict:
+    return {
+        "transform": transform,
+        "sample_index": sample,
+        "rgb_mae_0_255": float(sample + 1),
+        "model_input_changed": True,
+    }
+
+
+def _case(transform: str, sample: int, seed: int) -> dict:
+    return {
+        "transform": transform,
+        "sample_index": sample,
+        "seed": seed,
+        "probability_mae": float(sample + seed),
+        "dominant_switch_fraction": float(sample + seed) / 10.0,
+    }
+
+
+def test_build_image_records_uses_complete_seed_averages():
+    effects = [_effect("dim", sample) for sample in range(4)]
+    cases = [_case("dim", sample, seed) for sample in range(4) for seed in (0, 1, 2)]
+    records = build_image_records(effects, cases, ["dim"], 4, [0, 1, 2])
+    assert len(records) == 4
+    assert records[2]["target_probability_mae_mean_across_seeds"] == pytest.approx(3.0)
+
+
+def test_build_image_records_rejects_incomplete_seed_matrix():
+    effects = [_effect("dim", sample) for sample in range(4)]
+    cases = [_case("dim", sample, seed) for sample in range(4) for seed in (0, 1, 2)]
+    with pytest.raises(ValueError, match="incomplete or duplicate seed matrix"):
+        build_image_records(effects, cases[:-1], ["dim"], 4, [0, 1, 2])

--- a/tools/e3_routing/tests/p2/test_layer_drilldown.py
+++ b/tools/e3_routing/tests/p2/test_layer_drilldown.py
@@ -1,0 +1,69 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from e3_p2.io_utils import sha256_file, write_manifest
+from e3_p2.layer_drilldown import margin_bin_summary, summarize_layer_attribution, verify_parent_evidence
+
+
+def _comparison(transform: str, module: str, seed: int, value: float) -> dict:
+    return {
+        "family": "moa",
+        "comparison_type": f"appearance_{transform}",
+        "module": module,
+        "seed": seed,
+        "metrics": {"probability_mae": value},
+    }
+
+
+def test_parent_verification_rejects_mutation_and_extra_files(tmp_path: Path):
+    (tmp_path / "payload.txt").write_text("locked\n", encoding="utf-8")
+    manifest = write_manifest(tmp_path)
+    digest = sha256_file(manifest)
+    result = verify_parent_evidence(tmp_path, digest)
+    assert result["status"] == "PASS"
+    assert result["verified_file_count"] == 1
+    (tmp_path / "payload.txt").write_text("changed\n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="integrity mismatch"):
+        verify_parent_evidence(tmp_path, digest)
+    (tmp_path / "payload.txt").write_text("locked\n", encoding="utf-8")
+    (tmp_path / "extra.txt").write_text("extra\n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="file set mismatch"):
+        verify_parent_evidence(tmp_path, digest)
+
+
+def test_layer_attribution_ranks_target_and_normalizes_shares():
+    records = []
+    for transform in ("dim", "bright"):
+        for seed in (0, 1):
+            records.extend(
+                [
+                    _comparison(transform, "target", seed, 4.0 + seed),
+                    _comparison(transform, "other", seed, 1.0),
+                ]
+            )
+    result = summarize_layer_attribution(records, "moa", ["dim", "bright"], "target")
+    assert result["target_rank_one_transform_seed_count"] == 4
+    assert result["transform_seed_group_count"] == 4
+    for item in result["by_transform"].values():
+        assert item["target_rank"] == 1
+        assert sum(entry["share_of_layer_mean_mae_sum"] for entry in item["ranking"]) == pytest.approx(1.0)
+
+
+def test_margin_bins_partition_tokens_once_and_localize_switches():
+    margins = np.arange(100, dtype=np.float64)
+    switched = margins < 10
+    result = margin_bin_summary(margins, switched, 10)
+    assert sum(item["token_comparison_count"] for item in result["bins"]) == 100
+    assert sum(item["switch_count"] for item in result["bins"]) == 10
+    assert result["bins"][0]["switch_fraction"] == 1.0
+    assert all(item["switch_fraction"] == 0.0 for item in result["bins"][1:])
+
+
+def test_parent_manifest_digest_is_bound(tmp_path: Path):
+    (tmp_path / "payload.json").write_text(json.dumps({"value": 1}), encoding="utf-8")
+    write_manifest(tmp_path)
+    with pytest.raises(RuntimeError, match="manifest digest mismatch"):
+        verify_parent_evidence(tmp_path, "0" * 64)

--- a/tools/e3_routing/tests/p2/test_output_coupling_runner.py
+++ b/tools/e3_routing/tests/p2/test_output_coupling_runner.py
@@ -1,0 +1,70 @@
+import pytest
+
+from e3_p2.output_coupling_runner import (
+    DETECTOR_TENSORS,
+    analyze_output_coupling,
+    build_output_coupling_records,
+)
+
+
+def _route(transform: str, sample: int, seed: int) -> dict:
+    return {
+        "transform": transform,
+        "sample_index": sample,
+        "seed": seed,
+        "probability_mae": (sample + 1) * (seed + 1) / 100.0,
+        "dominant_switch_fraction": (sample + 1) * (seed + 1) / 50.0,
+    }
+
+
+def _detector(transform: str, sample: int, seed: int) -> dict:
+    tensors = {
+        tensor: {"mean_absolute_change": (sample + 1) * (seed + 1) / (index + 2)}
+        for index, tensor in enumerate(DETECTOR_TENSORS)
+    }
+    return {
+        "transform": transform,
+        "sample_index": sample,
+        "seed": seed,
+        "metrics": {"primary_tensor": "one2one_scores", "tensors": tensors},
+    }
+
+
+def test_build_and_analyze_output_coupling_matrix():
+    transforms, seeds = ["dim", "blur"], [0, 1, 2]
+    routes = [_route(t, image, seed) for t in transforms for image in range(6) for seed in seeds]
+    detector = [_detector(t, image, seed) for t in transforms for image in range(6) for seed in seeds]
+    records = build_output_coupling_records(routes, detector, transforms, 6, seeds)
+    assert len(records) == 12
+    assert records[2]["seed_count"] == 3
+    result = analyze_output_coupling(records, transforms, 1000, 42)
+    observed = result["by_transform"]["dim"]["detector_tensors"]["one2one_scores"][
+        "route_endpoints"
+    ]["probability_mae"]["bootstrap"]["observed_spearman_rho"]
+    assert observed == pytest.approx(1.0)
+    assert result == analyze_output_coupling(records, transforms, 1000, 42)
+
+
+def test_build_output_coupling_rejects_incomplete_detector_matrix():
+    transforms, seeds = ["dim"], [0, 1, 2]
+    routes = [_route("dim", image, seed) for image in range(4) for seed in seeds]
+    detector = [_detector("dim", image, seed) for image in range(4) for seed in seeds]
+    with pytest.raises(ValueError, match="incomplete or duplicate detector seed matrix"):
+        build_output_coupling_records(routes, detector[:-1], transforms, 4, seeds)
+
+
+def test_constant_detector_endpoint_is_preserved_as_undefined():
+    transforms, seeds = ["dim"], [0, 1, 2]
+    routes = [_route("dim", image, seed) for image in range(6) for seed in seeds]
+    detector = [_detector("dim", image, seed) for image in range(6) for seed in seeds]
+    for item in detector:
+        item["metrics"]["tensors"]["one2one_scores"]["mean_absolute_change"] = 0.0
+    records = build_output_coupling_records(routes, detector, transforms, 6, seeds)
+    result = analyze_output_coupling(records, transforms, 1000, 19)
+    endpoint = result["by_transform"]["dim"]["detector_tensors"]["one2one_scores"][
+        "route_endpoints"
+    ]["probability_mae"]
+    assert endpoint["status"] == "UNDEFINED_CONSTANT_VECTOR"
+    assert endpoint["observed_spearman_rho"] is None
+    assert endpoint["y_unique_value_count"] == 1
+    assert endpoint["bootstrap"] is None

--- a/tools/e3_routing/tests/p2/test_plotting.py
+++ b/tools/e3_routing/tests/p2/test_plotting.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from e3_p2.geometry import letterbox
+from e3_p2.plotting import save_dominant_overlay, save_metric_overlay, save_probability_overlay
+
+
+def test_overlay_outputs_original_size_and_reports_raw_probability(tmp_path: Path):
+    original = Image.new("RGB", (80, 40), (120, 130, 140))
+    _, meta = letterbox(original, 64)
+    probability = np.linspace(0, 1, 20, dtype=np.float32).reshape(4, 5)
+    output = tmp_path / "probability.png"
+    stats = save_probability_overlay(original, probability, meta, str(output), expert_index=1, alpha=0.5)
+    assert Image.open(output).size == original.size
+    assert stats["feature_min"] == 0.0
+    assert stats["feature_max"] == 1.0
+
+
+def test_dominant_overlay_counts_match_feature_tokens(tmp_path: Path):
+    original = Image.new("RGB", (50, 50), "black")
+    _, meta = letterbox(original, 32)
+    weights = np.zeros((3, 2, 2), dtype=np.float32)
+    weights[0, 0, :] = 1
+    weights[1, 1, 0] = 1
+    weights[2, 1, 1] = 1
+    output = tmp_path / "dominant.png"
+    counts = save_dominant_overlay(original, weights, meta, str(output), alpha=0.5)
+    assert counts == [2, 1, 1]
+    assert Image.open(output).size == original.size
+
+
+def test_metric_overlay_preserves_fixed_scale_and_original_size(tmp_path: Path):
+    original = Image.new("RGB", (63, 40), "black")
+    _, meta = letterbox(original, 64)
+    output = tmp_path / "entropy.png"
+    stats = save_metric_overlay(
+        original,
+        np.full((4, 5), 0.75, dtype=np.float32),
+        meta,
+        str(output),
+        color=(166, 108, 255),
+        alpha=0.5,
+    )
+    assert Image.open(output).size == original.size
+    assert stats["feature_mean"] == pytest.approx(0.75)
+    with pytest.raises(ValueError, match="within"):
+        save_metric_overlay(
+            original,
+            np.full((4, 5), 1.01, dtype=np.float32),
+            meta,
+            str(tmp_path / "bad.png"),
+            color=(0, 0, 0),
+            alpha=0.5,
+        )

--- a/tools/e3_routing/tests/p2/test_regions.py
+++ b/tools/e3_routing/tests/p2/test_regions.py
@@ -1,0 +1,119 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from e3_p2.geometry import LetterboxMeta
+from e3_p2.regions import (
+    YoloBox,
+    aggregate_region_diagnostics,
+    label_path_for_image,
+    parse_yolo_labels,
+    region_routing_diagnostics,
+    token_region_masks,
+)
+
+
+def _meta() -> LetterboxMeta:
+    return LetterboxMeta(
+        original_width=100,
+        original_height=50,
+        input_size=100,
+        resized_width=100,
+        resized_height=50,
+        pad_left=0,
+        pad_top=25,
+        pad_right=0,
+        pad_bottom=25,
+        scale=1.0,
+    )
+
+
+def test_label_path_replaces_images_component(tmp_path: Path):
+    image = tmp_path / "dataset" / "images" / "val" / "sample.jpg"
+    assert label_path_for_image(image) == tmp_path / "dataset" / "labels" / "val" / "sample.txt"
+
+
+def test_strict_yolo_label_parser(tmp_path: Path):
+    labels = tmp_path / "sample.txt"
+    labels.write_text("2 0.5 0.5 0.4 0.2\n", encoding="utf-8")
+    assert parse_yolo_labels(labels) == [YoloBox(2, 0.5, 0.5, 0.4, 0.2)]
+    labels.write_text("2 1.2 0.5 0.4 0.2\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="center"):
+        parse_yolo_labels(labels)
+
+
+def test_token_masks_exclude_letterbox_padding_and_use_cell_centers():
+    masks = token_region_masks([YoloBox(0, 0.5, 0.5, 0.5, 1.0)], _meta(), 4, 4)
+    assert masks["padding"].tolist() == [
+        [True, True, True, True],
+        [False, False, False, False],
+        [False, False, False, False],
+        [True, True, True, True],
+    ]
+    assert masks["foreground"].sum() == 4
+    assert masks["background"].sum() == 4
+    assert np.all(masks["foreground"][:, 1:3] == ~masks["padding"][:, 1:3])
+
+
+def test_region_diagnostics_has_known_contrast():
+    weights = np.asarray(
+        [
+            [[0.9, 0.8], [0.2, 0.1]],
+            [[0.1, 0.2], [0.8, 0.9]],
+        ],
+        dtype=np.float32,
+    )
+    foreground = np.asarray([[True, True], [False, False]])
+    background = ~foreground
+    diagnostics = region_routing_diagnostics(
+        weights,
+        {"foreground": foreground, "background": background, "padding": np.zeros((2, 2), dtype=bool)},
+    )
+    assert diagnostics["status"] == "SUPPORTED"
+    assert diagnostics["foreground"]["mean_expert_probability"] == pytest.approx([0.85, 0.15])
+    assert diagnostics["background"]["mean_expert_probability"] == pytest.approx([0.15, 0.85])
+    assert diagnostics["contrast"]["total_variation_distance"] == pytest.approx(0.7)
+
+
+def test_region_diagnostics_marks_empty_group_without_inventing_values():
+    weights = np.full((2, 2, 2), 0.5, dtype=np.float32)
+    diagnostics = region_routing_diagnostics(
+        weights,
+        {
+            "foreground": np.zeros((2, 2), dtype=bool),
+            "background": np.ones((2, 2), dtype=bool),
+            "padding": np.zeros((2, 2), dtype=bool),
+        },
+    )
+    assert diagnostics["status"] == "INSUFFICIENT_TOKENS"
+    assert diagnostics["foreground"]["mean_expert_probability"] is None
+    assert diagnostics["contrast"] is None
+
+
+def test_aggregate_reports_pooled_and_equal_weight_paired_contrasts():
+    first = region_routing_diagnostics(
+        np.asarray([[[0.9, 0.2], [0.9, 0.2]], [[0.1, 0.8], [0.1, 0.8]]], dtype=np.float32),
+        {
+            "foreground": np.asarray([[True, False], [True, False]]),
+            "background": np.asarray([[False, True], [False, True]]),
+            "padding": np.asarray([[False, False], [False, False]]),
+        },
+    )
+    second = region_routing_diagnostics(
+        np.asarray([[[0.6, 0.4], [0.6, 0.4]], [[0.4, 0.6], [0.4, 0.6]]], dtype=np.float32),
+        {
+            "foreground": np.asarray([[True, False], [True, False]]),
+            "background": np.asarray([[False, True], [False, True]]),
+            "padding": np.asarray([[False, False], [False, False]]),
+        },
+    )
+    aggregate = aggregate_region_diagnostics(
+        [
+            {"family": "mot", "module": "router", "region_diagnostics": first},
+            {"family": "mot", "module": "router", "region_diagnostics": second},
+        ]
+    )["by_family"]["mot"]
+    assert aggregate["pooled_contrast"]["total_variation_distance"] == pytest.approx(0.45)
+    assert aggregate["paired_capture_contrast"]["capture_count"] == 2
+    assert aggregate["paired_capture_contrast"]["total_variation_distance"]["mean"] == pytest.approx(0.45)

--- a/tools/e3_routing/tests/p2/test_runner_contract.py
+++ b/tools/e3_routing/tests/p2/test_runner_contract.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+from e3_p2.demo import resolve_run_dir
+from e3_p2.runner import _demo_html, _load_config, _slug, _verify_project_source_state
+
+
+def _config() -> dict:
+    return {
+        "run_id": "safe-run",
+        "sample_indices": [0],
+        "spatial_profiles": {"mot": {}, "moa": {}},
+        "non_spatial_profiles": {"moe": {}, "latent": {}, "molora": {}},
+        "batch_equivalence_sizes": [2],
+        "region_analysis": {
+            "enabled": True,
+            "label_format": "yolo_detection_normalized_xywh",
+            "assignment_rule": "valid_token_center_inside_any_ground_truth_box",
+            "exclude_letterbox_padding": True,
+        },
+    }
+
+
+def test_run_id_cannot_escape_evidence_directory(tmp_path: Path):
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(_config()), encoding="utf-8")
+    assert _load_config(path)["run_id"] == "safe-run"
+    with pytest.raises(ValueError, match="path-safe"):
+        _load_config(path, "../escape")
+
+
+def test_family_contract_is_explicit(tmp_path: Path):
+    config = _config()
+    config["non_spatial_profiles"].pop("molora")
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    with pytest.raises(ValueError, match="exactly"):
+        _load_config(path)
+
+
+def test_slug_is_stable_for_module_paths():
+    assert _slug("model.13.m.0/router") == "model.13.m.0-router"
+
+
+def test_demo_requires_both_index_and_html(tmp_path: Path):
+    (tmp_path / "demo.html").write_text("ok", encoding="utf-8")
+    with pytest.raises(FileNotFoundError, match="Not a P2 demo"):
+        resolve_run_dir(tmp_path)
+
+
+def test_repository_implementation_state_is_inspectable():
+    state = _verify_project_source_state(False)
+    assert set(state) == {"commit", "tree", "implementation_status_porcelain", "implementation_clean"}
+
+
+def test_invalid_batch_equivalence_size_is_rejected(tmp_path: Path):
+    config = _config()
+    config["batch_equivalence_sizes"] = [1]
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    with pytest.raises(ValueError, match=">= 2"):
+        _load_config(path)
+
+
+def test_region_assignment_contract_cannot_be_silently_changed(tmp_path: Path):
+    config = _config()
+    config["region_analysis"]["exclude_letterbox_padding"] = False
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    with pytest.raises(ValueError, match="region_analysis"):
+        _load_config(path)
+
+
+def test_demo_exposes_original_entropy_margin_and_failure_state():
+    html = _demo_html()
+    assert 'id=\"original\"' in html
+    assert 'id=\"groundTruth\"' in html
+    assert "Normalized routing entropy" in html
+    assert "Top-1 routing margin" in html
+    assert "FG/BG TV" in html
+    assert "Evidence failed to load" in html

--- a/tools/e3_routing/tests/p2/test_scale_runner.py
+++ b/tools/e3_routing/tests/p2/test_scale_runner.py
@@ -1,0 +1,124 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from e3_p2.scale_runner import (
+    _load_config,
+    archive_selected_inputs,
+    bootstrap_layer_share_interval,
+    bootstrap_mean_interval,
+    deterministic_image_selection,
+    summarize_image_level_attribution,
+)
+
+
+def test_scale_config_keeps_default_contract_but_allows_explicit_extended_modes(tmp_path: Path):
+    import yaml
+
+    base = {
+        "run_id": "test-dose",
+        "device": "cpu",
+        "resolution": 128,
+        "family": "moa",
+        "target_module": "target",
+        "seeds": [0, 1],
+        "selected_image_count": 16,
+        "expected_dataset_image_count": 16,
+        "selection_salt": "fixed",
+        "bootstrap_draws": 1000,
+        "max_evidence_bytes": 1_000_000,
+        "transformations": [{"name": "identity", "kind": "identity"}]
+        + [{"name": f"condition_{index}", "kind": "brightness", "factor": 0.9} for index in range(9)],
+    }
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(base), encoding="utf-8")
+    with pytest.raises(ValueError, match="transform contract must remain fixed"):
+        _load_config(config_path, None)
+    base["study_kind"] = "dose_response"
+    config_path.write_text(yaml.safe_dump(base), encoding="utf-8")
+    assert _load_config(config_path, None)["study_kind"] == "dose_response"
+    base["study_kind"] = "output_coupling"
+    base["record_detector_outputs"] = True
+    base["transformations"] = base["transformations"][:4]
+    config_path.write_text(yaml.safe_dump(base), encoding="utf-8")
+    assert _load_config(config_path, None)["study_kind"] == "output_coupling"
+    base["record_detector_outputs"] = False
+    config_path.write_text(yaml.safe_dump(base), encoding="utf-8")
+    with pytest.raises(ValueError, match="detector-output recording"):
+        _load_config(config_path, None)
+
+
+def test_hash_selection_is_order_independent_and_not_content_driven():
+    paths = [Path(name) for name in ("c.jpg", "a.jpg", "d.jpg", "b.jpg")]
+    first, first_records = deterministic_image_selection(paths, 2, "fixed")
+    second, second_records = deterministic_image_selection(list(reversed(paths)), 2, "fixed")
+    assert [path.name for path in first] == [path.name for path in second]
+    assert [item["selection_sha256"] for item in first_records] == [
+        item["selection_sha256"] for item in second_records
+    ]
+
+
+def test_archive_retains_a_selected_image_without_label(tmp_path: Path):
+    from PIL import Image
+
+    image_dir = tmp_path / "images" / "train"
+    image_dir.mkdir(parents=True)
+    image_path = image_dir / "background.jpg"
+    Image.new("RGB", (8, 6), (20, 30, 40)).save(image_path)
+    run_dir = tmp_path / "run"
+    records = archive_selected_inputs([image_path], run_dir)
+    assert records[0]["label_status"] == "MISSING_DATASET_LABEL"
+    assert records[0]["label_sha256"] is None
+    assert records[0]["label_artifact"] is None
+    assert (run_dir / records[0]["image_artifact"]).is_file()
+
+
+def test_bootstrap_helpers_are_deterministic_and_image_level():
+    values = np.asarray([0.1, 0.2, 0.3, 0.4])
+    first = bootstrap_mean_interval(values, 1000, 7)
+    second = bootstrap_mean_interval(values, 1000, 7)
+    assert first == second
+    assert first["unit_count"] == 4
+    matrix = np.asarray([[9.0, 1.0], [8.0, 2.0], [7.0, 3.0], [6.0, 4.0]])
+    result = bootstrap_layer_share_interval(matrix, 0, 1000, 9)
+    assert result["image_unit_count"] == 4
+    assert result["observed_target_share"] == pytest.approx(0.75)
+    assert result["target_rank_one_draw_fraction"] == 1.0
+
+
+def _comparison(image: int, transform: str, seed: int, module: str, value: float) -> dict:
+    return {
+        "family": "moa",
+        "sample_index": image,
+        "comparison_type": f"appearance_{transform}",
+        "seed": seed,
+        "module": module,
+        "metrics": {"probability_mae": value},
+    }
+
+
+def test_image_level_attribution_keeps_case_and_leave_one_out_counts():
+    records = []
+    for image in range(3):
+        for transform in ("brightness", "blur"):
+            for seed in (0, 1):
+                records.append(_comparison(image, transform, seed, "target", 10.0 + image))
+                records.append(_comparison(image, transform, seed, "other", 1.0))
+    result = summarize_image_level_attribution(records, ["brightness", "blur"], "target", 1000, 4)
+    assert result["target_rank_one_case_count"] == 12
+    assert result["case_count"] == 12
+    assert result["target_rank_one_image_transform_count"] == 6
+    assert result["target_rank_one_image_count"] == 3
+    assert result["target_rank_one_leave_one_out_count"] == 6
+    assert result["leave_one_out_count"] == 6
+
+
+def test_image_level_attribution_rejects_incomplete_matrix():
+    records = [
+        _comparison(0, "brightness", 0, "target", 2.0),
+        _comparison(0, "brightness", 0, "other", 1.0),
+        _comparison(1, "brightness", 0, "target", 2.0),
+    ]
+    with pytest.raises(ValueError, match="incomplete"):
+        summarize_image_level_attribution(records, ["brightness"], "target", 1000, 4)

--- a/tools/e3_routing/tests/p2/test_stability.py
+++ b/tools/e3_routing/tests/p2/test_stability.py
@@ -1,0 +1,95 @@
+import numpy as np
+import pytest
+
+from e3_p2.geometry import LetterboxMeta
+from e3_p2.stability import (
+    aggregate_stability_comparisons,
+    probability_map_comparison,
+    restore_probability_stack,
+)
+
+
+def test_identical_nonconstant_maps_have_exact_identity_metrics():
+    first = np.asarray([[[0.2, 0.8], [0.4, 0.6]], [[0.8, 0.2], [0.6, 0.4]]], dtype=np.float32)
+    result = probability_map_comparison(first, first.copy())
+    assert result["probability_mae"] == 0.0
+    assert result["mean_jensen_shannon_divergence_nats"] == 0.0
+    assert result["dominant_expert_agreement_fraction"] == 1.0
+    assert result["defined_pearson_mean"] == pytest.approx(1.0)
+
+
+def test_constant_correlation_is_explicitly_undefined():
+    constant = np.full((2, 3, 4), 0.5, dtype=np.float32)
+    result = probability_map_comparison(constant, constant.copy())
+    assert result["probability_mae"] == 0.0
+    assert result["defined_pearson_count"] == 0
+    assert result["undefined_pearson_count"] == 2
+    assert result["defined_pearson_mean"] is None
+    assert all(item["status"] == "UNDEFINED_CONSTANT_INPUT" for item in result["expert_pearson"])
+
+
+def test_known_probability_change_has_expected_mae_tv_and_dominant_agreement():
+    first = np.asarray([[[0.9, 0.2]], [[0.1, 0.8]]], dtype=np.float32)
+    second = np.asarray([[[0.8, 0.7]], [[0.2, 0.3]]], dtype=np.float32)
+    result = probability_map_comparison(first, second)
+    assert result["probability_mae"] == pytest.approx(0.3)
+    assert result["mean_total_variation_distance"] == pytest.approx(0.3)
+    assert result["dominant_expert_agreement_fraction"] == pytest.approx(0.5)
+    assert result["mean_jensen_shannon_divergence_nats"] >= 0.0
+    assert result["reference_top1_margin_mean"] == pytest.approx(0.7)
+    curve = result["agreement_at_or_above_reference_margin_percentiles"]
+    assert curve[0]["dominant_expert_agreement_fraction"] == pytest.approx(0.5)
+    assert curve[3]["reference_margin_percentile"] == 75
+    assert curve[3]["dominant_expert_agreement_fraction"] == 1.0
+    assert result["changed_pixel_reference_margin_mean"] == pytest.approx(0.6)
+    assert result["unchanged_pixel_reference_margin_mean"] == pytest.approx(0.8)
+
+
+def test_horizontal_unflip_restores_the_same_coordinate_system():
+    original = np.asarray(
+        [[[0.1, 0.3, 0.8], [0.2, 0.4, 0.7]], [[0.9, 0.7, 0.2], [0.8, 0.6, 0.3]]],
+        dtype=np.float32,
+    )
+    flipped_observation = np.flip(original, axis=2)
+    result = probability_map_comparison(original, np.flip(flipped_observation, axis=2))
+    assert result["probability_mae"] == 0.0
+    assert result["dominant_expert_agreement_fraction"] == 1.0
+
+
+def test_restore_probability_stack_keeps_original_shape_and_normalization():
+    meta = LetterboxMeta(8, 4, 8, 8, 4, 0, 2, 0, 2, 1.0)
+    weights = np.asarray(
+        [
+            [[0.2, 0.4], [0.6, 0.8]],
+            [[0.8, 0.6], [0.4, 0.2]],
+        ],
+        dtype=np.float32,
+    )
+    restored, validation = restore_probability_stack(weights, meta)
+    assert restored.shape == (2, 4, 8)
+    assert np.allclose(restored.sum(axis=0), 1.0)
+    assert validation["post_normalization_max_expert_sum_error"] <= 1e-6
+
+
+def test_aggregate_counts_defined_and_undefined_correlations():
+    variable = np.asarray([[[0.2, 0.8]], [[0.8, 0.2]]], dtype=np.float32)
+    constant = np.full((2, 1, 2), 0.5, dtype=np.float32)
+    comparisons = []
+    for metrics in (probability_map_comparison(variable, variable), probability_map_comparison(constant, constant)):
+        comparisons.append(
+            {
+                "comparison_type": "horizontal_flip",
+                "family": "mot",
+                "candidate_resolution": 64,
+                "module": "router",
+                "seed": 0,
+                "metrics": metrics,
+            }
+        )
+    aggregate = aggregate_stability_comparisons(comparisons)
+    summary = aggregate["by_type_family_resolution"]["horizontal_flip:mot:64"]
+    assert summary["comparison_count"] == 2
+    assert summary["expert_pearson"]["defined_count"] == 2
+    assert summary["expert_pearson"]["undefined_count"] == 2
+    assert aggregate["by_type_family_module"]["horizontal_flip:mot:router"]["comparison_count"] == 2
+    assert aggregate["by_type_family_seed"]["horizontal_flip:mot:seed-0"]["comparison_count"] == 2

--- a/tools/e3_routing/tests/test_cli_defaults.py
+++ b/tools/e3_routing/tests/test_cli_defaults.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from e3_p0.runner import PROJECT_ROOT as P0_ROOT
+from e3_p0.runner import parse_args as parse_p0_args
+from e3_p1.benchmark import PROJECT_ROOT as P1_ROOT
+from e3_p1.benchmark import parse_args as parse_p1_args
+from e3_p2 import runner as p2_runner
+from e3_p2.__main__ import PROJECT_ROOT as P2_ROOT
+from e3_p2.__main__ import build_parser
+
+
+def test_p0_default_config_exists(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["e3_p0"])
+    config = parse_p0_args().config
+    assert config == P0_ROOT / "configs" / "p0" / "p0.yaml"
+    assert config.is_file()
+
+
+def test_p1_default_config_exists(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["e3_p1"])
+    config = parse_p1_args().config
+    assert config == P1_ROOT / "configs" / "p1" / "p1.yaml"
+    assert config.is_file()
+
+
+def test_all_p2_default_configs_exist() -> None:
+    parser = build_parser()
+    expected = {
+        "run": "p2.yaml",
+        "robustness": "robustness.yaml",
+        "appearance": "appearance.yaml",
+        "layer-drilldown": "layer_drilldown.yaml",
+        "image-scale": "image_scale.yaml",
+        "image-driver": "image_driver.yaml",
+        "dose-response": "dose_response.yaml",
+        "output-coupling": "output_coupling.yaml",
+        "dose-holdout": "dose_holdout.yaml",
+        "blur-residual": "blur_residual.yaml",
+    }
+    for command, filename in expected.items():
+        config: Path = parser.parse_args([command]).config
+        assert config == P2_ROOT / "configs" / "p2" / filename
+        assert config.is_file()
+
+
+def test_direct_p2_runner_uses_existing_default_config(monkeypatch) -> None:
+    seen: dict[str, Path] = {}
+
+    def fake_run(config: Path, **_: object) -> Path:
+        seen["config"] = config
+        return config
+
+    monkeypatch.setattr(p2_runner, "run", fake_run)
+    p2_runner.main([])
+    assert seen["config"] == P2_ROOT / "configs" / "p2" / "p2.yaml"
+    assert seen["config"].is_file()


### PR DESCRIPTION
## Summary

This PR adds the E3 routing-observability workflow under `tools/e3_routing` without changing model forward
signatures or routing decisions.

- **P0:** one versioned event schema and static diagnostics for real MoE, MoT and Latent forwards.
- **P1:** a read-only localhost dashboard plus paired full-step overhead measurement.
- **P2:** a five-family feasibility audit and original-image overlays only for routers with a genuine 2D token axis.

Hooks are removable and hooked/unhooked outputs are checked for equality. Spatial diagnostics fail closed: MoE,
Latent and MoLoRA are reported as `UNSUPPORTED` instead of reshaping sample-level or expert-axis vectors into heatmaps.

## Acceptance results

| Level | Result |
| --- | --- |
| P0 | 52 primary events across 6 MoE, 4 MoT and 3 Latent modules; 52/52 repeat fingerprints matched; batch 2/4 maximum load delta `0` (`1e-5` gate) |
| P1 | Three-family HTTP dashboard; 108 paired full training steps; all slowdown medians and 95% CI upper bounds below the predeclared 10% gate |
| P2 | Five families audited; MoT/MoA spatially supported; 32 captures, 240 raw arrays and 192 selectable views; hook output delta `0` |

### P1 overhead

| Family | Pairs | Median slowdown | 95% bootstrap CI | Verdict |
| --- | ---: | ---: | ---: | --- |
| MoE | 30 | 2.113% | [-2.514%, 8.361%] | PASS / STRONG |
| MoT | 48 | -0.050% | [-6.374%, 9.451%] | PASS / STRONG |
| Latent | 30 | -5.741% | [-16.195%, 1.570%] | PASS / STRONG |

Negative values are treated as CPU timing noise, not observer speedups. The measured step includes detection loss,
backward, gradient clipping, grouped SGD, and the requested JSONL write/flush.

## Implementation notes

### P0

- Defines `e3.routing/v1.0.0` with expert load, entropy, Gini, dominant share, mixing-weight availability and
  auxiliary-loss availability.
- Writes JSONL, aggregates, repeat/batch comparisons, static plots, resolved configuration, input hashes and
  SHA-256 manifests.

### P1

- Reads the same event stream through health, dashboard and snapshot endpoints bound to `127.0.0.1`.
- Separates source count, active window size and truncation; only a concurrently written final partial line is ignored.
- Compares `off`, `capture_memory` and `capture_jsonl` under a balanced schedule and includes an official
  `DetectionTrainer` state-equivalence cross-check.

### P2

- Captures router-child outputs before public snapshots average spatial axes.
- Reverses recorded letterbox geometry and exports fixed-scale probability, entropy, Top-1 margin and
  dominant-expert views at the original image size.
- Adds batch-position identity, repeatability, geometry, source-fingerprint, ground-truth-region and asset-integrity
  gates.
- Includes a localhost demo with family/sample/layer/view selection, ground-truth toggling, metadata copy and PNG
  export.

The extended diagnostic study covers 32 images, three seeds and graded brightness/contrast/blur perturbations. The
predeclared blur residual test produced no Holm-significant association; the null result is retained rather than
reinterpreted after the fact.

## Verification

Final release tree: `c753ca3d13ab6f90bba86636774ce7e4c937c47d`, based directly on upstream
`7bfbfd374a6b44720f98366e088f3a962e16321d`.

- `113 passed` for the combined phase and CLI-contract suite.
- Ruff: `PASS` for `src`, `tests` and `scripts`.
- Upstream config/model regression subset: `13 passed`; one expected MoA head-adjustment warning.
- Latest-main real-forward smoke: `PASS`; P0 module counts `6/4/3`, MoT/MoA spatial counts `4/4`, all hook deltas `0`.
- Latest-main full P0: `PASS`; 52 primary + 52 repeat events, batch 2/4 maximum load delta `0`.
- P1 dashboard over the latest P0 stream: HTTP 200, 52 events, MoE/MoT/Latent, no truncation.
- Latest-main full P2 with `require_committed_source=true`: `PASS`; clean implementation state and 9/9 source
  fingerprints matched.
- Seven archived formal evidence packages: 395 manifest entries independently rehashed with zero mismatch.

## Reviewer quick start

From the YOLO-Master repository root:

```bat
cd tools\e3_routing
python -m pip install -e ".[test]"
python -m pytest tests -q
python -m ruff check src tests scripts
python scripts\latest_main_smoke.py --repo-root ..\.. --output artifacts\latest-main-smoke.json
python -m e3_p0 --run-id review-p0 --no-update-latest
python -m e3_p2 run --run-id review-p2 --no-latest
python -m e3_p1.dashboard --events artifacts\p0\review-p0\routing-all.jsonl
```

Active configs target the containing checkout. Frozen configs preserve the source identity used for the archived
numerical evidence; latest-main compatibility checks do not relabel historical runs.

## Evidence

- P0 fixed evidence: https://github.com/Ricky-7-Yan/YOLO-Master-E3-P0/tree/7766f5038d8cafb40f001dd0ce3fd9c9d89030b8
- P1 fixed evidence: https://github.com/Ricky-7-Yan/YOLO-Master-E3-P1/tree/bea6e7e526ca7667c1b933e8ac24627ce757d337
- P2 fixed evidence: https://github.com/Ricky-7-Yan/YOLO-Master-E3-P2/tree/b04c52286502cd41a437081c046166a9db091c7c

## Demo video

https://github.com/user-attachments/assets/9dbbcf77-5b89-40bb-ac48-25d412b68dba

## Limitations

- Evidence is CPU-only and primarily uses randomly initialized models. It validates instrumentation and bounded
  cold-start diagnostics, not trained AP, convergence or expert semantics.
- No CUDA overhead or GPU-memory claim is made.
- The short coco8 `DetectionTrainer` epoch windows are descriptive; the preregistered 108-pair full-step benchmark
  remains the formal P1 verdict.
- Only MoT and MoA expose recoverable 2D token routes in the audited runtime.
- Routing/output associations are diagnostic, not causal.