### PR TITLE
[犀牛鸟-D2]：Foundation 蒸馏 P0-P2 评估闭环与 Go/No-Go 工具（吴夏祯）

### DIFF
--- a/docs/en/guides/foundation-distillation-evaluation.md
+++ b/docs/en/guides/foundation-distillation-evaluation.md
@@ -1,0 +1,72 @@
+# Foundation Distillation Evaluation Plan
+
+This document is the review contract for the Foundation teacher experiment. It freezes the design and decision line
+before an accuracy result is inspected.
+
+## P0: minimum viable distillation
+
+- Student location: the P4 source consumed by the YOLO `Detect` head. `StudentFeatureTap` resolves it from the head's
+  graph metadata instead of relying on a model-specific hard-coded layer number.
+- Teacher location: DINOv3 dense patch tokens, normalized to BCHW and exposed as `dense["p4"]` by the teacher protocol.
+- Projection: trainable student 1x1 convolution plus optional normalization; detached teacher identity or frozen 1x1
+  projection. Only the teacher grid is resized to the live student grid.
+- Loss: cosine feature loss plus optional sampled relational loss. The teacher is detached, kept out of the optimizer,
+  state dict, EMA, DDP graph, prediction path, and export graph.
+- Smoke evidence: `python scripts/foundation_p0_smoke.py`. Passing requires finite loss, decreasing single-batch loss,
+  aligned stage shapes, a trainable student projector, and no teacher gradient.
+
+The production entry point remains `FoundationDistillationModel`; the offline smoke is deliberately a dependency-light
+acceptance probe, not a second training implementation.
+
+## P1: paired on/off experiment
+
+Use `scripts/foundation_f08_effect_gate.py` with at least three seeds. Each baseline/Foundation pair must share the
+model config, initialization seed, dataset split, epochs, image size, batch size, optimizer, augmentation, validation
+split, and checkpoint-selection rule. Only `foundation_*` settings and run identity may differ.
+
+The primary metric is `metrics/mAP50-95(B)`. Repository metrics use a 0..1 fraction; the decision report converts them
+to percentage points. The preregistered rule is:
+
+> NO-GO when `abs(mean paired delta) < 0.3 mAP points` and the two-sided 95% paired Student-t confidence interval
+> contains zero.
+
+A positive GO requires both a mean delta of at least +0.3 points and a confidence interval strictly above zero. A
+negative interval is NO-GO. All other outcomes are INCONCLUSIVE and require more paired seeds without changing the
+decision line.
+
+Generate the review artifacts with:
+
+```bash
+python scripts/foundation_distill_decision.py \
+  --input reports/foundation/v0.1/f08-effect-gate-mps.json \
+  --output-json reports/foundation/v0.1/distill-decision.json \
+  --output-md reports/foundation/v0.1/distill-recommendation.md
+```
+
+## No-confound table
+
+| Variable | Baseline | Foundation | Allowed to differ |
+|---|---|---|---|
+| Student YAML and initialization | same model + seed | same model + seed | no |
+| Dataset and train/validation split | frozen | frozen | no |
+| Epochs, batch, image size, optimizer | frozen | frozen | no |
+| Augmentation and checkpoint selection | frozen | frozen | no |
+| Teacher/projector/loss settings | disabled | preregistered recipe | yes |
+| Decision threshold | 0.3 mAP points | 0.3 mAP points | no |
+
+The decision tool audits the serialized run plan and returns `INSUFFICIENT` if a non-Foundation field differs.
+
+## P2: interpretation and recommendation
+
+For GO, report paired AP deltas for small/medium/large objects and optional per-class AP. A category claim is allowed
+only when the evaluator supplied `per_class_ap`, `per_category_ap`, or `category_ap`; missing values are never imputed.
+
+For NO-GO or INCONCLUSIVE, the generated recommendation covers four hypotheses:
+
+- capacity: compare the next student size only when scale evidence supports a backbone bottleneck;
+- dimension: compare one smaller and one larger `foundation_align_dim` under the same paired budget;
+- optimization: inspect Foundation/task loss ratio and raw cosine/relational curves before retuning the weight;
+- data: add paired seeds when the confidence interval is wide, without moving the 0.3-point decision line.
+
+The Markdown output is the formal go/no-go recommendation. It must accompany the machine-readable JSON and the source
+effect-gate report in review.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -542,6 +542,7 @@ nav:
       - Isolating Segmentation Objects: guides/isolating-segmentation-objects.md
       - K-Fold Cross Validation: guides/kfold-cross-validation.md
       - Foundation Teacher Distillation: guides/foundation-distillation.md
+      - Foundation Distillation Evaluation: guides/foundation-distillation-evaluation.md
       - Knowledge Distillation 🚀: guides/knowledge-distillation.md
       - Maintaining Your Computer Vision Model: guides/model-monitoring-and-maintenance.md
       - Modal Quickstart: guides/modal-quickstart.md

--- a/scripts/foundation_distill_decision.py
+++ b/scripts/foundation_distill_decision.py
@@ -1,0 +1,571 @@
+#!/usr/bin/env python3
+"""Turn paired Foundation on/off runs into a preregistered go/no-go recommendation.
+
+The input is the JSON report emitted by ``foundation_f08_effect_gate.py``. Metrics are
+normally stored on a 0..1 scale; decisions are reported in mAP percentage points.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Mapping
+
+SCHEMA_VERSION = 1
+DEFAULT_METRIC = "metrics/mAP50-95(B)"
+SCALE_METRICS = {
+    "small": "metrics/mAP_small(B)",
+    "medium": "metrics/mAP_medium(B)",
+    "large": "metrics/mAP_large(B)",
+}
+_T95 = {
+    1: 12.706,
+    2: 4.303,
+    3: 3.182,
+    4: 2.776,
+    5: 2.571,
+    6: 2.447,
+    7: 2.365,
+    8: 2.306,
+    9: 2.262,
+    10: 2.228,
+    11: 2.201,
+    12: 2.179,
+    13: 2.160,
+    14: 2.145,
+    15: 2.131,
+    16: 2.120,
+    17: 2.110,
+    18: 2.101,
+    19: 2.093,
+    20: 2.086,
+    21: 2.080,
+    22: 2.074,
+    23: 2.069,
+    24: 2.064,
+    25: 2.060,
+    26: 2.056,
+    27: 2.052,
+    28: 2.048,
+    29: 2.045,
+    30: 2.042,
+}
+
+
+def _finite(value: Any) -> float | None:
+    """Return a finite float, otherwise ``None``."""
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _metrics(record: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Resolve the metric container used by supported experiment reports."""
+    for key in ("observed", "validation_metrics", "metrics"):
+        value = record.get(key)
+        if isinstance(value, Mapping):
+            return value
+    return {}
+
+
+def _record_arm(record: Mapping[str, Any]) -> str | None:
+    """Resolve an explicit arm or the generic baseline/Foundation branch name."""
+    if record.get("arm") is not None:
+        return str(record["arm"])
+    if isinstance(record.get("foundation"), bool):
+        return "foundation" if record["foundation"] else "baseline"
+    return None
+
+
+def _plan_arm(spec: Mapping[str, Any]) -> str | None:
+    """Resolve a plan arm using the same rules as result records."""
+    return _record_arm(spec)
+
+
+def _metric_multiplier(records: list[Mapping[str, Any]], metric: str, metric_scale: str) -> float:
+    """Convert repository-native 0..1 AP values into percentage points."""
+    if metric_scale == "fraction":
+        return 100.0
+    if metric_scale == "points":
+        return 1.0
+    values = [_finite(_metrics(record).get(metric)) for record in records]
+    finite = [abs(value) for value in values if value is not None]
+    return 100.0 if finite and max(finite) <= 1.5 else 1.0
+
+
+def _paired_records(
+    payload: Mapping[str, Any], baseline_arm: str, treatment_arm: str
+) -> tuple[list[tuple[int, Mapping[str, Any], Mapping[str, Any]]], list[dict[str, Any]]]:
+    """Pair baseline and treatment records by seed without imputing missing runs."""
+    records = payload.get("records")
+    if not isinstance(records, list):
+        raise TypeError("report must contain a records list")
+    by_key: dict[tuple[int, str], Mapping[str, Any]] = {}
+    issues: list[dict[str, Any]] = []
+    for record in records:
+        if not isinstance(record, Mapping) or _record_arm(record) not in {baseline_arm, treatment_arm}:
+            continue
+        try:
+            key = (int(record["seed"]), str(_record_arm(record)))
+        except (KeyError, TypeError, ValueError):
+            issues.append({"kind": "invalid_record", "record": dict(record) if isinstance(record, Mapping) else record})
+            continue
+        if key in by_key:
+            raise ValueError(f"duplicate record for seed={key[0]} arm={key[1]}")
+        by_key[key] = record
+    seeds = sorted({seed for seed, _ in by_key})
+    pairs = []
+    for seed in seeds:
+        baseline = by_key.get((seed, baseline_arm))
+        treatment = by_key.get((seed, treatment_arm))
+        if baseline is None or treatment is None:
+            issues.append(
+                {
+                    "kind": "incomplete_pair",
+                    "seed": seed,
+                    "baseline_present": baseline is not None,
+                    "treatment_present": treatment is not None,
+                }
+            )
+            continue
+        pairs.append((seed, baseline, treatment))
+    return pairs, issues
+
+
+def _clean_overrides(spec: Mapping[str, Any]) -> dict[str, Any]:
+    """Remove only the preregistered treatment and run-identity fields."""
+    overrides = spec.get("overrides")
+    if not isinstance(overrides, Mapping):
+        return {}
+    return {
+        str(key): value
+        for key, value in overrides.items()
+        if not str(key).startswith("foundation_") and key not in {"name", "resume"}
+    }
+
+
+def audit_equal_budget(payload: Mapping[str, Any], baseline_arm: str, treatment_arm: str) -> dict[str, Any]:
+    """Audit that paired plan arms differ only in Foundation-specific fields."""
+    plan = payload.get("plan")
+    if not isinstance(plan, list):
+        return {"available": False, "passed": False, "mismatches": ["missing plan"]}
+    by_key = {}
+    for spec in plan:
+        if not isinstance(spec, Mapping) or _plan_arm(spec) not in {baseline_arm, treatment_arm}:
+            continue
+        try:
+            by_key[(int(spec["seed"]), str(_plan_arm(spec)))] = spec
+        except (KeyError, TypeError, ValueError):
+            continue
+    seeds = sorted({seed for seed, _ in by_key})
+    mismatches = []
+    checked = 0
+    for seed in seeds:
+        baseline = by_key.get((seed, baseline_arm))
+        treatment = by_key.get((seed, treatment_arm))
+        if baseline is None or treatment is None:
+            mismatches.append({"seed": seed, "fields": ["missing paired plan arm"]})
+            continue
+        checked += 1
+        left, right = _clean_overrides(baseline), _clean_overrides(treatment)
+        fields = sorted(key for key in set(left) | set(right) if left.get(key) != right.get(key))
+        if fields:
+            mismatches.append(
+                {
+                    "seed": seed,
+                    "fields": fields,
+                    "baseline": {key: left.get(key) for key in fields},
+                    "treatment": {key: right.get(key) for key in fields},
+                }
+            )
+    return {
+        "available": True,
+        "passed": checked > 0 and not mismatches,
+        "paired_specs_checked": checked,
+        "mismatches": mismatches,
+    }
+
+
+def paired_interval(values: list[float], *, confidence: float = 0.95) -> dict[str, Any]:
+    """Calculate a two-sided Student-t interval for paired deltas."""
+    if not values:
+        return {"n": 0, "mean": None, "sample_std": None, "low": None, "high": None, "confidence": confidence}
+    mean = statistics.fmean(values)
+    if len(values) == 1:
+        return {"n": 1, "mean": mean, "sample_std": None, "low": None, "high": None, "confidence": confidence}
+    sample_std = statistics.stdev(values)
+    if confidence != 0.95:
+        raise ValueError("only the preregistered 95% confidence interval is supported")
+    critical = _T95.get(len(values) - 1, 1.96)
+    half_width = critical * sample_std / math.sqrt(len(values))
+    return {
+        "n": len(values),
+        "mean": mean,
+        "sample_std": sample_std,
+        "low": mean - half_width,
+        "high": mean + half_width,
+        "confidence": confidence,
+    }
+
+
+def _summarize_metric(
+    pairs: list[tuple[int, Mapping[str, Any], Mapping[str, Any]]], metric: str, multiplier: float
+) -> dict[str, Any]:
+    """Summarize complete paired deltas for one metric in mAP points."""
+    observations = []
+    for seed, baseline, treatment in pairs:
+        baseline_value = _finite(_metrics(baseline).get(metric))
+        treatment_value = _finite(_metrics(treatment).get(metric))
+        if baseline_value is None or treatment_value is None:
+            continue
+        observations.append(
+            {
+                "seed": seed,
+                "baseline": baseline_value * multiplier,
+                "treatment": treatment_value * multiplier,
+                "delta": (treatment_value - baseline_value) * multiplier,
+            }
+        )
+    interval = paired_interval([item["delta"] for item in observations])
+    return {"metric": metric, "unit": "mAP_points", "observations": observations, **interval}
+
+
+def _class_ap(record: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Resolve optional per-category AP emitted by an evaluator extension."""
+    for container in (record, _metrics(record)):
+        for key in ("per_class_ap", "per_category_ap", "category_ap"):
+            value = container.get(key) if isinstance(container, Mapping) else None
+            if isinstance(value, Mapping):
+                return value
+    return {}
+
+
+def _category_summary(
+    pairs: list[tuple[int, Mapping[str, Any], Mapping[str, Any]]], multiplier: float
+) -> list[dict[str, Any]]:
+    """Aggregate optional paired per-category AP deltas."""
+    values: dict[str, list[float]] = defaultdict(list)
+    for _, baseline, treatment in pairs:
+        baseline_ap, treatment_ap = _class_ap(baseline), _class_ap(treatment)
+        for name in sorted(set(baseline_ap) & set(treatment_ap)):
+            left, right = _finite(baseline_ap[name]), _finite(treatment_ap[name])
+            if left is not None and right is not None:
+                values[str(name)].append((right - left) * multiplier)
+    result = [{"category": name, "unit": "mAP_points", **paired_interval(deltas)} for name, deltas in values.items()]
+    return sorted(result, key=lambda item: float(item["mean"]), reverse=True)
+
+
+def _benefit_summary(scales: Mapping[str, Mapping[str, Any]], categories: list[Mapping[str, Any]]) -> dict[str, Any]:
+    """Separate observed positive deltas from confidence-supported benefits."""
+
+    def positive(item: Mapping[str, Any]) -> bool:
+        return item.get("mean") is not None and float(item["mean"]) > 0
+
+    def confirmed(item: Mapping[str, Any]) -> bool:
+        return int(item.get("n", 0)) >= 3 and item.get("low") is not None and float(item["low"]) > 0
+
+    ranked_scales = sorted(
+        ({"scale": name, **dict(item)} for name, item in scales.items() if item.get("mean") is not None),
+        key=lambda item: float(item["mean"]),
+        reverse=True,
+    )
+    ranked_categories = [dict(item) for item in categories]
+    return {
+        "scale_evidence_available": bool(ranked_scales),
+        "observed_positive_scales": [item["scale"] for item in ranked_scales if positive(item)],
+        "confirmed_positive_scales": [item["scale"] for item in ranked_scales if confirmed(item)],
+        "ranked_scales": ranked_scales,
+        "category_evidence_available": bool(ranked_categories),
+        "category_claim_allowed": bool(ranked_categories) and all(int(item.get("n", 0)) >= 3 for item in categories),
+        "observed_positive_categories": [item["category"] for item in ranked_categories if positive(item)],
+        "confirmed_positive_categories": [item["category"] for item in ranked_categories if confirmed(item)],
+        "ranked_categories": ranked_categories,
+    }
+
+
+def _treatment_metric_mean(pairs: list[tuple[int, Mapping[str, Any], Mapping[str, Any]]], metric: str) -> float | None:
+    values = [_finite(_metrics(treatment).get(metric)) for _, _, treatment in pairs]
+    finite = [value for value in values if value is not None]
+    return statistics.fmean(finite) if finite else None
+
+
+def _diagnostics(
+    decision: str,
+    primary: Mapping[str, Any],
+    scales: Mapping[str, Mapping[str, Any]],
+    pairs: list[tuple[int, Mapping[str, Any], Mapping[str, Any]]],
+    payload: Mapping[str, Any],
+    treatment_arm: str,
+) -> list[dict[str, Any]]:
+    """Produce evidence-linked P2 diagnoses without pretending missing data are measurements."""
+    diagnostics = []
+    width = None
+    if primary.get("low") is not None and primary.get("high") is not None:
+        width = float(primary["high"]) - float(primary["low"])
+    diagnostics.append(
+        {
+            "area": "data",
+            "status": "risk" if int(primary["n"]) < 5 or (width is not None and width > 0.6) else "checked",
+            "evidence": (
+                f"{primary['n']} paired seeds; 95% CI width={width:.4f} mAP points"
+                if width is not None
+                else f"{primary['n']} paired seeds; CI unavailable"
+            ),
+            "next_action": (
+                "Add paired seeds with the same frozen budget and decision line; do not retune the threshold."
+            ),
+        }
+    )
+    task_ratio = _treatment_metric_mean(pairs, "train/foundation_task_ratio")
+    if task_ratio is None:
+        optimization_status, optimization_evidence = "open", "foundation/task loss ratio was not reported"
+    elif task_ratio > 0.3:
+        optimization_status, optimization_evidence = "risk", f"mean Foundation/task loss ratio={task_ratio:.4f} (>0.3)"
+    elif task_ratio < 1e-4:
+        optimization_status, optimization_evidence = "risk", f"mean Foundation/task loss ratio={task_ratio:.6f} (<1e-4)"
+    else:
+        optimization_status, optimization_evidence = "checked", f"mean Foundation/task loss ratio={task_ratio:.4f}"
+    diagnostics.append(
+        {
+            "area": "optimization",
+            "status": optimization_status,
+            "evidence": optimization_evidence,
+            "next_action": "Inspect task ratio and raw cosine/relational curves before changing only the loss weight.",
+        }
+    )
+    plan = payload.get("plan") or []
+    treatment_specs = [item for item in plan if isinstance(item, Mapping) and _plan_arm(item) == treatment_arm]
+    dims = sorted(
+        {
+            int(item.get("overrides", {}).get("foundation_align_dim"))
+            for item in treatment_specs
+            if _finite(item.get("overrides", {}).get("foundation_align_dim")) is not None
+        }
+    )
+    diagnostics.append(
+        {
+            "area": "dimension",
+            "status": "open",
+            "evidence": f"tested align_dim={dims}" if dims else "alignment dimension metadata unavailable",
+            "next_action": (
+                "If no-go persists, compare one smaller and one larger align_dim under the identical paired budget."
+            ),
+        }
+    )
+    worst_scale = min(
+        ((name, item.get("mean")) for name, item in scales.items() if item.get("mean") is not None),
+        key=lambda item: float(item[1]),
+        default=None,
+    )
+    diagnostics.append(
+        {
+            "area": "capacity",
+            "status": "open" if decision != "GO" else "checked",
+            "evidence": (
+                f"weakest scale={worst_scale[0]} ({float(worst_scale[1]):+.4f} points)"
+                if worst_scale
+                else "scale AP unavailable"
+            ),
+            "next_action": (
+                "Run the same recipe on the next student size only if scale evidence suggests a backbone capacity "
+                "bottleneck."
+            ),
+        }
+    )
+    return diagnostics
+
+
+def analyze_report(
+    payload: Mapping[str, Any],
+    *,
+    baseline_arm: str = "B0",
+    treatment_arm: str = "D2",
+    metric: str = DEFAULT_METRIC,
+    min_effect_points: float = 0.3,
+    metric_scale: str = "auto",
+) -> dict[str, Any]:
+    """Analyze one paired report using the preregistered P1 decision rule."""
+    if min_effect_points <= 0 or not math.isfinite(min_effect_points):
+        raise ValueError("min_effect_points must be finite and positive")
+    if metric_scale not in {"auto", "fraction", "points"}:
+        raise ValueError("metric_scale must be auto, fraction, or points")
+    records = payload.get("records")
+    if not isinstance(records, list):
+        raise TypeError("report must contain a records list")
+    pairs, issues = _paired_records(payload, baseline_arm, treatment_arm)
+    multiplier = _metric_multiplier(records, metric, metric_scale)
+    primary = _summarize_metric(pairs, metric, multiplier)
+    budget = audit_equal_budget(payload, baseline_arm, treatment_arm)
+    ci_contains_zero = (
+        primary["low"] is not None and primary["high"] is not None and primary["low"] <= 0 <= primary["high"]
+    )
+    small_effect = primary["mean"] is not None and abs(primary["mean"]) < min_effect_points
+    if not budget["passed"] or primary["n"] < 3:
+        decision, reason = "INSUFFICIENT", "need at least 3 complete paired seeds and a clean same-budget audit"
+    elif primary["high"] < 0:
+        decision, reason = "NO-GO", "paired confidence interval is entirely negative"
+    elif small_effect and ci_contains_zero:
+        decision, reason = "NO-GO", "preregistered negligible-effect rule matched"
+    elif primary["mean"] >= min_effect_points and primary["low"] > 0:
+        decision, reason = "GO", "effect exceeds 0.3 mAP points and the paired interval excludes zero"
+    else:
+        decision, reason = "INCONCLUSIVE", "add paired seeds without changing the preregistered decision line"
+    scales = {name: _summarize_metric(pairs, key, multiplier) for name, key in SCALE_METRICS.items()}
+    categories = _category_summary(pairs, multiplier)
+    benefits = _benefit_summary(scales, categories)
+    result = {
+        "schema_version": SCHEMA_VERSION,
+        "analysis": "foundation_distillation_go_no_go",
+        "baseline_arm": baseline_arm,
+        "treatment_arm": treatment_arm,
+        "metric_scale": metric_scale,
+        "metric_multiplier_to_points": multiplier,
+        "preregistered_rule": {
+            "min_effect_points": min_effect_points,
+            "no_go": "abs(mean_delta_points) < min_effect_points and 95% paired CI contains 0",
+            "minimum_paired_seeds": 3,
+        },
+        "budget_audit": budget,
+        "pair_issues": issues,
+        "primary": primary,
+        "decision": decision,
+        "reason": reason,
+        "criteria": {"small_effect": small_effect, "ci_contains_zero": ci_contains_zero},
+        "scale_analysis": scales,
+        "category_analysis": categories,
+        "benefit_summary": benefits,
+    }
+    diagnostics = _diagnostics(decision, primary, scales, pairs, payload, treatment_arm)
+    result["diagnostics"] = diagnostics
+    if decision == "GO":
+        action = "advance_to_confirmation"
+        recommendation = "Proceed to scale/category confirmation; keep the student deployment contract unchanged."
+        required_followups = [
+            "Confirm reported scale benefits with the same paired seeds.",
+            "Claim category benefits only where per-class AP is present and its paired interval excludes zero.",
+        ]
+    elif decision == "NO-GO":
+        action = "stop_default_distillation_path"
+        recommendation = (
+            "Do not claim an accuracy gain or enable Foundation KD by default. Follow the evidence-linked diagnostics."
+        )
+        required_followups = [item["next_action"] for item in diagnostics if item["status"] in {"risk", "open"}]
+    else:
+        action = "hold_and_collect_evidence"
+        recommendation = (
+            "Do not claim an accuracy gain. Resolve the budget/evidence gaps and add paired seeds without changing "
+            "the preregistered threshold."
+        )
+        required_followups = [item["next_action"] for item in diagnostics if item["status"] in {"risk", "open"}]
+    result["p2"] = {
+        "path": "positive_benefit_analysis" if decision == "GO" else "negative_or_uncertain_diagnosis",
+        "benefits": benefits,
+        "diagnostics": [] if decision == "GO" else diagnostics,
+        "formal_recommendation": {
+            "decision": decision,
+            "action": action,
+            "accuracy_claim_allowed": decision == "GO",
+            "category_claim_allowed": decision == "GO" and benefits["category_claim_allowed"],
+            "recommendation": recommendation,
+            "required_followups": required_followups,
+        },
+    }
+    result["recommendation"] = recommendation
+    return result
+
+
+def render_markdown(result: Mapping[str, Any], source: str) -> str:
+    """Render a formal, reviewable recommendation from a decision result."""
+    primary = result["primary"]
+    low = "n/a" if primary["low"] is None else f"{primary['low']:+.4f}"
+    high = "n/a" if primary["high"] is None else f"{primary['high']:+.4f}"
+    mean = "n/a" if primary["mean"] is None else f"{primary['mean']:+.4f}"
+    lines = [
+        "# Foundation 蒸馏 Go/No-Go 建议书",
+        "",
+        f"- 数据来源：`{source}`",
+        f"- 对照：`{result['baseline_arm']}` vs `{result['treatment_arm']}`",
+        f"- 结论：**{result['decision']}**",
+        f"- 原因：{result['reason']}",
+        "",
+        "## P1 预注册判读",
+        "",
+        f"主指标为 `{primary['metric']}`；配对 seed 数为 {primary['n']}；平均差为 {mean} mAP 点；95% CI 为 [{low}, {high}]。",
+        f"判读线固定为 `|ΔmAP| < {result['preregistered_rule']['min_effect_points']} 点` 且置信区间含 0 时 NO-GO。",
+        f"同预算审计：{'通过' if result['budget_audit']['passed'] else '未通过'}。",
+        "",
+        "## P2 尺度与类别",
+        "",
+    ]
+    for name, item in result["scale_analysis"].items():
+        value = "n/a" if item["mean"] is None else f"{item['mean']:+.4f} mAP 点"
+        lines.append(f"- {name}: {value}（n={item['n']}）")
+    categories = result["category_analysis"]
+    if categories:
+        lines.extend(("", "类别收益前五："))
+        for item in categories[:5]:
+            lines.append(f"- {item['category']}: {item['mean']:+.4f} mAP 点（n={item['n']}）")
+    else:
+        lines.append("- 当前报告没有 per-class AP；不得声称具体类别受益。")
+    benefits = result["benefit_summary"]
+    if result["decision"] == "GO":
+        lines.extend(("", "### 置信区间支持的受益项", ""))
+        lines.append(f"- 尺度：{', '.join(benefits['confirmed_positive_scales']) or '无'}")
+        lines.append(f"- 类别：{', '.join(benefits['confirmed_positive_categories'][:5]) or '无'}")
+    else:
+        lines.extend(("", "## 负结果/不确定结果诊断", ""))
+        for item in result["diagnostics"]:
+            lines.append(f"- **{item['area']} / {item['status']}**：{item['evidence']}。下一步：{item['next_action']}")
+    formal = result["p2"]["formal_recommendation"]
+    lines.extend(
+        (
+            "",
+            "## 正式建议",
+            "",
+            f"行动：`{formal['action']}`。",
+            str(formal["recommendation"]),
+            "",
+            "必要后续：",
+        )
+    )
+    lines.extend(f"- {item}" for item in formal["required_followups"])
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Analyze a completed report and write JSON plus Markdown evidence."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--output-json", type=Path, required=True)
+    parser.add_argument("--output-md", type=Path, required=True)
+    parser.add_argument("--baseline-arm", default="B0")
+    parser.add_argument("--treatment-arm", default="D2")
+    parser.add_argument("--metric", default=DEFAULT_METRIC)
+    parser.add_argument("--min-effect-points", type=float, default=0.3)
+    parser.add_argument("--metric-scale", choices=("auto", "fraction", "points"), default="auto")
+    args = parser.parse_args(argv)
+    payload = json.loads(args.input.read_text(encoding="utf-8"))
+    result = analyze_report(
+        payload,
+        baseline_arm=args.baseline_arm,
+        treatment_arm=args.treatment_arm,
+        metric=args.metric,
+        min_effect_points=args.min_effect_points,
+        metric_scale=args.metric_scale,
+    )
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    args.output_md.parent.mkdir(parents=True, exist_ok=True)
+    args.output_json.write_text(json.dumps(result, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    args.output_md.write_text(render_markdown(result, str(args.input)), encoding="utf-8")
+    print(json.dumps({"decision": result["decision"], "paired_seeds": result["primary"]["n"]}, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/foundation_p0_smoke.py
+++ b/scripts/foundation_p0_smoke.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Run an offline single-stage Foundation distillation smoke test.
+
+This smoke deliberately avoids detector data and external teacher weights. It exercises the
+minimum acceptance chain used by the real wrapper: frozen teacher feature -> live student P4
+hook -> spatial/channel projector -> cosine loss -> optimizer step.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import torch
+from torch import nn
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _load_symbol(relative_path: str, symbol: str):
+    """Load one symbol without importing the full optional YOLO runtime."""
+    path = REPO_ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(f"_foundation_smoke_{path.stem}", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load smoke dependency: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return getattr(module, symbol)
+
+
+P4AlignmentProjector = _load_symbol("ultralytics/nn/foundation/projectors.py", "P4AlignmentProjector")
+cosine_kd_loss = _load_symbol("ultralytics/nn/foundation/losses.py", "cosine_kd_loss")
+
+
+class TinyStudent(nn.Module):
+    """Tiny backbone with an explicit P4-like stage for the offline smoke."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.stem = nn.Conv2d(3, 8, 3, stride=2, padding=1)
+        self.p4 = nn.Conv2d(8, 12, 3, stride=2, padding=1)
+
+    def forward(self, images: torch.Tensor) -> torch.Tensor:
+        return self.p4(torch.relu(self.stem(images)))
+
+
+class FrozenTeacher(nn.Module):
+    """Small deterministic teacher double with a different grid and channel count."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.encoder = nn.Conv2d(3, 20, 3, stride=4, padding=1, bias=False)
+        self.requires_grad_(False)
+        self.eval()
+
+    def forward(self, images: torch.Tensor) -> torch.Tensor:
+        with torch.inference_mode():
+            return self.encoder(images)
+
+
+def run_smoke(*, steps: int = 16, seed: int = 20260824) -> dict[str, object]:
+    """Run the deterministic smoke and return machine-readable acceptance evidence."""
+    if steps < 2:
+        raise ValueError("steps must be at least 2")
+    torch.manual_seed(seed)
+    student = TinyStudent().train()
+    teacher = FrozenTeacher()
+    projector = P4AlignmentProjector(student_channels=12, teacher_channels=20, align_dim=8, use_norm=False)
+    captured: dict[str, torch.Tensor] = {}
+
+    def capture_p4(_module: nn.Module, _inputs: tuple[object, ...], output: torch.Tensor) -> None:
+        captured["p4"] = output
+
+    handle = student.p4.register_forward_hook(capture_p4)
+    optimizer = torch.optim.Adam((*student.parameters(), *projector.student_proj.parameters()), lr=0.03)
+    images = torch.randn(2, 3, 32, 32)
+    losses: list[float] = []
+    student_shape: tuple[int, ...] | None = None
+    teacher_shape: tuple[int, ...] | None = None
+    aligned_shape: tuple[int, ...] | None = None
+    try:
+        for _ in range(steps):
+            optimizer.zero_grad(set_to_none=True)
+            student(images)
+            student_feature = captured.pop("p4")
+            teacher_feature = teacher(images)
+            student_aligned, teacher_aligned = projector(student_feature, teacher_feature)
+            loss = cosine_kd_loss(student_aligned, teacher_aligned)
+            loss.backward()
+            optimizer.step()
+            losses.append(float(loss.detach()))
+            student_shape = tuple(student_feature.shape)
+            teacher_shape = tuple(teacher_feature.shape)
+            aligned_shape = tuple(student_aligned.shape)
+    finally:
+        handle.remove()
+
+    teacher_grad_free = all(parameter.grad is None for parameter in teacher.parameters())
+    result = {
+        "schema_version": 1,
+        "stage": "p4",
+        "steps": steps,
+        "seed": seed,
+        "student_shape": student_shape,
+        "teacher_shape": teacher_shape,
+        "aligned_shape": aligned_shape,
+        "teacher_resized": bool(projector.alignment["teacher_resized"]),
+        "teacher_frozen": all(not parameter.requires_grad for parameter in teacher.parameters()),
+        "teacher_grad_free": teacher_grad_free,
+        "projector_trainable": any(parameter.requires_grad for parameter in projector.student_proj.parameters()),
+        "initial_loss": losses[0],
+        "final_loss": losses[-1],
+        "loss_decreased": losses[-1] < losses[0],
+        "finite_losses": all(torch.isfinite(torch.tensor(losses)).tolist()),
+    }
+    result["passed"] = all(
+        (
+            result["teacher_frozen"],
+            result["teacher_grad_free"],
+            result["projector_trainable"],
+            result["loss_decreased"],
+            result["finite_losses"],
+            student_shape is not None,
+            teacher_shape is not None,
+            aligned_shape is not None,
+            aligned_shape[-2:] == student_shape[-2:],
+        )
+    )
+    return result
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the P0 smoke from the command line."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--steps", type=int, default=16)
+    parser.add_argument("--seed", type=int, default=20260824)
+    args = parser.parse_args(argv)
+    result = run_smoke(steps=args.steps, seed=args.seed)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if not result["passed"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_foundation_distill_decision.py
+++ b/tests/test_foundation_distill_decision.py
@@ -1,0 +1,116 @@
+"""Contracts for the preregistered Foundation distillation decision gate."""
+
+import json
+
+import pytest
+
+from scripts.foundation_distill_decision import analyze_report, main, render_markdown
+
+
+def _report(deltas, *, contaminate=False, categories=False):
+    records, plan = [], []
+    for seed, delta_points in enumerate(deltas):
+        baseline_metrics = {
+            "metrics/mAP50-95(B)": 0.30,
+            "metrics/mAP_small(B)": 0.10,
+            "metrics/mAP_medium(B)": 0.20,
+            "metrics/mAP_large(B)": 0.40,
+        }
+        treatment_metrics = {
+            "metrics/mAP50-95(B)": 0.30 + delta_points / 100,
+            "metrics/mAP_small(B)": 0.10 + (delta_points + 0.2) / 100,
+            "metrics/mAP_medium(B)": 0.20 + delta_points / 100,
+            "metrics/mAP_large(B)": 0.40 + (delta_points - 0.2) / 100,
+            "train/foundation_task_ratio": 0.02,
+        }
+        baseline = {"seed": seed, "arm": "B0", "observed": baseline_metrics}
+        treatment = {"seed": seed, "arm": "D2", "observed": treatment_metrics}
+        if categories:
+            baseline["per_class_ap"] = {"person": 0.20, "car": 0.30}
+            treatment["per_class_ap"] = {"person": 0.21, "car": 0.295}
+        records.extend((baseline, treatment))
+        common = {"epochs": 10, "imgsz": 256, "batch": 4, "seed": seed, "optimizer": "SGD"}
+        baseline_overrides = {**common, "name": f"b0-s{seed}", "foundation_enabled": False}
+        treatment_overrides = {
+            **common,
+            "name": f"d2-s{seed}",
+            "foundation_enabled": True,
+            "foundation_loss": "hybrid",
+            "foundation_align_dim": 32,
+        }
+        if contaminate and seed == 1:
+            treatment_overrides["batch"] = 8
+        plan.extend(
+            (
+                {"seed": seed, "arm": "B0", "overrides": baseline_overrides},
+                {"seed": seed, "arm": "D2", "overrides": treatment_overrides},
+            )
+        )
+    return {"records": records, "plan": plan}
+
+
+def test_preregistered_small_effect_with_zero_in_ci_is_no_go():
+    result = analyze_report(_report([0.1, -0.1, 0.2]))
+    assert result["decision"] == "NO-GO"
+    assert result["criteria"] == {"small_effect": True, "ci_contains_zero": True}
+    assert result["budget_audit"]["passed"] is True
+
+
+def test_positive_effect_requires_margin_and_ci_above_zero():
+    result = analyze_report(_report([0.5, 0.6, 0.7]))
+    assert result["decision"] == "GO"
+    assert result["primary"]["mean"] == pytest.approx(0.6)
+    assert result["primary"]["low"] > 0
+
+
+def test_exact_effect_margin_is_not_classified_as_negligible():
+    result = analyze_report(_report([0.3, 0.3, 0.3]))
+    assert result["decision"] == "GO"
+    assert result["criteria"]["small_effect"] is False
+
+
+def test_budget_contamination_blocks_decision():
+    result = analyze_report(_report([0.5, 0.6, 0.7], contaminate=True))
+    assert result["decision"] == "INSUFFICIENT"
+    assert result["budget_audit"]["passed"] is False
+    assert result["budget_audit"]["mismatches"][0]["fields"] == ["batch"]
+
+
+def test_scale_and_category_analysis_are_paired():
+    result = analyze_report(_report([0.5, 0.6, 0.7], categories=True))
+    assert result["scale_analysis"]["small"]["mean"] == pytest.approx(0.8)
+    assert result["scale_analysis"]["large"]["mean"] == pytest.approx(0.4)
+    assert result["category_analysis"][0]["category"] == "person"
+    assert result["category_analysis"][0]["mean"] == pytest.approx(1.0)
+    assert result["p2"]["path"] == "positive_benefit_analysis"
+    assert result["benefit_summary"]["confirmed_positive_scales"] == ["small", "medium", "large"]
+    assert result["benefit_summary"]["confirmed_positive_categories"] == ["person"]
+    assert result["p2"]["formal_recommendation"]["category_claim_allowed"] is True
+    assert "Foundation 蒸馏 Go/No-Go 建议书" in render_markdown(result, "report.json")
+
+
+def test_no_go_emits_four_evidence_linked_diagnostic_areas():
+    result = analyze_report(_report([0.1, -0.1, 0.2]))
+    diagnostics = result["p2"]["diagnostics"]
+    assert result["p2"]["path"] == "negative_or_uncertain_diagnosis"
+    assert {item["area"] for item in diagnostics} == {"capacity", "dimension", "optimization", "data"}
+    assert result["p2"]["formal_recommendation"]["action"] == "stop_default_distillation_path"
+    assert result["p2"]["formal_recommendation"]["accuracy_claim_allowed"] is False
+    assert result["p2"]["formal_recommendation"]["category_claim_allowed"] is False
+
+
+def test_missing_category_metrics_prohibit_category_claim_even_for_go():
+    result = analyze_report(_report([0.5, 0.6, 0.7]))
+    assert result["decision"] == "GO"
+    assert result["benefit_summary"]["category_evidence_available"] is False
+    assert result["p2"]["formal_recommendation"]["category_claim_allowed"] is False
+
+
+def test_cli_writes_json_and_formal_recommendation(tmp_path):
+    source = tmp_path / "report.json"
+    output_json = tmp_path / "decision.json"
+    output_md = tmp_path / "recommendation.md"
+    source.write_text(json.dumps(_report([0.1, -0.1, 0.2])), encoding="utf-8")
+    main(["--input", str(source), "--output-json", str(output_json), "--output-md", str(output_md)])
+    assert json.loads(output_json.read_text(encoding="utf-8"))["decision"] == "NO-GO"
+    assert "不得声称具体类别受益" in output_md.read_text(encoding="utf-8")

--- a/tests/test_foundation_p0_smoke.py
+++ b/tests/test_foundation_p0_smoke.py
@@ -1,0 +1,13 @@
+"""Offline acceptance test for the minimum Foundation distillation chain."""
+
+from scripts.foundation_p0_smoke import run_smoke
+
+
+def test_single_stage_smoke_aligns_and_decreases_loss():
+    result = run_smoke(steps=12)
+    assert result["passed"] is True
+    assert result["stage"] == "p4"
+    assert result["teacher_frozen"] is True
+    assert result["teacher_grad_free"] is True
+    assert result["aligned_shape"][-2:] == result["student_shape"][-2:]
+    assert result["final_loss"] < result["initial_loss"]


### PR DESCRIPTION
## Summary
- add a dependency-light P0 single-stage Foundation distillation smoke test covering teacher freeze, P4 hook alignment, projection, cosine KD, and loss descent
- add a P1 paired on/off decision gate with equal-budget auditing and the preregistered `|ΔmAP| < 0.3` plus 95% CI rule
- add P2 scale/category analysis, negative-result diagnostics, and machine-readable plus Markdown go/no-go recommendations
- document the experiment contract and expose it in the MkDocs navigation

## Acceptance evidence
- P0 smoke: loss decreased from `1.010572` to `0.100697`; teacher frozen and gradient-free; student/teacher/projected shapes aligned
- `python -m pytest tests/test_foundation_p0_smoke.py tests/test_foundation_distill_decision.py -q`: **9 passed**
- changed-file `ruff check` and `ruff format --check`: passed
- changed-file `codespell`: passed
- `git diff --check`: passed
- existing F08 run-plan equal-budget audit: 3 paired specs checked, no mismatches

## Decision contract
- `NO-GO`: `abs(mean paired ΔmAP) < 0.3` percentage point and the two-sided 95% paired Student-t CI contains zero
- `GO`: mean paired ΔmAP is at least +0.3 point and the CI is strictly above zero
- otherwise `INCONCLUSIVE`; add paired seeds without moving the threshold